### PR TITLE
Fix performance issue by removing rest-client and sticking to net/http

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'puma', '~> 3.7'
 gem 'mysql2'
 gem 'sequel'
 gem 'tiny_tds'
-gem 'rest-client'
 
 gem 'delayed_job'
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,6 @@ GEM
       activerecord (>= 3.0, < 5.3)
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     faker (1.9.1)
       i18n (>= 0.7)
@@ -62,8 +60,6 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     listen (3.1.5)
@@ -76,14 +72,10 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     mysql2 (0.5.2)
-    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -119,10 +111,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rest-client (2.0.2)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -164,9 +152,6 @@ GEM
     tiny_tds (2.1.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.5)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -187,7 +172,6 @@ DEPENDENCIES
   mysql2
   puma (~> 3.7)
   rails (~> 5.1.6)
-  rest-client
   rspec-its
   rspec-rails
   sequel


### PR DESCRIPTION
Change has made the request go from 30+ seconds for a single tenancy ref, to subsecond for 30 tenancies.