### PR TITLE
Add user assignment to tenancies, and pagination to the my-cases endpoint

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -1,17 +1,16 @@
 class MyCasesController < ApplicationController
   def index
-    cases = income_use_case_factory.view_my_cases.execute(tenancy_refs)
+    cases = income_use_case_factory.view_my_cases.execute(
+      user_id: params.fetch(:user_id).to_i,
+      page_number: params.fetch(:page_number).to_i,
+      number_per_page: params.fetch(:number_per_page).to_i
+    )
+
     render json: cases
   end
 
   def sync
     income_use_case_factory.sync_cases.execute
     render json: { success: true }
-  end
-
-  private
-
-  def tenancy_refs
-    params.fetch(:tenancy_refs, [])
   end
 end

--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -1,12 +1,12 @@
 class MyCasesController < ApplicationController
   def index
-    cases = income_use_case_factory.view_my_cases.execute(
+    response = income_use_case_factory.view_my_cases.execute(
       user_id: params.fetch(:user_id).to_i,
       page_number: params.fetch(:page_number).to_i,
       number_per_page: params.fetch(:number_per_page).to_i
     )
 
-    render json: cases
+    render json: response
   end
 
   def sync

--- a/db/migrate/20180912114134_add_assigned_user_id_to_tenancies.rb
+++ b/db/migrate/20180912114134_add_assigned_user_id_to_tenancies.rb
@@ -1,0 +1,5 @@
+class AddAssignedUserIdToTenancies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tenancies, :assigned_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180828112331) do
+ActiveRecord::Schema.define(version: 20180912114134) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -33,6 +33,33 @@ ActiveRecord::Schema.define(version: 20180828112331) do
     t.decimal "priority_score"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "balance_contribution"
+    t.decimal "days_in_arrears_contribution"
+    t.decimal "days_since_last_payment_contribution"
+    t.decimal "payment_amount_delta_contribution"
+    t.decimal "payment_date_delta_contribution"
+    t.decimal "number_of_broken_agreements_contribution"
+    t.decimal "active_agreement_contribution"
+    t.decimal "broken_court_order_contribution"
+    t.decimal "nosp_served_contribution"
+    t.decimal "active_nosp_contribution"
+    t.decimal "balance"
+    t.integer "days_in_arrears"
+    t.integer "days_since_last_payment"
+    t.decimal "payment_amount_delta"
+    t.integer "payment_date_delta"
+    t.integer "number_of_broken_agreements"
+    t.boolean "active_agreement"
+    t.boolean "broken_court_order"
+    t.boolean "nosp_served"
+    t.boolean "active_nosp"
+    t.string "current_arrears_agreement_status"
+    t.string "latest_action_code"
+    t.string "latest_action_date"
+    t.string "primary_contact_name"
+    t.string "primary_contact_short_address"
+    t.string "primary_contact_postcode"
+    t.integer "assigned_user_id"
   end
 
 end

--- a/lib/hackney/income/dangerous_view_my_cases.rb
+++ b/lib/hackney/income/dangerous_view_my_cases.rb
@@ -7,12 +7,12 @@ module Hackney
       end
 
       def execute(user_id:, page_number:, number_per_page:)
-        stored_tenancies = @stored_tenancies_gateway.get_tenancies_for_user(user_id: user_id, page_number: page_number, number_per_page: number_per_page)
-        stored_tenancy_refs = stored_tenancies.map { |t| t.fetch(:tenancy_ref) }
-        full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(stored_tenancy_refs)
+        assigned_tenancies = @stored_tenancies_gateway.get_tenancies_for_user(user_id: user_id, page_number: page_number, number_per_page: number_per_page)
+        assigned_tenancy_refs = assigned_tenancies.map { |t| t.fetch(:tenancy_ref) }
+        full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(assigned_tenancy_refs)
 
-        stored_tenancies.map do |stored_tenancy|
-          tenancy = full_tenancies.find { |t| t.fetch(:ref) == stored_tenancy.fetch(:tenancy_ref) }
+        assigned_tenancies.map do |assigned_tenancy|
+          tenancy = full_tenancies.find { |t| t.fetch(:ref) == assigned_tenancy.fetch(:tenancy_ref) }
           next if tenancy.nil?
 
           {
@@ -28,30 +28,30 @@ module Hackney
               short_address: tenancy.dig(:primary_contact, :short_address),
               postcode: tenancy.dig(:primary_contact, :postcode),
             },
