### PR TITLE
Update MyCases controller to read tenancy refs

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -1,25 +1,17 @@
 class MyCasesController < ApplicationController
   def index
-    cases = view_my_cases_use_case.execute(random_tenancy_refs)
+    cases = income_use_case_factory.view_my_cases.execute(tenancy_refs)
     render json: cases
   end
 
   def sync
-    sync_cases_use_case.execute
+    income_use_case_factory.sync_cases.execute
     render json: { success: true }
   end
 
   private
 
-  def view_my_cases_use_case
-    income_use_case_factory.view_my_cases
-  end
-
-  def sync_cases_use_case
-    income_use_case_factory.sync_cases
-  end
-
-  def random_tenancy_refs
-    Hackney::Income::Models::Tenancy.first(20).map { |t| t.tenancy_ref }
+  def tenancy_refs
+    params.fetch(:tenancy_refs, [])
   end
 end

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -16,26 +16,54 @@ describe MyCasesController do
         get :index
       end
 
-      it 'should call the view tenancies use case' do
-        expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
-          .to receive(:execute)
-          .and_return([])
+      context 'with no tenancy refs' do
+        it 'should call the view tenancies use case with none' do
+          expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
+            .to receive(:execute)
+            .with([])
+            .and_return([])
 
-        get :index
+          get :index
+        end
+
+        it 'should respond with no results' do
+          allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
+            .to receive(:execute)
+            .and_return([])
+
+          get :index
+
+          expect(response.body).to eq([].to_json)
+        end
       end
 
-      it 'should respond with the results of the view tenancies use case' do
-        expected_result = [{
-          Faker::GreekPhilosophers.name => Faker::GreekPhilosophers.quote
-        }]
+      context 'with tenancy refs' do
+        let(:tenancy_refs) do
+          Array.new(Faker::Number.number(2).to_i).map { Faker::Code.isbn }
+        end
 
-        allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
-          .to receive(:execute)
-          .and_return(expected_result)
+        it 'should call the view tenancies use case with the given tenancy refs' do
+          expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
+            .to receive(:execute)
+            .with(tenancy_refs)
+            .and_return([])
 
-        get :index
+          get :index, params: { tenancy_refs: tenancy_refs }
+        end
 
-        expect(response.body).to eq(expected_result.to_json)
+        it 'should respond with the results of the view tenancies use case' do
+          expected_result = [{
+            Faker::GreekPhilosophers.name => Faker::GreekPhilosophers.quote
+          }]
+
+          allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
+            .to receive(:execute)
+            .and_return(expected_result)
+
+          get :index
+
+          expect(response.body).to eq(expected_result.to_json)
+        end
       end
     end
   end


### PR DESCRIPTION
The ICS will pass in tenancy refs for cases assigned to the current user.