### PR TITLE
Add production deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ workflows:
       - staging_release:
           requires:
             - check
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - permit_production_release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,41 @@ jobs:
           name: Force new deployment
           command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout 32000
 
+  production_release:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Install AWS CLI
+          command: pip install awscli --upgrade --user
+      - run:
+          name: Install jq
+          command: |
+            sudo apt-get update
+            sudo apt-get install jq
+      - run:
+          name: Install ecs-deploy
+          command: |
+            curl https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy | sudo tee /usr/bin/ecs-deploy
+            sudo chmod +x /usr/bin/ecs-deploy
+      - run:
+          name: Login to ECR
+          command: aws ecr get-login --region $AWS_REGION --no-include-email | sh
+      - run:
+          name: Build new application Docker image
+          command: docker build --tag hackney/apps/income-api .
+      - run:
+          name: Tag new image for staging release
+          command: |
+            docker tag hackney/apps/income-api:latest $ECR_IMAGE_URL:production
+      - run:
+          name: Release new image to ECR
+          command: |
+            docker push $ECR_IMAGE_URL:production
+      - run:
+          name: Force new deployment
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout 32000
+
 workflows:
   version: 2
   continuous_delivery:
@@ -70,3 +105,10 @@ workflows:
           # filters:
           #   branches:
           #     only: master
+      - permit_production_release:
+          type: approval
+          requires:
+            - staging_release
+      - production_release:
+          requires:
+            - permit_production_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             docker push $ECR_IMAGE_URL:staging
       - run:
           name: Force new deployment
-          command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout 32000
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout $ECS_DEPLOY_TIMEOUT
 
   production_release:
     machine: true
@@ -92,7 +92,7 @@ jobs:
             docker push $ECR_IMAGE_URL:production
       - run:
           name: Force new deployment
-          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout 32000
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout $ECS_DEPLOY_TIMEOUT
 
 workflows:
   version: 2


### PR DESCRIPTION
We add a new build step to circle config to add production deployments of lbh-income-api.

We also include another change to configure `ecs-deploy` timeouts via ENV:

`ecs-deploy` will timeout is a deploy does not complete within 90 seconds by default. It can take longer than this as we not only have to drain traffic from old deploys but also wait for ELB to deregister and register new applications. See here for more information: https://github.com/fabfuel/ecs-deploy/issues/14#issuecomment-277424439

We allow the timeout to be set via ENV in Circle as we've had issues of deploys taking more than 10 minutes to fully drain old tasks. Putting this in ENV will allow us to configure dynamically without changing the .circle/config.yml in future.