-            priority_band: stored_tenancy.fetch(:priority_band),
-            priority_score: stored_tenancy.fetch(:priority_score),
+            priority_band: assigned_tenancy.fetch(:priority_band),
+            priority_score: assigned_tenancy.fetch(:priority_score),
 
-            balance_contribution: stored_tenancy.fetch(:balance_contribution),
-            days_in_arrears_contribution: stored_tenancy.fetch(:days_in_arrears_contribution),
-            days_since_last_payment_contribution: stored_tenancy.fetch(:days_since_last_payment_contribution),
-            payment_amount_delta_contribution: stored_tenancy.fetch(:payment_amount_delta_contribution),
-            payment_date_delta_contribution: stored_tenancy.fetch(:payment_date_delta_contribution),
-            number_of_broken_agreements_contribution: stored_tenancy.fetch(:number_of_broken_agreements_contribution),
-            active_agreement_contribution: stored_tenancy.fetch(:active_agreement_contribution),
-            broken_court_order_contribution: stored_tenancy.fetch(:broken_court_order_contribution),
-            nosp_served_contribution: stored_tenancy.fetch(:nosp_served_contribution),
-            active_nosp_contribution: stored_tenancy.fetch(:active_nosp_contribution),
+            balance_contribution: assigned_tenancy.fetch(:balance_contribution),
+            days_in_arrears_contribution: assigned_tenancy.fetch(:days_in_arrears_contribution),
+            days_since_last_payment_contribution: assigned_tenancy.fetch(:days_since_last_payment_contribution),
+            payment_amount_delta_contribution: assigned_tenancy.fetch(:payment_amount_delta_contribution),
+            payment_date_delta_contribution: assigned_tenancy.fetch(:payment_date_delta_contribution),
+            number_of_broken_agreements_contribution: assigned_tenancy.fetch(:number_of_broken_agreements_contribution),
+            active_agreement_contribution: assigned_tenancy.fetch(:active_agreement_contribution),
+            broken_court_order_contribution: assigned_tenancy.fetch(:broken_court_order_contribution),
+            nosp_served_contribution: assigned_tenancy.fetch(:nosp_served_contribution),
+            active_nosp_contribution: assigned_tenancy.fetch(:active_nosp_contribution),
 
-            balance: stored_tenancy.fetch(:balance),
-            days_in_arrears: stored_tenancy.fetch(:days_in_arrears),
-            days_since_last_payment: stored_tenancy.fetch(:days_since_last_payment),
-            payment_amount_delta: stored_tenancy.fetch(:payment_amount_delta),
-            payment_date_delta: stored_tenancy.fetch(:payment_date_delta),
-            number_of_broken_agreements: stored_tenancy.fetch(:number_of_broken_agreements),
-            active_agreement: stored_tenancy.fetch(:active_agreement),
-            broken_court_order: stored_tenancy.fetch(:broken_court_order),
-            nosp_served: stored_tenancy.fetch(:nosp_served),
-            active_nosp: stored_tenancy.fetch(:active_nosp)
+            balance: assigned_tenancy.fetch(:balance),
+            days_in_arrears: assigned_tenancy.fetch(:days_in_arrears),
+            days_since_last_payment: assigned_tenancy.fetch(:days_since_last_payment),
+            payment_amount_delta: assigned_tenancy.fetch(:payment_amount_delta),
+            payment_date_delta: assigned_tenancy.fetch(:payment_date_delta),
+            number_of_broken_agreements: assigned_tenancy.fetch(:number_of_broken_agreements),
+            active_agreement: assigned_tenancy.fetch(:active_agreement),
+            broken_court_order: assigned_tenancy.fetch(:broken_court_order),
+            nosp_served: assigned_tenancy.fetch(:nosp_served),
+            active_nosp: assigned_tenancy.fetch(:active_nosp)
           }
         end.compact
       end

--- a/lib/hackney/income/dangerous_view_my_cases.rb
+++ b/lib/hackney/income/dangerous_view_my_cases.rb
@@ -1,59 +1,70 @@
 module Hackney
   module Income
     class DangerousViewMyCases
+      Response = Struct.new(:cases, :number_of_pages)
+
       def initialize(tenancy_api_gateway:, stored_tenancies_gateway:)
         @tenancy_api_gateway = tenancy_api_gateway
         @stored_tenancies_gateway = stored_tenancies_gateway
       end
 
       def execute(user_id:, page_number:, number_per_page:)
