### PR TITLE
Resolve error when syncing cases

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -4,6 +4,11 @@ class MyCasesController < ApplicationController
     render json: cases
   end
 
+  def sync
+    sync = Hackney::Income::DangerousSyncCases.new(prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new, uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new, stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new)
+    sync.execute
+  end
+
   private
 
   def view_my_cases

--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -13,7 +13,7 @@ class MyCasesController < ApplicationController
 
   def view_my_cases
     Hackney::Income::DangerousViewMyCases.new(
-      tenancy_api_gateway: Hackney::Income::TenancyApiGateway.new(host: 'http://tenancy_api'),
+      tenancy_api_gateway: Hackney::Income::TenancyApiGateway.new(host: ENV['INCOME_COLLECTION_API_HOST'], key: ENV['INCOME_COLLECTION_API_KEY']),
       stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
     )
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get '/api/v1/my-cases', to: 'my_cases#index'
+  get '/api/v1/sync-cases', to: 'my_cases#sync'
 end

--- a/lib/hackney/income/tenancy_api_gateway.rb
+++ b/lib/hackney/income/tenancy_api_gateway.rb
@@ -1,14 +1,19 @@
 module Hackney
   module Income
     class TenancyApiGateway
-      def initialize(host:)
+      def initialize(host:, key:)
         @host = host
+        @key = key
       end
 
       def get_tenancies_by_refs(refs)
         return [] if refs.empty?
 
-        response = RestClient.get("#{@host}/api/v1/tenancies", params: { tenancy_refs: convert_to_params_array(refs) })
+        response = RestClient.get(
+          "#{@host}/tenancies",
+          'x-api-key' => @api_key,
+          params: { tenancy_refs: convert_to_params_array(refs) }
+        )
         body = JSON.load(response.body)
 
         body['tenancies'].map do |tenancy|

--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -2,11 +2,7 @@ module Hackney
   module Income
     class UniversalHousingTenanciesGateway
       def tenancies_in_arrears
-        tenancy_refs = []
-        query = database.execute('SELECT tag_ref FROM tenagree WHERE cur_bal > 0')
-        query.each { |record| tenancy_refs << record.fetch('tag_ref').strip }
-        query.do
-        tenancy_refs
+        database[:tenagree].where { cur_bal > 0 }.map(:tag_ref).map(&:strip)
       end
 
       private

--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -2,7 +2,11 @@ module Hackney
   module Income
     class UniversalHousingTenanciesGateway
       def tenancies_in_arrears
-        database[:tenagree].where { cur_bal > 0 }.map(:tag_ref).map(&:strip)
+        tenancy_refs = []
+        query = database.execute('SELECT tag_ref FROM tenagree WHERE cur_bal > 0')
+        query.each { |record| tenancy_refs << record.fetch('tag_ref').strip }
+        query.do
+        tenancy_refs
       end
 
       private

--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -8,7 +8,10 @@ module Hackney
       private
 
       def database
-        Hackney::UniversalHousing::Client.connection
+        Hackney::UniversalHousing::Client.connection.tap do |db|
+          db.extension :identifier_mangling
+          db.identifier_input_method = db.identifier_output_method = nil
+        end
       end
     end
   end

--- a/spec/hackney/income/tenancy_api_gateway_spec.rb
+++ b/spec/hackney/income/tenancy_api_gateway_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
 describe Hackney::Income::TenancyApiGateway do
-  let(:gateway) { described_class.new(host: 'https://example.com') }
+  let(:gateway) { described_class.new(host: 'https://example.com', key: 'skeleton') }
 
   context 'when retrieving tenancies' do
     subject { gateway.get_tenancies_by_refs(refs) }
 
     context 'and using a different host' do
-      let(:gateway) { described_class.new(host: 'https://other.com') }
+      let(:gateway) { described_class.new(host: 'https://other.com', key: 'skeleton') }
       let(:refs) { %w(123) }
 
       before do
-        stub_request(:get, "https://other.com/api/v1/tenancies?tenancy_refs%5B%5D=123")
+        stub_request(:get, "https://other.com/tenancies?tenancy_refs%5B%5D=123")
           .to_return(body: { 'tenancies' => [example_tenancy] }.to_json)
       end
 
       it 'should use the host' do
         subject
-        expect(WebMock).to have_requested(:get, 'https://other.com/api/v1/tenancies?tenancy_refs%5B%5D=123').once
+        expect(WebMock).to have_requested(:get, 'https://other.com/tenancies?tenancy_refs%5B%5D=123').once
       end
     end
 
@@ -33,7 +33,7 @@ describe Hackney::Income::TenancyApiGateway do
       let(:refs) { %w(000015/01) }
 
       before do
-        stub_request(:get, "https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000015/01")
+        stub_request(:get, "https://example.com/tenancies?tenancy_refs%5B%5D=000015/01")
           .to_return(body: { 'tenancies' => [example_tenancy] }.to_json)
       end
 
@@ -59,7 +59,7 @@ describe Hackney::Income::TenancyApiGateway do
       let(:refs) { %w(000017/01) }
 
       before do
-        stub_request(:get, "https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000017/01")
+        stub_request(:get, "https://example.com/tenancies?tenancy_refs%5B%5D=000017/01")
           .to_return(body: { 'tenancies' => [example_tenancy_with_nils] }.to_json)
       end
 
@@ -78,7 +78,7 @@ describe Hackney::Income::TenancyApiGateway do
       let(:refs) { %w(000015/01 000017/01) }
 
       before do
-        stub_request(:get, "https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000017/01&tenancy_refs%5B%5D=000015/01")
+        stub_request(:get, "https://example.com/tenancies?tenancy_refs%5B%5D=000017/01&tenancy_refs%5B%5D=000015/01")
           .to_return(body: { 'tenancies' => [example_tenancy, example_tenancy_with_nils] }.to_json)
       end
 


### PR DESCRIPTION
Cases would fail to sync due to Sequel mangling the database name on AWS but not locally. Add a fix to prevent this.