### PR TITLE
Fix concurrent tasks not running on ECS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,25 @@ jobs:
           command: |
             docker run -e DATABASE_URL=$STAGING_DATABASE_URL --rm hackney/apps/income-api:latest rails db:migrate
       - run:
-          name: Force new deployment
+          name: Build new worker Docker image
+          command: docker build --tag hackney/apps/income-api-worker .
+      - run:
+          name: Tag new worker image for staging release
+          command: |
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:$CIRCLE_SHA1
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:latest
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:staging
+      - run:
+          name: Release new worker image to ECR
+          command: |
+            docker push $ECR_WORKER_IMAGE_URL:$CIRCLE_SHA1
+            docker push $ECR_WORKER_IMAGE_URL:latest
+            docker push $ECR_WORKER_IMAGE_URL:staging
+      - run:
+          name: Force new worker deployment
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_WORKER_NAME --image $ECR_WORKER_IMAGE_URL:staging --timeout $ECS_DEPLOY_TIMEOUT
+      - run:
+          name: Force new application deployment
           command: ecs-deploy --region $AWS_REGION --cluster $ECS_STAGING_CLUSTER --service-name $ECS_STAGING_APP_NAME --image $ECR_IMAGE_URL:staging --timeout $ECS_DEPLOY_TIMEOUT
 
   production_release:
@@ -90,7 +108,7 @@ jobs:
           name: Build new application Docker image
           command: docker build --tag hackney/apps/income-api .
       - run:
-          name: Tag new image for staging release
+          name: Tag new image for production release
           command: |
             docker tag hackney/apps/income-api:latest $ECR_IMAGE_URL:production
       - run:
@@ -102,7 +120,25 @@ jobs:
           command: |
             docker run -e DATABASE_URL=$PRODUCTION_DATABASE_URL --rm hackney/apps/income-api:latest rails db:migrate
       - run:
-          name: Force new deployment
+          name: Build new worker Docker image
+          command: docker build --tag hackney/apps/income-api-worker .
+      - run:
+          name: Tag new worker image for production release
+          command: |
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:$CIRCLE_SHA1
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:latest
+            docker tag hackney/apps/income-api-worker:latest $ECR_WORKER_IMAGE_URL:production
+      - run:
+          name: Release new worker image to ECR
+          command: |
+            docker push $ECR_WORKER_IMAGE_URL:$CIRCLE_SHA1
+            docker push $ECR_WORKER_IMAGE_URL:latest
+            docker push $ECR_WORKER_IMAGE_URL:production
+      - run:
+          name: Force new worker deployment
+          command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_WORKER_NAME --image $ECR_WORKER_IMAGE_URL:production --timeout $ECS_DEPLOY_TIMEOUT
+      - run:
+          name: Force new application deployment
           command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout $ECS_DEPLOY_TIMEOUT
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN bundle check || bundle install
 COPY . /app
 EXPOSE 3000
 
-CMD ["sh", "-c", "rake jobs:work ; rails s"]
+CMD rails s


### PR DESCRIPTION
Runs a separate worker container for each environment on ECS, instead of running jobs and the application in the same container.

A) Fixes a bug where both _aren't_ running concurrently at the moment.
B) Means both can be stopped gracefully when ECS redeploys.