### PR TITLE
Add find or create user and sql users gateway from ICS

### DIFF
--- a/app/models/hackney/income/models/user.rb
+++ b/app/models/hackney/income/models/user.rb
@@ -1,0 +1,9 @@
+module Hackney
+  module Income
+    module Models
+      class User < ApplicationRecord
+        has_many :tenancies, foreign_key: :assigned_user_id
+      end
+    end
+  end
+end

--- a/db/migrate/20180913132800_add_users.rb
+++ b/db/migrate/20180913132800_add_users.rb
@@ -1,0 +1,15 @@
+class AddUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :provider_uid
+      t.string :provider
+      t.string :name
+      t.string :email
+      t.string :first_name
+      t.string :last_name
+      t.string :provider_permissions
+    end
+
+    add_reference :tenancies, :assigned_user, foreign_key: { to_table: :users }
+  end
+end

--- a/lib/hackney/income/find_or_create_user.rb
+++ b/lib/hackney/income/find_or_create_user.rb
@@ -1,0 +1,21 @@
+module Hackney
+  module Income
+    class FindOrCreateUser
+      def initialize(users_gateway:)
+        @users_gateway = users_gateway
+      end
+
+      def execute(provider_uid:, provider:, name:, email:, first_name:, last_name:, provider_permissions:)
+        @users_gateway.find_or_create_user(
+          provider_uid: provider_uid,
+          provider: provider,
+          name: name,
+          email: email,
+          first_name: first_name,
+          last_name: last_name,
+          provider_permissions: provider_permissions
+        )
+      end
+    end
+  end
+end

--- a/lib/hackney/income/sql_users_gateway.rb
+++ b/lib/hackney/income/sql_users_gateway.rb
@@ -1,0 +1,12 @@
+module Hackney
+  module Income
+    class SqlUsersGateway
+      def find_or_create_user(provider_uid:, provider:, name:, email:, first_name:, last_name:, provider_permissions:)
+        user = Hackney::Income::Models::User.find_or_create_by!(provider_uid: provider_uid, provider: provider)
+        user.update!(name: name, email: email, first_name: first_name, last_name: last_name, provider_permissions: provider_permissions)
+
+        { id: user.id, name: user.name, email: user.email, first_name: user.first_name, last_name: user.last_name, provider_permissions: user.provider_permissions }
+      end
+    end
+  end
+end

--- a/lib/hackney/income/stub_sql_users_gateway.rb
+++ b/lib/hackney/income/stub_sql_users_gateway.rb
@@ -1,0 +1,22 @@
+module Hackney
+  module Income
+    class StubSqlUsersGateway
+      def initialize
+        @id = 0
+      end
+
+      def find_or_create_user(provider_uid:, provider:, name:, email:, first_name:, last_name:, provider_permissions:)
+        {
+          id: @id += 1,
+          name: name,
+          email: email,
+          provider_uid: provider_uid,
+          provider: provider,
+          first_name: first_name,
+          last_name: last_name,
+          provider_permissions: provider_permissions
+         }
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/income/find_or_create_user_spec.rb
+++ b/spec/lib/hackney/income/find_or_create_user_spec.rb
@@ -1,0 +1,45 @@
+describe Hackney::Income::FindOrCreateUser do
+  let(:users_gateway) { Hackney::Income::StubSqlUsersGateway.new }
+  let(:subject) { described_class.new(users_gateway: users_gateway) }
+
+  context 'when logging in to the app' do
+    let(:name) { Faker::Lovecraft.deity }
+    let(:uid) { Faker::Number.number(10) }
+    let(:email) { Faker::Lovecraft.sentence }
+    let(:provider_permissions) { "#{Faker::Number.number(6)}.#{Faker::Number.number(6)}" }
+
+    it 'should return a hash for the user' do
+      expect(call_subject(uid: uid, name: name, email: email, provider_permissions: provider_permissions)).to include(
+        id: 1,
+        name: name,
+        email: email,
+        provider_permissions: provider_permissions
+      )
+    end
+
+    let(:name) { Faker::Lovecraft.deity }
+    let(:uid) { Faker::Number.number(10) }
+
+    it 'should create a new user id for each user' do
+      call_subject(uid: 'test-uid', name: 'test-name', email: 'test-email', provider_permissions: provider_permissions)
+      expect(call_subject(uid: uid, name: name, email: email, provider_permissions: provider_permissions)).to include(
+        id: 2,
+        name: name,
+        email: email,
+        provider_permissions: provider_permissions
+      )
+    end
+  end
+
+  def call_subject(uid:, name:, email:, provider_permissions:)
+    subject.execute(
+      provider_uid: uid,
+      provider: 'omniauth-active-directory',
+      name: name,
+      email: email,
+      first_name: 'Robert',
+      last_name: 'Smith',
+      provider_permissions: provider_permissions
+    )
+  end
+end

--- a/spec/lib/hackney/income/sql_users_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_users_gateway_spec.rb
@@ -1,0 +1,66 @@
+describe Hackney::Income::SqlUsersGateway do
+  let(:gateway) { described_class.new }
+
+  context 'when finding or creating a User' do
+    subject do
+      gateway.find_or_create_user(
+        provider_uid: 'close-to-me',
+        provider: 'universal',
+        name: 'Robert Smith',
+        email: 'exploding-boy@the-cure.com',
+        first_name: 'Robert',
+        last_name: 'Smith',
+        provider_permissions: '12345.98765'
+      )
+    end
+
+    context 'and this user does not already exist' do
+      before { subject }
+
+      it 'should create a new User instance for that user' do
+        expect(Hackney::Income::Models::User.first).to have_attributes(
+          provider_uid: 'close-to-me',
+          provider: 'universal',
+          name: 'Robert Smith',
+          email: 'exploding-boy@the-cure.com',
+          first_name: 'Robert',
+          last_name: 'Smith',
+          provider_permissions: '12345.98765'
+        )
+      end
+    end
+
+    context 'and a user already exists' do
+      before do
+        Hackney::Income::Models::User.create!(
+          provider_uid: 'close-to-me',
+          provider: 'universal',
+          name: 'Robert Smith',
+          email: 'old-email@the-cure.com',
+          first_name: 'Robert',
+          last_name: 'Smith',
+          provider_permissions: '12345.98765'
+        )
+
+        subject
+      end
+
+      it 'should not create a duplicate user' do
+        expect(Hackney::Income::Models::User.count).to eq(1)
+      end
+
+      it 'should update the record found' do
+        expect(Hackney::Income::Models::User.first.email).to eq('exploding-boy@the-cure.com')
+      end
+    end
+
+    context 'in either case' do
+      it 'should return a hash representing the user' do
+        expect(subject).to include(
+          id: 1,
+          name: 'Robert Smith'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
WHAT 
Copy the find or create user use case and the sql users gateway from the ICS app to here. 

WHY
Next step will be to expose an endpoint allowing API consumers to create users directly. This will allow us to assign users to cases on the API, allowing consumers to request _cases_ for a given _user_.
The benefit of this is that we can control how and when user assignment is done, which will be when cases are synced from the data source.