### PR TITLE
Only schedule jobs on app start, not on app load

### DIFF
--- a/config/initializers/schedule_jobs.rb
+++ b/config/initializers/schedule_jobs.rb
@@ -1,1 +1,8 @@
-JobScheduler.enqueue_jobs if Rails.env.staging? or Rails.env.production?
+if defined?(Rails::Server)
+  # Scheduled tasks like SyncCasesJob should automatically re-queue their next run, if necessary.
+  # This sets up these scheduled tasks for the first time if they haven't already been queued, when booting the application server.
+
+  Delayed::Worker.logger = ActiveSupport::Logger.new(STDOUT)
+
+  JobScheduler.enqueue_jobs if Rails.env.staging? or Rails.env.production?
+end


### PR DESCRIPTION
To prevent this occurring whenever Rails is loaded without being served. e.g. to run migrations.