### PR TITLE
Save priority factors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           name: Spin up docker instances
           command: docker-compose up -d ; sleep 20
       - run:
+          name: Run migrations
+          command: docker-compose exec app rails db:migrate RAILS_ENV=test
+      - run:
           name: Run tests
           command: docker-compose exec app rspec
 

--- a/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
+++ b/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
@@ -12,11 +12,11 @@ class AddPriorityFactorsToTenancies < ActiveRecord::Migration[5.1]
     add_column :tenancies, :active_nosp_contribution, :decimal
 
     add_column :tenancies, :balance, :decimal
-    add_column :tenancies, :days_in_arrears, :decimal
-    add_column :tenancies, :days_since_last_payment, :decimal
+    add_column :tenancies, :days_in_arrears, :integer
+    add_column :tenancies, :days_since_last_payment, :integer
     add_column :tenancies, :payment_amount_delta, :decimal
-    add_column :tenancies, :payment_date_delta, :decimal
-    add_column :tenancies, :number_of_broken_agreements, :decimal
+    add_column :tenancies, :payment_date_delta, :integer
+    add_column :tenancies, :number_of_broken_agreements, :integer
     add_column :tenancies, :active_agreement, :boolean
     add_column :tenancies, :broken_court_order, :boolean
     add_column :tenancies, :nosp_served, :boolean

--- a/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
+++ b/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
@@ -10,5 +10,16 @@ class AddPriorityFactorsToTenancies < ActiveRecord::Migration[5.1]
     add_column :tenancies, :broken_court_order_contribution, :decimal
     add_column :tenancies, :nosp_served_contribution, :decimal
     add_column :tenancies, :active_nosp_contribution, :decimal
+
+    add_column :tenancies, :balance, :decimal
+    add_column :tenancies, :days_in_arrears, :decimal
+    add_column :tenancies, :days_since_last_payment, :decimal
+    add_column :tenancies, :payment_amount_delta, :decimal
+    add_column :tenancies, :payment_date_delta, :decimal
+    add_column :tenancies, :number_of_broken_agreements, :decimal
+    add_column :tenancies, :active_agreement, :boolean
+    add_column :tenancies, :broken_court_order, :boolean
+    add_column :tenancies, :nosp_served, :boolean
+    add_column :tenancies, :active_nosp, :boolean
   end
 end

--- a/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
+++ b/db/migrate/20180829140413_add_priority_factors_to_tenancies.rb
@@ -1,0 +1,14 @@
+class AddPriorityFactorsToTenancies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tenancies, :balance_contribution, :decimal
+    add_column :tenancies, :days_in_arrears_contribution, :decimal
+    add_column :tenancies, :days_since_last_payment_contribution, :decimal
+    add_column :tenancies, :payment_amount_delta_contribution, :decimal
+    add_column :tenancies, :payment_date_delta_contribution, :decimal
+    add_column :tenancies, :number_of_broken_agreements_contribution, :decimal
+    add_column :tenancies, :active_agreement_contribution, :decimal
+    add_column :tenancies, :broken_court_order_contribution, :decimal
+    add_column :tenancies, :nosp_served_contribution, :decimal
+    add_column :tenancies, :active_nosp_contribution, :decimal
+  end
+end

--- a/lib/hackney/income/dangerous_sync_cases.rb
+++ b/lib/hackney/income/dangerous_sync_cases.rb
@@ -11,11 +11,12 @@ module Hackney
         tenancy_refs = @uh_tenancies_gateway.tenancies_in_arrears
         tenancy_refs.each do |tenancy_ref|
           priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
-
           @stored_tenancies_gateway.store_tenancy(
             tenancy_ref: tenancy_ref,
             priority_band: priorities.fetch(:priority_band),
-            priority_score: priorities.fetch(:priority_score)
+            priority_score: priorities.fetch(:priority_score),
+            criteria: priorities.fetch(:criteria),
+            weightings: priorities.fetch(:weightings)
           )
         end
       end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -1,10 +1,25 @@
 module Hackney
   module Income
     class StoredTenanciesGateway
