### PR TITLE
Add daily sync cases job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem 'sequel'
 gem 'tiny_tds'
 gem 'rest-client'
 
+gem 'delayed_job'
+gem 'delayed_job_active_record'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -175,6 +180,8 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  delayed_job
+  delayed_job_active_record
   faker
   listen (>= 3.0.5, < 3.2)
   mysql2

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,8 @@
 class ApplicationJob < ActiveJob::Base
+  def income_use_case_factory
+    @income_use_case_factory ||= Hackney::Income::UseCaseFactory.new
+  end
+
   class << self
     def enqueue_next
       unless already_queued_for_next_run?

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,22 @@
 class ApplicationJob < ActiveJob::Base
+  class << self
+    def enqueue_next
+      unless already_queued_for_next_run?
+        set(wait_until: next_run_time).perform_later
+      end
+    end
+
+    def next_run_time
+      raise NotImplementedError
+    end
+
+    private
+
+    def already_queued_for_next_run?
+      Delayed::Job.any? do |next_job|
+        next_job_data = YAML.load(next_job.handler).job_data
+        name == next_job_data['job_class'] && next_run_time == next_job.run_at
+      end
+    end
+  end
 end

--- a/app/jobs/hackney/income/jobs/sync_cases_job.rb
+++ b/app/jobs/hackney/income/jobs/sync_cases_job.rb
@@ -1,0 +1,32 @@
+module Hackney
+  module Income
+    module Jobs
+      class SyncCasesJob < ApplicationJob
+        queue_as :default
+
+        after_perform do
+          self.class.set(wait_until: next_run_time).perform_later
+        end
+
+        def perform
+          begin
+            sync_cases.execute
+          rescue
+          end
+        end
+
+        def sync_cases
+          Hackney::Income::DangerousSyncCases.new(
+            prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
+            uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new,
+            stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
+          )
+        end
+
+        def next_run_time
+          Date.tomorrow.midnight + 3.hours
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/hackney/income/jobs/sync_cases_job.rb
+++ b/app/jobs/hackney/income/jobs/sync_cases_job.rb
@@ -10,7 +10,8 @@ module Hackney
 
         def perform
           sync_cases.execute
-        rescue
+        rescue => e
+          Rails.logger.error("Caught error: #{e}")
         ensure
           self.class.enqueue_next
         end

--- a/app/jobs/hackney/income/jobs/sync_cases_job.rb
+++ b/app/jobs/hackney/income/jobs/sync_cases_job.rb
@@ -9,19 +9,11 @@ module Hackney
         end
 
         def perform
-          sync_cases.execute
+          income_use_case_factory.sync_cases.execute
         rescue => e
           Rails.logger.error("Caught error: #{e}")
         ensure
           self.class.enqueue_next
-        end
-
-        def sync_cases
-          Hackney::Income::DangerousSyncCases.new(
-            prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
-            uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new,
-            stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
-          )
         end
       end
     end

--- a/app/jobs/hackney/income/jobs/sync_cases_job.rb
+++ b/app/jobs/hackney/income/jobs/sync_cases_job.rb
@@ -4,15 +4,15 @@ module Hackney
       class SyncCasesJob < ApplicationJob
         queue_as :default
 
-        after_perform do
-          self.class.set(wait_until: next_run_time).perform_later
+        def self.next_run_time
+          Date.tomorrow.midnight + 3.hours
         end
 
         def perform
-          begin
-            sync_cases.execute
-          rescue
-          end
+          sync_cases.execute
+        rescue
+        ensure
+          self.class.enqueue_next
         end
 
         def sync_cases
@@ -21,10 +21,6 @@ module Hackney
             uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new,
             stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
           )
-        end
-
-        def next_run_time
-          Date.tomorrow.midnight + 3.hours
         end
       end
     end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,7 @@ module App
     config.api_only = true
 
     config.eager_load_paths << Rails.root.join('lib')
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,8 +49,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "app_#{Rails.env}"
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/schedule_jobs.rb
+++ b/config/initializers/schedule_jobs.rb
@@ -1,0 +1,1 @@
+JobScheduler.enqueue_jobs if Rails.env.staging? or Rails.env.production?