+        number_of_pages_for_user = @stored_tenancies_gateway.number_of_pages_for_user(user_id: user_id, number_per_page: number_per_page)
         assigned_tenancies = @stored_tenancies_gateway.get_tenancies_for_user(user_id: user_id, page_number: page_number, number_per_page: number_per_page)
         assigned_tenancy_refs = assigned_tenancies.map { |t| t.fetch(:tenancy_ref) }
         full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(assigned_tenancy_refs)
 
-        assigned_tenancies.map do |assigned_tenancy|
+        cases = assigned_tenancies.map do |assigned_tenancy|
           tenancy = full_tenancies.find { |t| t.fetch(:ref) == assigned_tenancy.fetch(:tenancy_ref) }
           next if tenancy.nil?
 
-          {
-            ref: tenancy.fetch(:ref),
-            current_balance: tenancy.fetch(:current_balance),
-            current_arrears_agreement_status: tenancy.fetch(:current_arrears_agreement_status),
-            latest_action: {
-              code: tenancy.dig(:latest_action, :code),
-              date: tenancy.dig(:latest_action, :date),
-            },
-            primary_contact: {
-              name: tenancy.dig(:primary_contact, :name),
-              short_address: tenancy.dig(:primary_contact, :short_address),
-              postcode: tenancy.dig(:primary_contact, :postcode),
-            },
-            priority_band: assigned_tenancy.fetch(:priority_band),
-            priority_score: assigned_tenancy.fetch(:priority_score),
-
-            balance_contribution: assigned_tenancy.fetch(:balance_contribution),
-            days_in_arrears_contribution: assigned_tenancy.fetch(:days_in_arrears_contribution),
-            days_since_last_payment_contribution: assigned_tenancy.fetch(:days_since_last_payment_contribution),
-            payment_amount_delta_contribution: assigned_tenancy.fetch(:payment_amount_delta_contribution),
-            payment_date_delta_contribution: assigned_tenancy.fetch(:payment_date_delta_contribution),
-            number_of_broken_agreements_contribution: assigned_tenancy.fetch(:number_of_broken_agreements_contribution),
-            active_agreement_contribution: assigned_tenancy.fetch(:active_agreement_contribution),
-            broken_court_order_contribution: assigned_tenancy.fetch(:broken_court_order_contribution),
-            nosp_served_contribution: assigned_tenancy.fetch(:nosp_served_contribution),
-            active_nosp_contribution: assigned_tenancy.fetch(:active_nosp_contribution),
-
-            balance: assigned_tenancy.fetch(:balance),
-            days_in_arrears: assigned_tenancy.fetch(:days_in_arrears),
-            days_since_last_payment: assigned_tenancy.fetch(:days_since_last_payment),
-            payment_amount_delta: assigned_tenancy.fetch(:payment_amount_delta),
-            payment_date_delta: assigned_tenancy.fetch(:payment_date_delta),
-            number_of_broken_agreements: assigned_tenancy.fetch(:number_of_broken_agreements),
-            active_agreement: assigned_tenancy.fetch(:active_agreement),
-            broken_court_order: assigned_tenancy.fetch(:broken_court_order),
-            nosp_served: assigned_tenancy.fetch(:nosp_served),
-            active_nosp: assigned_tenancy.fetch(:active_nosp)
-          }
+          build_tenancy_list_item(tenancy, assigned_tenancy)
         end.compact