-      def store_tenancy(tenancy_ref:, priority_band:, priority_score:)
+      def store_tenancy(tenancy_ref:, priority_band:, priority_score:, criteria:, weightings:)
+        score_calculator = Hackney::Income::TenancyPrioritiser::Score.new(
+          criteria,
+          weightings,
+        )
+
         Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).update(
           priority_band: priority_band,
-          priority_score: priority_score
+          priority_score: priority_score,
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp
         )
       end
 
@@ -13,7 +28,17 @@ module Hackney
           {
             tenancy_ref: model.tenancy_ref,
             priority_band: model.priority_band,
-            priority_score: model.priority_score
+            priority_score: model.priority_score,
+            balance_contribution: model.balance_contribution,
+            days_in_arrears_contribution: model.days_in_arrears_contribution,
+            days_since_last_payment_contribution: model.days_since_last_payment_contribution,
+            payment_amount_delta_contribution: model.payment_amount_delta_contribution,
+            payment_date_delta_contribution: model.payment_date_delta_contribution,
+            number_of_broken_agreements_contribution: model.number_of_broken_agreements_contribution,
+            active_agreement_contribution: model.active_agreement_contribution,
+            broken_court_order_contribution: model.broken_court_order_contribution,
+            nosp_served_contribution: model.nosp_served_contribution,
+            active_nosp_contribution: model.active_nosp_contribution
           }
         end
       end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -10,6 +10,7 @@ module Hackney
         Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).update(
           priority_band: priority_band,
           priority_score: priority_score,
+
           balance_contribution: score_calculator.balance,
           days_in_arrears_contribution: score_calculator.days_in_arrears,
           days_since_last_payment_contribution: score_calculator.days_since_last_payment,
@@ -19,7 +20,18 @@ module Hackney
           active_agreement_contribution: score_calculator.active_agreement,
           broken_court_order_contribution: score_calculator.broken_court_order,
           nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: criteria.balance,
+          days_in_arrears: criteria.days_in_arrears,
+          days_since_last_payment: criteria.days_since_last_payment,
+          payment_amount_delta: criteria.payment_amount_delta,
+          payment_date_delta: criteria.payment_date_delta,
+          number_of_broken_agreements: criteria.number_of_broken_agreements,
+          active_agreement: criteria.active_agreement?,
+          broken_court_order: criteria.broken_court_order?,
+          nosp_served: criteria.nosp_served?,
+          active_nosp: criteria.active_nosp?
         )
       end
 
@@ -29,6 +41,7 @@ module Hackney
             tenancy_ref: model.tenancy_ref,
             priority_band: model.priority_band,
             priority_score: model.priority_score,
+
             balance_contribution: model.balance_contribution,
             days_in_arrears_contribution: model.days_in_arrears_contribution,
             days_since_last_payment_contribution: model.days_since_last_payment_contribution,
@@ -38,7 +51,18 @@ module Hackney
             active_agreement_contribution: model.active_agreement_contribution,
             broken_court_order_contribution: model.broken_court_order_contribution,
             nosp_served_contribution: model.nosp_served_contribution,
-            active_nosp_contribution: model.active_nosp_contribution
+            active_nosp_contribution: model.active_nosp_contribution,
+
+            balance: model.balance,
+            days_in_arrears: model.days_in_arrears,
+            days_since_last_payment: model.days_since_last_payment,
+            payment_amount_delta: model.payment_amount_delta,
+            payment_date_delta: model.payment_date_delta,
+            number_of_broken_agreements: model.number_of_broken_agreements,
+            active_agreement: model.active_agreement,
+            broken_court_order: model.broken_court_order,
+            nosp_served: model.nosp_served,
+            active_nosp: model.active_nosp
           }
         end
       end

--- a/lib/hackney/income/universal_housing_prioritisation_gateway.rb
+++ b/lib/hackney/income/universal_housing_prioritisation_gateway.rb
@@ -7,7 +7,7 @@ module Hackney
         weightings = Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
         prioritiser = Hackney::Income::TenancyPrioritiser.new(criteria: criteria, weightings: weightings)
 
-        { priority_score: prioritiser.priority_score, priority_band: prioritiser.priority_band }
+        { priority_score: prioritiser.priority_score, priority_band: prioritiser.priority_band, criteria: criteria }
       end
     end
   end

