### PR TITLE
Add rake task for syncing income cases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require File.expand_path('../config/environment', __FILE__)
 
 Rails.application.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::API
+  def income_use_case_factory
+    @income_use_case_factory ||= Hackney::Income::UseCaseFactory.new
+  end
 end

--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -12,18 +12,11 @@ class MyCasesController < ApplicationController
   private
 
   def view_my_cases_use_case
-    Hackney::Income::DangerousViewMyCases.new(
-      tenancy_api_gateway: Hackney::Income::TenancyApiGateway.new(host: ENV['INCOME_COLLECTION_API_HOST'], key: ENV['INCOME_COLLECTION_API_KEY']),
-      stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
-    )
+    income_use_case_factory.view_my_cases
   end
 
   def sync_cases_use_case
-    Hackney::Income::DangerousSyncCases.new(
-      prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
-      uh_tenancies_gateway: Hackney::Income::HardcodedTenanciesGateway.new,
-      stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
-    )
+    income_use_case_factory.sync_cases
   end
 
   def random_tenancy_refs

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -1,0 +1,23 @@
+module Hackney
+  module Income
+    class UseCaseFactory
+      def view_my_cases
+        Hackney::Income::DangerousViewMyCases.new(
+          tenancy_api_gateway: Hackney::Income::TenancyApiGateway.new(
+            host: ENV['INCOME_COLLECTION_API_HOST'],
+            key: ENV['INCOME_COLLECTION_API_KEY']
+          ),
+          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
+        )
+      end
+
+      def sync_cases
+        Hackney::Income::DangerousSyncCases.new(
+          prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
+          uh_tenancies_gateway: Hackney::Income::HardcodedTenanciesGateway.new,
+          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/income.rake
+++ b/lib/tasks/income.rake
@@ -1,0 +1,6 @@
+namespace :income do
+  task :sync do
+    use_case_factory = Hackney::Income::UseCaseFactory.new
+    use_case_factory.sync_cases.execute
+  end
+end


### PR DESCRIPTION
We add rake task for syncing income collection cases to make it convenient to sync.

In order reduce chance of error we move construction of use cases into a factory.

We also needed to make a change to `Rakefile` to load an initialised version of the Rails application because the use case factory didn't autoload otherwise.