--- a/db/migrate/20180828112331_create_delayed_jobs.rb
+++ b/db/migrate/20180828112331_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.1]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180806221942) do
+ActiveRecord::Schema.define(version: 20180828112331) do
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
   create_table "tenancies", force: :cascade do |t|
     t.string "tenancy_ref"
     t.string "priority_band"
-    t.integer "priority_score"
+    t.decimal "priority_score"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/job_scheduler.rb
+++ b/lib/job_scheduler.rb
@@ -1,0 +1,5 @@
+class JobScheduler
+  def self.enqueue_jobs
+    Hackney::Income::Jobs::SyncCasesJob.enqueue_next
+  end
+end

--- a/spec/hackney/income/jobs/sync_cases_job_spec.rb
+++ b/spec/hackney/income/jobs/sync_cases_job_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Hackney::Income::Jobs::SyncCasesJob do
+  subject { described_class }
+
+  it 'should run the DangerousSyncCases use case' do
+    expect_any_instance_of(Hackney::Income::DangerousSyncCases).to receive(:execute).with(no_args)
+    subject.perform_now
+  end
+
+  it 'should be able to be scheduled' do
+    expect {
+      subject.set(wait_until: Time.now + 5.minutes).perform_later
+    }.to_not raise_error
+  end
+
+  it 'should still schedule a new job for tomorrow on completion' do
+    subject.perform_now
+    expect(Delayed::Job.last).to have_attributes(run_at: next_expected_run_time)
+  end
+
+  context 'when the DangerousSyncCases use case fails' do
+    before do
+      allow_any_instance_of(Hackney::Income::DangerousSyncCases).to receive(:execute).and_raise('oh no!')
+      subject.perform_later
+    end
+
+    it 'the job should still succeed and be removed from the queue' do
+      job = Delayed::Job.first
+
+      expect {
+        Delayed::Worker.new.work_off
+      }.to change {
+        Delayed::Job.exists?(job.id)
+      }.from(true).to(false)
+    end
+
+    it 'should still schedule a new job for tomorrow' do
+      Delayed::Worker.new.work_off
+
+      expect(Delayed::Job.last).to have_attributes(run_at: next_expected_run_time)
+    end
+  end
+
+  def next_expected_run_time
+    Date.tomorrow.midnight + 3.hours
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe ApplicationJob do
+  context '#enqueue_next' do
+    context 'when the next run is already scheduled' do
+      subject { MidnightJob }
+
+      it 'should not schedule again' do
+        subject.set(wait_until: subject.next_run_time).perform_later
+
+        expect { subject.enqueue_next }.to_not change { Delayed::Job.count }
+      end
+    end
+
+    context 'when the next run time is tomorrow at lunch' do
+      subject { LunchJob }
+
+      it 'should queue the job for tomorrow at lunch' do
+        subject.enqueue_next
+        expect(Delayed::Job.last).to have_attributes(run_at: Date.tomorrow.noon)
+      end
+    end
+
+    context 'when the next run time is tomorrow at midnight' do
+      subject { MidnightJob }
+
+      it 'should queue the job for tomorrow at midnight' do
+        subject.enqueue_next
+        expect(Delayed::Job.last).to have_attributes(run_at: Date.tomorrow.midnight)
+      end
+    end
+
+    context 'when next run time has not been set' do
+      subject { NextRunNotDefinedJob }
+
+      it 'should raise an exception' do
+        expect { subject.enqueue_next }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  class NextRunNotDefinedJob < ApplicationJob; end
+
+  class LunchJob < ApplicationJob
+    def self.next_run_time
+      Date.tomorrow.noon
+    end
+  end
+
+  class MidnightJob < ApplicationJob
+    def self.next_run_time
+      Date.tomorrow.midnight
+    end
+  end
+end

--- a/spec/lib/job_scheduler_spec.rb
+++ b/spec/lib/job_scheduler_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe JobScheduler do
+  subject { described_class }
+
+  it 'should try and schedule the next SyncCasesJob' do
+    expect(Hackney::Income::Jobs::SyncCasesJob).to receive(:enqueue_next)
+    subject.enqueue_jobs
+  end
+end


### PR DESCRIPTION
- Syncs cases using the DangerousSyncCases use case.
- Runs daily at 3am. May need to amend this time, but fine for now I think.
- Schedules itself on completion, regardless of success.
- Fails without retrying at the moment, to avoid retries rolling over into normal daily operating hours.
- Logs errors.