--- a/lib/hackney/income/universal_housing_prioritisation_gateway.rb
+++ b/lib/hackney/income/universal_housing_prioritisation_gateway.rb
@@ -7,7 +7,7 @@ module Hackney
         weightings = Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
         prioritiser = Hackney::Income::TenancyPrioritiser.new(criteria: criteria, weightings: weightings)
 
-        { priority_score: prioritiser.priority_score, priority_band: prioritiser.priority_band, criteria: criteria }
+        { priority_score: prioritiser.priority_score, priority_band: prioritiser.priority_band, criteria: criteria, weightings: weightings }
       end
     end
   end

--- a/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
@@ -35,7 +35,9 @@ describe Hackney::Income::DangerousSyncCases do
         expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
           tenancy_ref: '000009/01',
           priority_band: :green,
-          priority_score: 1000
+          priority_score: 1000,
+          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
+          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
         subject
@@ -54,7 +56,9 @@ describe Hackney::Income::DangerousSyncCases do
         expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
           tenancy_ref: '000010/01',
           priority_band: :red,
-          priority_score: 5000
+          priority_score: 5000,
+          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
+          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
         subject
@@ -78,19 +82,25 @@ describe Hackney::Income::DangerousSyncCases do
         expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
           tenancy_ref: '000010/01',
           priority_band: :red,
-          priority_score: 300
+          priority_score: 300,
+          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
+          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
         expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
           tenancy_ref: '000011/01',
           priority_band: :green,
-          priority_score: 100
+          priority_score: 100,
+          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
+          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
         expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
           tenancy_ref: '000012/01',
           priority_band: :amber,
-          priority_score: 200
+          priority_score: 200,
+          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
+          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
         subject
@@ -107,7 +117,9 @@ class PrioritisationGatewayDouble
   def priorities_for_tenancy(tenancy_ref)
     {
       priority_score: @tenancy_refs_to_scores.dig(tenancy_ref, :priority_score),
-      priority_band: @tenancy_refs_to_scores.dig(tenancy_ref, :priority_band)
+      priority_band: @tenancy_refs_to_scores.dig(tenancy_ref, :priority_band),
+      criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
+      weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
     }
   end
 end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -9,9 +9,18 @@ describe Hackney::Income::StoredTenanciesGateway do
         {
           tenancy_ref: Faker::Internet.slug,
           priority_band: Faker::Internet.slug,
-          priority_score: Faker::Number.number(5).to_i
+          priority_score: Faker::Number.number(5).to_i,
+          criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
+          weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
         }
       end
+
+      let(:score_calculator) do
+         Hackney::Income::TenancyPrioritiser::Score.new(
+           attributes.fetch(:criteria),
+           attributes.fetch(:weightings),
+         )
+       end
 
       subject { gateway.get_tenancies_by_refs([attributes.fetch(:tenancy_ref)]) }
 
@@ -20,7 +29,17 @@ describe Hackney::Income::StoredTenanciesGateway do
           Hackney::Income::Models::Tenancy.create(
             tenancy_ref: attributes.fetch(:tenancy_ref),
             priority_band: attributes.fetch(:priority_band),
-            priority_score: attributes.fetch(:priority_score)
+            priority_score: attributes.fetch(:priority_score),
+            balance_contribution: score_calculator.balance,
+            days_in_arrears_contribution: score_calculator.days_in_arrears,
+            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+            payment_date_delta_contribution: score_calculator.payment_date_delta,
+            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+            active_agreement_contribution: score_calculator.active_agreement,
+            broken_court_order_contribution: score_calculator.broken_court_order,
+            nosp_served_contribution: score_calculator.nosp_served,
+            active_nosp_contribution: score_calculator.active_nosp
           )
         end
 
