### PR TITLE
Bind vars in SQL calls and use Sequel instead of TinyTds directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'puma', '~> 3.7'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'sequel'
 gem 'tiny_tds'
 gem 'rest-client'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     rspec-support (3.7.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
+    sequel (5.11.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -180,6 +181,7 @@ DEPENDENCIES
   rest-client
   rspec-its
   rspec-rails
+  sequel
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/config/database_universal_housing.yml
+++ b/config/database_universal_housing.yml
@@ -1,4 +1,5 @@
 default: &default
+  adapter: 'tinytds'
   username: <%= ENV['UH_DATABASE_USERNAME'] %>
   password: <%= ENV['UH_DATABASE_PASSWORD'] %>
   host: <%= ENV['UH_DATABASE_HOST'] %>

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -4,10 +4,10 @@ module Hackney
       class UniversalHousingCriteria
         def self.for_tenancy(universal_housing_client, tenancy_ref)
           sql = <<-SQL
-            DECLARE @TenancyRef VARCHAR(60) = '#{tenancy_ref}'
-            DECLARE @ActiveArrearsAgreementStatus VARCHAR(60) = '#{Hackney::Income::ACTIVE_ARREARS_AGREEMENT_STATUS}'
-            DECLARE @BreachedArrearsAgreementStatus VARCHAR(60) = '#{Hackney::Income::BREACHED_ARREARS_AGREEMENT_STATUS}'
-            DECLARE @NospActionDiaryCode VARCHAR(60) = '#{Hackney::Income::NOSP_ACTION_DIARY_CODE}'
+            DECLARE @TenancyRef VARCHAR(60) = ?
+            DECLARE @ActiveArrearsAgreementStatus VARCHAR(60) = ?
+            DECLARE @BreachedArrearsAgreementStatus VARCHAR(60) = ?
+            DECLARE @NospActionDiaryCode VARCHAR(60) = ?
             DECLARE @PaymentTypes table(payment_type varchar(3))
             INSERT INTO @PaymentTypes VALUES ('RBA'), ('RBP'), ('RBR'), ('RCI'), ('RCO'), ('RCP'), ('RDD'), ('RDN'), ('RDP'), ('RDR'), ('RDS'), ('RDT'), ('REF'), ('RHA'), ('RHB'), ('RIT'), ('RML'), ('RPD'), ('RPO'), ('RPY'), ('RQP'), ('RRC'), ('RRP'), ('RSO'), ('RTM'), ('RUC'), ('RWA')
 
@@ -66,11 +66,15 @@ module Hackney
               @Payment3Date as payment_3_date;
           SQL
 
-          query = universal_housing_client.execute(sql)
-          attributes = query.each(first: true).first
-          query.do
+          attributes = universal_housing_client[
+            sql,
+            tenancy_ref,
+            Hackney::Income::ACTIVE_ARREARS_AGREEMENT_STATUS,
+            Hackney::Income::BREACHED_ARREARS_AGREEMENT_STATUS,
+            Hackney::Income::NOSP_ACTION_DIARY_CODE
+          ]
 
-          new(tenancy_ref, attributes.symbolize_keys)
+          new(tenancy_ref, attributes.first.symbolize_keys)
         end
 
         def initialize(tenancy_ref, attributes)

--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -2,18 +2,12 @@ module Hackney
   module Income
     class UniversalHousingTenanciesGateway
       def tenancies_in_arrears
-        tenancy_refs = []
-
-        query = universal_housing_client.execute('SELECT tag_ref FROM tenagree WHERE cur_bal > 0')
-        query.each { |record| tenancy_refs << record.fetch('tag_ref').strip }
-        query.do
-
-        tenancy_refs
+        database[:tenagree].where { cur_bal > 0 }.map(:tag_ref).map(&:strip)
       end
 
       private
 
-      def universal_housing_client
+      def database
         Hackney::UniversalHousing::Client.connection
       end
     end

--- a/lib/hackney/universal_housing/client.rb
+++ b/lib/hackney/universal_housing/client.rb
@@ -3,14 +3,7 @@ module Hackney
     class Client
       class << self
         def connection
-          TinyTds::Client.new(
-            username: configuration.fetch(:username),
-            password: configuration.fetch(:password),
-            host: configuration.fetch(:host),
-            port: configuration.fetch(:port),
-            database: configuration.fetch(:database),
-            timeout: configuration.fetch(:timeout)
-          )
+          Sequel.connect(configuration)
         end
 
         private

--- a/spec/hackney/income/universal_housing_prioritisation_gateway_spec.rb
+++ b/spec/hackney/income/universal_housing_prioritisation_gateway_spec.rb
@@ -22,7 +22,7 @@ describe Hackney::Income::UniversalHousingPrioritisationGateway do
     it 'should determine universal housing criteria' do
       expect(Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria)
         .to receive(:for_tenancy)
-        .with(an_instance_of(TinyTds::Client), tenancy_ref)
+        .with(an_instance_of(Sequel::TinyTDS::Database), tenancy_ref)
 
       subject.priorities_for_tenancy(tenancy_ref)
     end

--- a/spec/hackney/universal_housing/client_spec.rb
+++ b/spec/hackney/universal_housing/client_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe Hackney::UniversalHousing::Client do
   subject { described_class.connection }
 
-  it 'connects using environmental configuration' do
-    expect(subject).to be_active
+  it 'to be a Sequel database instance' do
+    expect(subject).to be_a(Sequel::TinyTDS::Database)
   end
 
-  it 'to be a TinyTds instance' do
-    expect(subject).to be_a(TinyTds::Client)
+  it 'can execute queries against the database' do
+    expect(subject.table_exists?('tenagree')).to be(true)
   end
 end

--- a/spec/universal_housing_helper.rb
+++ b/spec/universal_housing_helper.rb
@@ -1,28 +1,24 @@
 module UniversalHousingHelper
   def create_uh_tenancy_agreement(tenancy_ref:, current_balance:)
-    universal_housing_client.execute("INSERT [dbo].[tenagree] (tag_ref, cur_bal) VALUES ('#{tenancy_ref}', #{current_balance})").do
+    Hackney::UniversalHousing::Client.connection[:tenagree].insert(tag_ref: tenancy_ref, cur_bal: current_balance)
   end
 
   def create_uh_transaction(tenancy_ref:, amount: 0.0, date: Date.today, type: '')
-    universal_housing_client.execute("INSERT [dbo].[rtrans] (tag_ref, real_value, post_date, trans_type, batchid) VALUES ('#{tenancy_ref}', '#{amount}', '#{date}', '#{type}', #{rand(1..100000)})").do
+    Hackney::UniversalHousing::Client.connection[:rtrans].insert(tag_ref: tenancy_ref, real_value: amount, post_date: date, trans_type: type, batchid: rand(1..100000))
   end
 
   def create_uh_arrears_agreement(tenancy_ref:, status:)
-    universal_housing_client.execute("INSERT [dbo].[arag] (arag_ref, tag_ref, arag_status) VALUES ('#{Faker::IDNumber.valid}', '#{tenancy_ref}', '#{status}')").do
+    Hackney::UniversalHousing::Client.connection[:arag].insert(arag_ref: Faker::IDNumber.valid, tag_ref: tenancy_ref, arag_status: status)
   end
 
   def create_uh_action(tenancy_ref:, code:, date:)
-    universal_housing_client.execute("INSERT [dbo].[araction] (tag_ref, action_code, action_date) VALUES ('#{tenancy_ref}', '#{code}', '#{date}')").do
+    Hackney::UniversalHousing::Client.connection[:araction].insert(tag_ref: tenancy_ref, action_code: code, action_date: date)
   end
 
   def truncate_uh_tables
-    universal_housing_client.execute('TRUNCATE TABLE [dbo].[tenagree]').do
-    universal_housing_client.execute('TRUNCATE TABLE [dbo].[rtrans]').do
-    universal_housing_client.execute('TRUNCATE TABLE [dbo].[arag]').do
-    universal_housing_client.execute('TRUNCATE TABLE [dbo].[araction]').do
-  end
-
-  def universal_housing_client
-    Hackney::UniversalHousing::Client.connection
+    Hackney::UniversalHousing::Client.connection[:tenagree].truncate
+    Hackney::UniversalHousing::Client.connection[:rtrans].truncate
+    Hackney::UniversalHousing::Client.connection[:arag].truncate
+    Hackney::UniversalHousing::Client.connection[:araction].truncate
   end
 end


### PR DESCRIPTION
~**Don't review until https://github.com/LBHackney-IT/lbh-income-api/pull/6 is merged.**~

- SQL queries were using interpolated variables, which made SQL injection requests possible.
- Sequel has an adapter for TinyTds and provides a much nicer SQL client interface.
- Out of the box has parameter support!