### PR TITLE
Migrate on the server before deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,6 @@ jobs:
             docker push $ECR_IMAGE_URL:latest
             docker push $ECR_IMAGE_URL:staging
       - run:
-          name: Run migrations
-          command: |
-            docker run -e DATABASE_URL=$STAGING_DATABASE_URL --rm hackney/apps/income-api:latest rails db:migrate
-      - run:
           name: Build new worker Docker image
           command: docker build --tag hackney/apps/income-api-worker .
       - run:
@@ -113,10 +109,6 @@ jobs:
           name: Release new image to ECR
           command: |
             docker push $ECR_IMAGE_URL:production
-      - run:
-          name: Run migrations
-          command: |
-            docker run -e DATABASE_URL=$PRODUCTION_DATABASE_URL --rm hackney/apps/income-api:latest rails db:migrate
       - run:
           name: Build new worker Docker image
           command: docker build --tag hackney/apps/income-api-worker .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN bundle check || bundle install
 COPY . /app
 EXPOSE 3000
 
-CMD rails s
+CMD ["sh", "-c", "rails db:migrate ; rails s"]


### PR DESCRIPTION
The RDS database can't be reached from Circle currently, temporarily running on the server instead.