@@ -29,7 +48,17 @@ describe Hackney::Income::StoredTenanciesGateway do
           expect(subject).to include(a_hash_including(
             tenancy_ref: attributes.fetch(:tenancy_ref),
             priority_band: attributes.fetch(:priority_band),
-            priority_score: attributes.fetch(:priority_score)
+            priority_score: attributes.fetch(:priority_score),
+            balance_contribution: score_calculator.balance,
+            days_in_arrears_contribution: score_calculator.days_in_arrears,
+            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+            payment_date_delta_contribution: score_calculator.payment_date_delta,
+            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+            active_agreement_contribution: score_calculator.active_agreement,
+            broken_court_order_contribution: score_calculator.broken_court_order,
+            nosp_served_contribution: score_calculator.nosp_served,
+            active_nosp_contribution: score_calculator.active_nosp
           ))
         end
       end
@@ -79,15 +108,26 @@ describe Hackney::Income::StoredTenanciesGateway do
       {
         tenancy_ref: Faker::Internet.slug,
         priority_band: Faker::Internet.slug,
-        priority_score: Faker::Number.number(5).to_i
+        priority_score: Faker::Number.number(5).to_i,
+        criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
+        weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
       }
     end
+
+    let(:score_calculator) do
+       Hackney::Income::TenancyPrioritiser::Score.new(
+         attributes.fetch(:criteria),
+         attributes.fetch(:weightings),
+       )
+     end
 
     subject(:store_tenancy) do
       gateway.store_tenancy(
         tenancy_ref: attributes.fetch(:tenancy_ref),
         priority_band: attributes.fetch(:priority_band),
-        priority_score: attributes.fetch(:priority_score)
+        priority_score: attributes.fetch(:priority_score),
+        criteria: attributes.fetch(:criteria),
+        weightings: attributes.fetch(:weightings)
       )
     end
 
@@ -99,7 +139,17 @@ describe Hackney::Income::StoredTenanciesGateway do
         expect(created_tenancy).to have_attributes(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score)
+          priority_score: attributes.fetch(:priority_score),
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp
         )
       end
     end
@@ -109,7 +159,17 @@ describe Hackney::Income::StoredTenanciesGateway do
         Hackney::Income::Models::Tenancy.create(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score)
+          priority_score: attributes.fetch(:priority_score),
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp
         )
       end
 
@@ -120,7 +180,17 @@ describe Hackney::Income::StoredTenanciesGateway do
         expect(stored_tenancy).to have_attributes(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score)
+          priority_score: attributes.fetch(:priority_score),
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp
         )
       end
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -39,7 +39,18 @@ describe Hackney::Income::StoredTenanciesGateway do
             active_agreement_contribution: score_calculator.active_agreement,
             broken_court_order_contribution: score_calculator.broken_court_order,
             nosp_served_contribution: score_calculator.nosp_served,
-            active_nosp_contribution: score_calculator.active_nosp
+            active_nosp_contribution: score_calculator.active_nosp,
+
+            balance: attributes.fetch(:criteria).balance,
+            days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+            days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+            payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+            payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+            number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+            active_agreement: attributes.fetch(:criteria).active_agreement?,
+            broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+            nosp_served: attributes.fetch(:criteria).nosp_served?,
+            active_nosp: attributes.fetch(:criteria).active_nosp?
           )
         end
 
@@ -49,6 +60,7 @@ describe Hackney::Income::StoredTenanciesGateway do
             tenancy_ref: attributes.fetch(:tenancy_ref),
             priority_band: attributes.fetch(:priority_band),
             priority_score: attributes.fetch(:priority_score),
+
             balance_contribution: score_calculator.balance,
             days_in_arrears_contribution: score_calculator.days_in_arrears,
             days_since_last_payment_contribution: score_calculator.days_since_last_payment,
@@ -58,7 +70,18 @@ describe Hackney::Income::StoredTenanciesGateway do
             active_agreement_contribution: score_calculator.active_agreement,
             broken_court_order_contribution: score_calculator.broken_court_order,
             nosp_served_contribution: score_calculator.nosp_served,
-            active_nosp_contribution: score_calculator.active_nosp
+            active_nosp_contribution: score_calculator.active_nosp,
+
+            balance: attributes.fetch(:criteria).balance,
+            days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+            days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+            payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+            payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+            number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+            active_agreement: attributes.fetch(:criteria).active_agreement?,
+            broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+            nosp_served: attributes.fetch(:criteria).nosp_served?,
+            active_nosp: attributes.fetch(:criteria).active_nosp?
           ))
         end
       end
