### PR TITLE
Remove duplicate column creation

### DIFF
--- a/db/migrate/20180912114135_remove_assigned_user_id_from_tenancies.rb
+++ b/db/migrate/20180912114135_remove_assigned_user_id_from_tenancies.rb
@@ -1,0 +1,5 @@
+class RemoveAssignedUserIdFromTenancies < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :tenancies, :assigned_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180912114134) do
+ActiveRecord::Schema.define(version: 20180913132800) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -60,6 +60,17 @@ ActiveRecord::Schema.define(version: 20180912114134) do
     t.string "primary_contact_short_address"
     t.string "primary_contact_postcode"
     t.integer "assigned_user_id"
+    t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider_uid"
+    t.string "provider"
+    t.string "name"
+    t.string "email"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "provider_permissions"
   end
 
 end


### PR DESCRIPTION
This column was created as part of the pagination PR, and additionally as part of the users table creation PR. The latter got merged first, so it's left the schema in an inconsistent state.

Adding a migration between them to remove the former and leave the latter works locally.