### PR TITLE
Restrict tenancies used to beta patches when generating priority scores

### DIFF
--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -8,14 +8,15 @@ module Hackney
 
       def tenancies_in_arrears
         query = database[:tenagree]
-          .left_join(:property, prop_ref: :prop_ref)
-          .where { Sequel[:tenagree][:cur_bal] > 0 }
 
         if @restrict_patches
-          query = query.where(Sequel[:property][:arr_patch] => @permitted_patches)
+          query = query
+            .left_join(:property, prop_ref: :prop_ref)
+            .where(Sequel[:property][:arr_patch] => @permitted_patches)
         end
 
         query
+          .where { Sequel[:tenagree][:cur_bal] > 0 }
           .select { Sequel[:tenagree][:tag_ref].as(:tag_ref) }
           .map { |record| record[:tag_ref].strip }
       end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -14,7 +14,10 @@ module Hackney
       def sync_cases
         Hackney::Income::DangerousSyncCases.new(
           prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
-          uh_tenancies_gateway: Hackney::Income::HardcodedTenanciesGateway.new,
+          uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new(
+            restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
+            patches: ENV.fetch('PERMITTED_PATCHES', [])
+          ),
           stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
         )
       end

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -44,7 +44,7 @@ describe MyCasesController do
     it 'should create the sync tenancies use case' do
       expect(Hackney::Income::DangerousSyncCases).to receive(:new).with(
         prioritisation_gateway: instance_of(Hackney::Income::UniversalHousingPrioritisationGateway),
-        uh_tenancies_gateway: instance_of(Hackney::Income::HardcodedTenanciesGateway),
+        uh_tenancies_gateway: instance_of(Hackney::Income::UniversalHousingTenanciesGateway),
         stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway)
       ).and_call_original
 

--- a/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
@@ -42,5 +42,46 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
         expect(subject).to eq(['000002/01', '000004/01'])
       end
     end
+
+    context 'when patches are restricted' do
+      context 'and a list of acceptable patches is given' do
+        let(:gateway) { described_class.new(restrict_patches: true, patches: ['X01', 'Y01', 'Z01']) }
+
+        context 'and a tenancy is not in an accepted patch' do
+          before do
+            create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, property_ref: 'PROP1')
+            create_uh_property(property_ref: 'PROP1', patch_code: 'B01')
+          end
+
+          it 'should not return the tenancy' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'and a tenancy is in one of the accepted patches' do
+          before do
+            create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, property_ref: 'PROP1')
+            create_uh_property(property_ref: 'PROP1', patch_code: 'Z01')
+          end
+
+          it 'should include the tenancy' do
+            expect(subject).to eq(['00001/01'])
+          end
+        end
+      end
+
+      context 'when no list of acceptable patches is given' do
+        let(:gateway) { described_class.new(restrict_patches: true) }
+
+        before do
+          create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, property_ref: 'PROP1')
+          create_uh_property(property_ref: 'PROP1', patch_code: 'B01')
+        end
+
+        it 'should return no tenancies' do
+          expect(subject).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -1,6 +1,6 @@
 module UniversalHousingHelper
-  def create_uh_tenancy_agreement(tenancy_ref:, current_balance:)
-    Hackney::UniversalHousing::Client.connection[:tenagree].insert(tag_ref: tenancy_ref, cur_bal: current_balance)
+  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, property_ref: '')
+    Hackney::UniversalHousing::Client.connection[:tenagree].insert(tag_ref: tenancy_ref, cur_bal: current_balance, prop_ref: property_ref)
   end
 
   def create_uh_transaction(tenancy_ref:, amount: 0.0, date: Date.today, type: '')
@@ -15,10 +15,15 @@ module UniversalHousingHelper
     Hackney::UniversalHousing::Client.connection[:araction].insert(tag_ref: tenancy_ref, action_code: code, action_date: date)
   end
 
+  def create_uh_property(property_ref:, patch_code:)
+    Hackney::UniversalHousing::Client.connection[:property].insert(prop_ref: property_ref, arr_patch: patch_code)
+  end
+
   def truncate_uh_tables
     Hackney::UniversalHousing::Client.connection[:tenagree].truncate
     Hackney::UniversalHousing::Client.connection[:rtrans].truncate
     Hackney::UniversalHousing::Client.connection[:arag].truncate
     Hackney::UniversalHousing::Client.connection[:araction].truncate
+    Hackney::UniversalHousing::Client.connection[:property].truncate
   end
 end


### PR DESCRIPTION
For our Beta team, we're going to start by only generating priority scores for tenancies in Beta patches. This should help us avoid performance issues making our sync job take too long in production, and reduce initial load on the database for a first test.

- Configures which patches are restricted via env vars.
- Will need to update env vars on staging and production before releasing.