+
+        Response.new(cases, number_of_pages_for_user)
+      end
+
+      private
+
+      def build_tenancy_list_item(tenancy, assigned_tenancy)
+        {
+          ref: tenancy.fetch(:ref),
+          current_balance: tenancy.fetch(:current_balance),
+          current_arrears_agreement_status: tenancy.fetch(:current_arrears_agreement_status),
+          latest_action: {
+            code: tenancy.dig(:latest_action, :code),
+            date: tenancy.dig(:latest_action, :date),
+          },
+          primary_contact: {
+            name: tenancy.dig(:primary_contact, :name),
+            short_address: tenancy.dig(:primary_contact, :short_address),
+            postcode: tenancy.dig(:primary_contact, :postcode),
+          },
+          priority_band: assigned_tenancy.fetch(:priority_band),
+          priority_score: assigned_tenancy.fetch(:priority_score),
+
+          balance_contribution: assigned_tenancy.fetch(:balance_contribution),
+          days_in_arrears_contribution: assigned_tenancy.fetch(:days_in_arrears_contribution),
+          days_since_last_payment_contribution: assigned_tenancy.fetch(:days_since_last_payment_contribution),
+          payment_amount_delta_contribution: assigned_tenancy.fetch(:payment_amount_delta_contribution),
+          payment_date_delta_contribution: assigned_tenancy.fetch(:payment_date_delta_contribution),
+          number_of_broken_agreements_contribution: assigned_tenancy.fetch(:number_of_broken_agreements_contribution),
+          active_agreement_contribution: assigned_tenancy.fetch(:active_agreement_contribution),
+          broken_court_order_contribution: assigned_tenancy.fetch(:broken_court_order_contribution),
+          nosp_served_contribution: assigned_tenancy.fetch(:nosp_served_contribution),
+          active_nosp_contribution: assigned_tenancy.fetch(:active_nosp_contribution),
+
+          balance: assigned_tenancy.fetch(:balance),
+          days_in_arrears: assigned_tenancy.fetch(:days_in_arrears),
+          days_since_last_payment: assigned_tenancy.fetch(:days_since_last_payment),
+          payment_amount_delta: assigned_tenancy.fetch(:payment_amount_delta),
+          payment_date_delta: assigned_tenancy.fetch(:payment_date_delta),
+          number_of_broken_agreements: assigned_tenancy.fetch(:number_of_broken_agreements),
+          active_agreement: assigned_tenancy.fetch(:active_agreement),
+          broken_court_order: assigned_tenancy.fetch(:broken_court_order),
+          nosp_served: assigned_tenancy.fetch(:nosp_served),
+          active_nosp: assigned_tenancy.fetch(:active_nosp)
+        }
       end
     end
   end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -47,6 +47,11 @@ module Hackney
         query.map(&method(:build_tenancy_list_item))
       end
 
+      def number_of_pages_for_user(user_id:, number_per_page:)
+        user_cases = Hackney::Income::Models::Tenancy.where(assigned_user_id: user_id)
+        (user_cases.count.to_f / number_per_page).ceil
+      end
+
       private
 
       def by_band_then_score

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -15,7 +15,7 @@ describe MyCasesController do
 
         allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
           .to receive(:execute)
-          .and_return([])
+          .and_return({ cases: [], number_per_page: 1 })
 
         get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
       end
@@ -24,15 +24,16 @@ describe MyCasesController do
         expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
           .to receive(:execute)
           .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page)
-          .and_return([])
+          .and_return({ cases: [], number_per_page: 1 })
 
         get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
       end
 
       it 'should respond with the results of the view my cases use case' do
-        expected_result = [{
-          Faker::GreekPhilosophers.name => Faker::GreekPhilosophers.quote
-        }]
+        expected_result = {
+          cases: [Faker::GreekPhilosophers.quote],
+          number_per_page: 10
+        }
 
         allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
           .to receive(:execute)
@@ -55,7 +56,7 @@ describe MyCasesController do
 
       allow_any_instance_of(Hackney::Income::DangerousSyncCases)
         .to receive(:execute)
-        .and_return([])
+        .and_return({ cases: [], number_per_page: 1 })
 
       get :sync
     end
@@ -63,7 +64,7 @@ describe MyCasesController do
     it 'should call the sync tenancies use case' do
       expect_any_instance_of(Hackney::Income::DangerousSyncCases)
         .to receive(:execute)
-        .and_return([])
+        .and_return({ cases: [], number_per_page: 1 })
 
       get :sync
     end
@@ -71,7 +72,7 @@ describe MyCasesController do
     it 'should respond with { success: true }' do
       allow_any_instance_of(Hackney::Income::DangerousSyncCases)
         .to receive(:execute)
-        .and_return([])
+        .and_return({ cases: [], number_per_page: 1 })
 
       get :sync
 

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 describe MyCasesController do
   describe '#index' do
     context 'when retrieving cases' do
-      it 'should create the view tenancies use case' do
+      let(:user_id) { Faker::Number.number(2).to_i }
+      let(:page_number) { Faker::Number.number(2).to_i }
+      let(:number_per_page) { Faker::Number.number(2).to_i }
+
+      it 'should create the view my cases use case' do
         expect(Hackney::Income::DangerousViewMyCases).to receive(:new).with(
           tenancy_api_gateway: instance_of(Hackney::Income::TenancyApiGateway),
           stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway)
@@ -13,57 +17,30 @@ describe MyCasesController do
           .to receive(:execute)
           .and_return([])
 
-        get :index
+        get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
       end
 
-      context 'with no tenancy refs' do
-        it 'should call the view tenancies use case with none' do
-          expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
-            .to receive(:execute)
-            .with([])
-            .and_return([])
+      it 'should call the view my cases use case with the given user_id, page_number and number_per_page' do
+        expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
+          .to receive(:execute)
+          .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page)
+          .and_return([])
 
