### PR TITLE
Stop test suite if UH credentials do not look like the simulator

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
+abort("The Universal Housing credentials do not look like the simulator!") if ENV['UH_DATABASE_NAME'] != 'uhsimulator'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!


### PR DESCRIPTION
Nearly ran the test suite against our development SQL Server, now preventing this outright.