@@ -140,6 +163,7 @@ describe Hackney::Income::StoredTenanciesGateway do
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
           priority_score: attributes.fetch(:priority_score),
+
           balance_contribution: score_calculator.balance,
           days_in_arrears_contribution: score_calculator.days_in_arrears,
           days_since_last_payment_contribution: score_calculator.days_since_last_payment,
@@ -149,7 +173,18 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_agreement_contribution: score_calculator.active_agreement,
           broken_court_order_contribution: score_calculator.broken_court_order,
           nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: attributes.fetch(:criteria).balance,
+          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+          active_agreement: attributes.fetch(:criteria).active_agreement?,
+          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+          nosp_served: attributes.fetch(:criteria).nosp_served?,
+          active_nosp: attributes.fetch(:criteria).active_nosp?
         )
       end
     end
@@ -160,6 +195,7 @@ describe Hackney::Income::StoredTenanciesGateway do
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
           priority_score: attributes.fetch(:priority_score),
+
           balance_contribution: score_calculator.balance,
           days_in_arrears_contribution: score_calculator.days_in_arrears,
           days_since_last_payment_contribution: score_calculator.days_since_last_payment,
@@ -169,7 +205,18 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_agreement_contribution: score_calculator.active_agreement,
           broken_court_order_contribution: score_calculator.broken_court_order,
           nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: attributes.fetch(:criteria).balance,
+          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+          active_agreement: attributes.fetch(:criteria).active_agreement?,
+          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+          nosp_served: attributes.fetch(:criteria).nosp_served?,
+          active_nosp: attributes.fetch(:criteria).active_nosp?
         )
       end
 
@@ -181,6 +228,7 @@ describe Hackney::Income::StoredTenanciesGateway do
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
           priority_score: attributes.fetch(:priority_score),
+
           balance_contribution: score_calculator.balance,
           days_in_arrears_contribution: score_calculator.days_in_arrears,
           days_since_last_payment_contribution: score_calculator.days_since_last_payment,
@@ -190,7 +238,18 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_agreement_contribution: score_calculator.active_agreement,
           broken_court_order_contribution: score_calculator.broken_court_order,
           nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: attributes.fetch(:criteria).balance,
+          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+          active_agreement: attributes.fetch(:criteria).active_agreement?,
+          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+          nosp_served: attributes.fetch(:criteria).nosp_served?,
+          active_nosp: attributes.fetch(:criteria).active_nosp?
         )
       end
 

--- a/spec/lib/hackney/income/universal_housing_prioritisation_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_prioritisation_gateway_spec.rb
@@ -15,8 +15,12 @@ describe Hackney::Income::UniversalHousingPrioritisationGateway, universal: true
       allow_any_instance_of(Hackney::Income::TenancyPrioritiser).to receive(:priority_band).and_return(priority_band)
     end
 
-    it 'should return the priority scores of that tenancy' do
-      expect(subject.priorities_for_tenancy(tenancy_ref)).to eq(priority_score: priority_score, priority_band: priority_band)
+    it 'should return the priority scores and criteria of that tenancy' do
+      expect(subject.priorities_for_tenancy(tenancy_ref)).to include(
+        priority_score: priority_score,
+        priority_band: priority_band,
+        criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria)
+      )
     end
 
     it 'should determine universal housing criteria' do

--- a/spec/lib/hackney/income/universal_housing_prioritisation_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_prioritisation_gateway_spec.rb
@@ -19,7 +19,8 @@ describe Hackney::Income::UniversalHousingPrioritisationGateway, universal: true
       expect(subject.priorities_for_tenancy(tenancy_ref)).to include(
         priority_score: priority_score,
         priority_band: priority_band,
-        criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria)
+        criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria),
+        weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
       )
     end
 


### PR DESCRIPTION
Adds a set of score contributions to the tenancy model, to be persisted along with score and band.

Saved directly as the numerical contribution to the score to be provided as a breakdown, so we can say 'having an active NOSP contributed x of y to the score' etc. 
This means by default, the score contribution of 100.00 balance would be stored as +120.00 score contribution, which should help clarify how the different score values are reached and aid tweaking score generation through feedback > adjust weighting > feedback cycle.