-          get :index
-        end
-
-        it 'should respond with no results' do
-          allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
-            .to receive(:execute)
-            .and_return([])
-
-          get :index
-
-          expect(response.body).to eq([].to_json)
-        end
+        get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
       end
 
-      context 'with tenancy refs' do
-        let(:tenancy_refs) do
-          Array.new(Faker::Number.number(2).to_i).map { Faker::Code.isbn }
-        end
+      it 'should respond with the results of the view my cases use case' do
+        expected_result = [{
+          Faker::GreekPhilosophers.name => Faker::GreekPhilosophers.quote
+        }]
 
-        it 'should call the view tenancies use case with the given tenancy refs' do
-          expect_any_instance_of(Hackney::Income::DangerousViewMyCases)
-            .to receive(:execute)
-            .with(tenancy_refs)
-            .and_return([])
+        allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
+          .to receive(:execute)
+          .and_return(expected_result)
 
-          get :index, params: { tenancy_refs: tenancy_refs }
-        end
+        get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
 
-        it 'should respond with the results of the view tenancies use case' do
-          expected_result = [{
-            Faker::GreekPhilosophers.name => Faker::GreekPhilosophers.quote
-          }]
-
-          allow_any_instance_of(Hackney::Income::DangerousViewMyCases)
-            .to receive(:execute)
-            .and_return(expected_result)
-
-          get :index
-
-          expect(response.body).to eq(expected_result.to_json)
-        end
+        expect(response.body).to eq(expected_result.to_json)
       end
     end
   end

--- a/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
@@ -36,7 +36,7 @@ describe Hackney::Income::DangerousViewMyCases do
 
   context 'when the stored tenancies gateway responds with no tenancies' do
     it 'should return nothing' do
-      expect(subject).to eq([])
+      expect(subject.cases).to eq([])
     end
   end
 
@@ -54,7 +54,7 @@ describe Hackney::Income::DangerousViewMyCases do
 
     context 'and full tenancy details can NOT be found' do
       it 'should ignore the tenancy' do
-        expect(subject).to eq([])
+        expect(subject.cases).to eq([])
       end
     end
 
@@ -67,8 +67,8 @@ describe Hackney::Income::DangerousViewMyCases do
       end
 
       it 'should return full details for the correct tenancy' do
