### PR TITLE
Connect to new UH simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Universal Housing configuration is given through environment variables, for exam
 - UH_DATABASE_HOST=universal_housing
 - UH_DATABASE_PORT=1433
 
-When developing locally, the docker compose configuration assumes this project is checked out in the same directory as `LBHTenancyAPI`, so the StubUniversalHousing Dockerfile can be reused.
+When developing locally, the docker compose configuration assumes that the [Universal Housing simulator](https://github.com/LBHackney-IT/lbh-universal-housing-simulator) is checked out in the same directory as this.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     command: rails s
     environment:
-      - UH_DATABASE_NAME=StubUH
+      - UH_DATABASE_NAME=uhsimulator
       - UH_DATABASE_USERNAME=sa
       - UH_DATABASE_PASSWORD=Rooty-Tooty
       - UH_DATABASE_HOST=universal_housing
@@ -16,8 +16,6 @@ services:
     volumes:
       - .:/app
   universal_housing:
-    build:
-      dockerfile: StubUniversalHousing/Dockerfile
-      context: ../LBHTenancyAPI
+    build: ../universal-housing-simulator
     ports:
       - 1433:1433


### PR DESCRIPTION
Uses the new [Universal Housing simulator](https://github.com/LBHackney-IT/lbh-universal-housing-simulator) Dockerfile instead of the one in LBHTenancyAPI.