-        expect(subject.count).to eq(1)
-        expect(subject).to include(a_hash_including(
+        expect(subject.cases.count).to eq(1)
+        expect(subject.cases).to include(a_hash_including(
           ref: tenancy_attributes.fetch(:ref),
           priority_score: tenancy_priority_score,
           priority_band: tenancy_priority_band,
@@ -109,6 +109,20 @@ describe Hackney::Income::DangerousViewMyCases do
           active_nosp: tenancy_priority_factors.fetch(:active_nosp)
         ))
       end
+    end
+  end
+
+  context 'counting the number of pages of tenancies for a user' do
+    let(:number_of_pages) { Faker::Number.number(3).to_i }
+
+    it 'should consult the stored tenancies gateway' do
+      expect(stored_tenancies_gateway).to receive(:number_of_pages_for_user).with(user_id: user_id, number_per_page: number_per_page).and_call_original
+      subject
+    end
+
+    it 'should return what the stored tenancies gateway does' do
+      allow(stored_tenancies_gateway).to receive(:number_of_pages_for_user).and_return(number_of_pages)
+      expect(subject.number_of_pages).to eq(number_of_pages)
     end
   end
 
@@ -173,5 +187,7 @@ describe Hackney::Income::DangerousViewMyCases do
     def get_tenancies_for_user(user_id:, page_number:, number_per_page:)
       @stored_tenancies_attributes.values
     end
+
+    def number_of_pages_for_user(user_id:, number_per_page:); end
   end
 end

--- a/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
@@ -126,6 +126,13 @@ describe Hackney::Income::DangerousViewMyCases do
     end
   end
 
+  it 'should be serialisable as valid JSON' do
+    loaded_json = JSON.load(subject.to_json)
+
+    expect(loaded_json.fetch('cases')).to be_a(Array)
+    expect(loaded_json.fetch('number_of_pages')).to be_an(Integer)
+  end
+
   def random_tenancy_priority_factors
     {
       balance_contribution: Faker::Number.number(5),
@@ -188,6 +195,8 @@ describe Hackney::Income::DangerousViewMyCases do
       @stored_tenancies_attributes.values
     end
 
-    def number_of_pages_for_user(user_id:, number_per_page:); end
+    def number_of_pages_for_user(user_id:, number_per_page:)
+      @stored_tenancies_attributes.keys.count
+    end
   end
 end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -3,129 +3,6 @@ require 'rails_helper'
 describe Hackney::Income::StoredTenanciesGateway do
   let(:gateway) { described_class.new }
 
-  context 'when retrieving tenancies' do
-    context 'using a single tenancy ref' do
-      let(:attributes) do
-        {
-          tenancy_ref: Faker::Internet.slug,
-          priority_band: Faker::Internet.slug,
-          priority_score: Faker::Number.number(5).to_i,
-          criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
-          weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
-        }
-      end
-
-      let(:score_calculator) do
-         Hackney::Income::TenancyPrioritiser::Score.new(
-           attributes.fetch(:criteria),
-           attributes.fetch(:weightings),
-         )
-       end
-
-      subject { gateway.get_tenancies_by_refs([attributes.fetch(:tenancy_ref)]) }
-
-      context 'and the tenancy exists' do
-        before do
-          Hackney::Income::Models::Tenancy.create(
-            tenancy_ref: attributes.fetch(:tenancy_ref),
-            priority_band: attributes.fetch(:priority_band),
-            priority_score: attributes.fetch(:priority_score),
-            balance_contribution: score_calculator.balance,
-            days_in_arrears_contribution: score_calculator.days_in_arrears,
-            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-            payment_date_delta_contribution: score_calculator.payment_date_delta,
-            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-            active_agreement_contribution: score_calculator.active_agreement,
-            broken_court_order_contribution: score_calculator.broken_court_order,
-            nosp_served_contribution: score_calculator.nosp_served,
-            active_nosp_contribution: score_calculator.active_nosp,
-
-            balance: attributes.fetch(:criteria).balance,
-            days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
-            days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-            payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
-            payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
-            number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
-            active_agreement: attributes.fetch(:criteria).active_agreement?,
-            broken_court_order: attributes.fetch(:criteria).broken_court_order?,
-            nosp_served: attributes.fetch(:criteria).nosp_served?,
-            active_nosp: attributes.fetch(:criteria).active_nosp?
-          )
-        end
-
-        it 'should include the tenancy\'s ref, band and score' do
-          expect(subject.count).to eq(1)
-          expect(subject).to include(a_hash_including(
-            tenancy_ref: attributes.fetch(:tenancy_ref),
-            priority_band: attributes.fetch(:priority_band),
-            priority_score: attributes.fetch(:priority_score),
-
-            balance_contribution: score_calculator.balance,
-            days_in_arrears_contribution: score_calculator.days_in_arrears,
-            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-            payment_date_delta_contribution: score_calculator.payment_date_delta,
-            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-            active_agreement_contribution: score_calculator.active_agreement,
-            broken_court_order_contribution: score_calculator.broken_court_order,
-            nosp_served_contribution: score_calculator.nosp_served,
-            active_nosp_contribution: score_calculator.active_nosp,
-
-            balance: attributes.fetch(:criteria).balance,
-            days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
-            days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-            payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
-            payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
-            number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
-            active_agreement: attributes.fetch(:criteria).active_agreement?,
-            broken_court_order: attributes.fetch(:criteria).broken_court_order?,
-            nosp_served: attributes.fetch(:criteria).nosp_served?,
-            active_nosp: attributes.fetch(:criteria).active_nosp?
-          ))
-        end
-      end
-    end
-
-    context 'using multiple tenancy refs' do
-      let(:multiple_attributes) do
-        Faker::Number.number(2).to_i.times.map do
-          {
-            tenancy_ref: Faker::Internet.slug,
-            priority_band: Faker::Internet.slug,
-            priority_score: Faker::Number.number(5).to_i
-          }
-        end
-      end
-
-      subject { gateway.get_tenancies_by_refs(multiple_attributes.map { |a| a.fetch(:tenancy_ref) }) }
-
-      context 'and the tenancies exist' do
-        before do
-          multiple_attributes.map do |attributes|
-            Hackney::Income::Models::Tenancy.create(
-              tenancy_ref: attributes.fetch(:tenancy_ref),
-              priority_band: attributes.fetch(:priority_band),
-              priority_score: attributes.fetch(:priority_score)
-            )
-          end
-        end
-
-        it 'should include the tenancy\'s ref, band and score' do
-          expect(subject.count).to eq(multiple_attributes.count)
-
-          multiple_attributes.each do |attributes|
-            expect(subject).to include(a_hash_including(
-              tenancy_ref: attributes.fetch(:tenancy_ref),
-              priority_band: attributes.fetch(:priority_band),
-              priority_score: attributes.fetch(:priority_score)
-            ))
-          end
-        end
-      end
-    end
-  end
-
   context 'when storing a tenancy' do
     let(:attributes) do
       {
@@ -191,7 +68,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
     context 'and the tenancy already exists' do
       before do
-        Hackney::Income::Models::Tenancy.create(
+        Hackney::Income::Models::Tenancy.create!(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
           priority_score: attributes.fetch(:priority_score),
@@ -256,6 +133,200 @@ describe Hackney::Income::StoredTenanciesGateway do
       it 'should not create a new tenancy' do
         store_tenancy
         expect(Hackney::Income::Models::Tenancy.count).to eq(1)
+      end
+    end
+  end
+
+  context 'when retrieving tenancies by user' do
+    let(:user_id) { 1 }
+    let(:other_user_id) { 2 }
+    subject { gateway.get_tenancies_for_user(user_id: user_id) }
+
+    context 'and the user has no tenancies' do
+      it 'should return no tenancies' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'and the user is assigned a single tenancy' do
+      let(:attributes) do
+        {
+          tenancy_ref: Faker::Internet.slug,
+          priority_band: Faker::Internet.slug,
+          priority_score: Faker::Number.number(5).to_i,
+          criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
+          weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
+        }
+      end
+
+      let(:score_calculator) do
+        Hackney::Income::TenancyPrioritiser::Score.new(
+          attributes.fetch(:criteria),
+          attributes.fetch(:weightings)
+        )
+      end
+
+      before do
+        Hackney::Income::Models::Tenancy.create!(
+          assigned_user_id: user_id,
+          tenancy_ref: attributes.fetch(:tenancy_ref),
+          priority_band: attributes.fetch(:priority_band),
+          priority_score: attributes.fetch(:priority_score),
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: attributes.fetch(:criteria).balance,
+          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+          active_agreement: attributes.fetch(:criteria).active_agreement?,
+          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+          nosp_served: attributes.fetch(:criteria).nosp_served?,
+          active_nosp: attributes.fetch(:criteria).active_nosp?
+        )
+      end
+
+      it 'should include the tenancy\'s ref, band and score' do
+        expect(subject.count).to eq(1)
+        expect(subject).to include(a_hash_including(
+          tenancy_ref: attributes.fetch(:tenancy_ref),
+          priority_band: attributes.fetch(:priority_band),
+          priority_score: attributes.fetch(:priority_score),
+
+          balance_contribution: score_calculator.balance,
+          days_in_arrears_contribution: score_calculator.days_in_arrears,
+          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+          payment_date_delta_contribution: score_calculator.payment_date_delta,
+          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+          active_agreement_contribution: score_calculator.active_agreement,
+          broken_court_order_contribution: score_calculator.broken_court_order,
+          nosp_served_contribution: score_calculator.nosp_served,
+          active_nosp_contribution: score_calculator.active_nosp,
+
+          balance: attributes.fetch(:criteria).balance,
+          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+          active_agreement: attributes.fetch(:criteria).active_agreement?,
+          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+          nosp_served: attributes.fetch(:criteria).nosp_served?,
+          active_nosp: attributes.fetch(:criteria).active_nosp?
+        ))
+      end
+    end
+
+    context 'and the user is assigned multiple tenancies' do
+      let(:multiple_attributes) do
+        Faker::Number.number(2).to_i.times.map do
+          {
+            tenancy_ref: Faker::Internet.slug,
+            priority_band: Faker::Internet.slug,
+            priority_score: Faker::Number.number(5).to_i
+          }
+        end
+      end
+
+      context 'and the tenancies exist' do
+        before do
+          multiple_attributes.map do |attributes|
+            Hackney::Income::Models::Tenancy.create!(
+              assigned_user_id: user_id,
+              tenancy_ref: attributes.fetch(:tenancy_ref),
+              priority_band: attributes.fetch(:priority_band),
+              priority_score: attributes.fetch(:priority_score)
+            )
+          end
+        end
+
+        it 'should include the tenancy\'s ref, band and score' do
+          expect(subject.count).to eq(multiple_attributes.count)
+
+          multiple_attributes.each do |attributes|
+            expect(subject).to include(a_hash_including(
+              tenancy_ref: attributes.fetch(:tenancy_ref),
+              priority_band: attributes.fetch(:priority_band),
+              priority_score: attributes.fetch(:priority_score)
+            ))
+          end
+        end
+
+        context 'and the cases are assigned different bands and scores' do
+          let(:multiple_attributes) do
+            [
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'red', priority_score: 1 },
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'green', priority_score: 50 },
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'amber', priority_score: 100 },
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'green', priority_score: 100 },
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'red', priority_score: 101 },
+              { tenancy_ref: Faker::Internet.slug, priority_band: 'amber', priority_score: 200 }
+            ]
+          end
+
+          let(:cases) do
+            subject.map do |c|
+              { band: c.fetch(:priority_band), score: c.fetch(:priority_score).to_i }
+            end
+          end
+
+          it 'should sort by band, then score' do
+            expect(cases).to eq([
+              { band: 'red', score: 101 },
+              { band: 'red', score: 1 },
+              { band: 'amber', score: 200 },
+              { band: 'amber', score: 100 },
+              { band: 'green', score: 100 },
+              { band: 'green', score: 50 }
+            ])
+          end
+
+          context 'and page number is set to one, and number per page is set to two' do
+            subject { gateway.get_tenancies_for_user(user_id: user_id, page_number: 1, number_per_page: 2) }
+
+            it 'should only return the first two' do
+              expect(cases).to eq([
+                { band: 'red', score: 101 },
+                { band: 'red', score: 1 }
+              ])
+            end
+          end
+
+          context 'and page number is set to two, and number per page is set to three' do
+            subject { gateway.get_tenancies_for_user(user_id: user_id, page_number: 2, number_per_page: 3) }
+
+            it 'should only return the last three' do
+              expect(cases).to eq([
+                { band: 'amber', score: 100 },
+                { band: 'green', score: 100 },
+                { band: 'green', score: 50 }
+              ])
+            end
+          end
+        end
+      end
+    end
+
+    context 'and tenancies exist which aren\'t assigned to the user' do
+      before do
+        Hackney::Income::Models::Tenancy.create!(assigned_user_id: user_id)
+        Hackney::Income::Models::Tenancy.create!(assigned_user_id: other_user_id)
+        Hackney::Income::Models::Tenancy.create!(assigned_user_id: user_id)
+      end
+
+      it 'should only return the user\'s tenancies' do
+        expect(subject.count).to eq(2)
       end
     end
   end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -330,4 +330,54 @@ describe Hackney::Income::StoredTenanciesGateway do
       end
     end
   end
+
+  context 'when counting the number of pages of tenancies for a user' do
+    let(:user_id) { Faker::Number.number(2).to_i }
+    subject { gateway.number_of_pages_for_user(user_id: user_id, number_per_page: number_per_page) }
+
+    context 'and the user has ten tenancies' do
+      before { 10.times { create_tenancy(user_id: user_id) } }
+
+      context 'and the number per page is five' do
+        let(:number_per_page) { 5 }
+        it { is_expected.to eq(2) }
+      end
+    end
+
+    context 'and the user has nine tenancies' do
+      before { 9.times { create_tenancy(user_id: user_id) } }
+
+      context 'and the number per page is five' do
+        let(:number_per_page) { 5 }
+        it { is_expected.to eq(2) }
+      end
+    end
+
+    context 'and the user has twelve tenancies' do
+      before { 12.times { create_tenancy(user_id: user_id) } }
+
+      context 'and the number per page is three' do
+        let(:number_per_page) { 3 }
+        it { is_expected.to eq(4) }
+      end
+    end
+
+    context 'and the user is not the only assignee' do
+      let(:other_user_id) { Faker::Number.number(3).to_i }
+
+      before do
+        6.times { create_tenancy(user_id: user_id) }
+        6.times { create_tenancy(user_id: other_user_id) }
+      end
+
+      context 'and the number per page is three' do
+        let(:number_per_page) { 3 }
+        it { is_expected.to eq(2) }
+      end
+    end
+  end
+
+  def create_tenancy(user_id: nil)
+    Hackney::Income::Models::Tenancy.create(assigned_user_id: user_id)
+  end
 end


### PR DESCRIPTION
For pagination with sorting to work efficiently, user assignment and priority scores should live in the same place. Previously, the Income Collection Service was aware of user assignment, but couldn't sort by priority score when retrieving user cases without fetching all of them. 

This also reduces the logic which will have to sit in the Income Collection Service, making it more easily reusable elsewhere.