### PR TITLE
Assign on sync

### DIFF
--- a/app/models/hackney/income/models/tenancy.rb
+++ b/app/models/hackney/income/models/tenancy.rb
@@ -2,6 +2,7 @@ module Hackney
   module Income
     module Models
       class Tenancy < ApplicationRecord
+        belongs_to :assigned_user, class_name: 'Hackney::Income::Models::User', optional: true
       end
     end
   end

--- a/lib/hackney/income/assign_tenancy_to_user.rb
+++ b/lib/hackney/income/assign_tenancy_to_user.rb
@@ -1,0 +1,15 @@
+module Hackney
+  module Income
+    class AssignTenancyToUser
+      def initialize(user_assignment_gateway:)
+        @user_assignment_gateway = user_assignment_gateway
+      end
+
+      def assign(tenancy:)
+        return tenancy.assigned_user_id if tenancy.assigned_user != nil
+
+        @user_assignment_gateway.assign_to_next_available_user(tenancy: tenancy)
+      end
+    end
+  end
+end

--- a/lib/hackney/income/dangerous_sync_cases.rb
+++ b/lib/hackney/income/dangerous_sync_cases.rb
@@ -1,23 +1,25 @@
 module Hackney
   module Income
     class DangerousSyncCases
-      def initialize(prioritisation_gateway:, uh_tenancies_gateway:, stored_tenancies_gateway:)
+      def initialize(prioritisation_gateway:, uh_tenancies_gateway:, stored_tenancies_gateway:, assign_tenancy_to_user:)
         @prioritisation_gateway = prioritisation_gateway
         @uh_tenancies_gateway = uh_tenancies_gateway
         @stored_tenancies_gateway = stored_tenancies_gateway
+        @assign_tenancy_to_user = assign_tenancy_to_user
       end
 
       def execute
         tenancy_refs = @uh_tenancies_gateway.tenancies_in_arrears
         tenancy_refs.each do |tenancy_ref|
           priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
-          @stored_tenancies_gateway.store_tenancy(
+          tenancy = @stored_tenancies_gateway.store_tenancy(
             tenancy_ref: tenancy_ref,
             priority_band: priorities.fetch(:priority_band),
             priority_score: priorities.fetch(:priority_score),
             criteria: priorities.fetch(:criteria),
             weightings: priorities.fetch(:weightings)
           )
+          @assign_tenancy_to_user.assign(tenancy: tenancy)
         end
       end
     end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -1,0 +1,39 @@
+module Hackney
+  module Income
+    class SqlTenancyCaseGateway
+      def persist(tenancies:)
+        tenancies.each do |tenancy|
+          Hackney::Income::Models::Tenancy.find_or_create_by!(tenancy_ref: tenancy.tenancy_ref)
+        end
+      end
+
+      def assign_user(tenancy_ref:, user_id:)
+        tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
+        tenancy.update!(assigned_user_id: user_id)
+      end
+
+      def assigned_tenancies(assignee_id:)
+        Hackney::Income::Models::Tenancy
+          .where(assigned_user_id: assignee_id)
+          .map { |t| { tenancy_ref: t.tenancy_ref } }
+      end
+
+      def assign_to_next_available_user(tenancy:)
+        tenancy.assigned_user = next_available_user_for(band: tenancy.priority_band)
+        tenancy.save
+        tenancy.assigned_user_id
+      end
+
+      private
+
+      def next_available_user_for(band:)
+        Hackney::Income::Models::User
+        .left_joins(:tenancies)
+        .group('users.id')
+        .where('tenancies.priority_band = ?', band)
+        .order('COUNT(tenancies.id) ASC')
+        .first
+      end
+    end
+  end
+end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -28,11 +28,11 @@ module Hackney
 
       def next_available_user_for(band:)
         Hackney::Income::Models::User
-        .left_joins(:tenancies)
-        .group('users.id')
-        .where('tenancies.priority_band = ?', band)
-        .order('COUNT(tenancies.id) ASC')
-        .first
+          .left_joins(:tenancies)
+          .group('users.id')
+          .where('tenancies.priority_band = ?', band)
+          .order('COUNT(tenancies.id) ASC')
+          .first
       end
     end
   end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -19,7 +19,9 @@ module Hackney
       end
 
       def assign_to_next_available_user(tenancy:)
-        tenancy.assigned_user = next_available_user_for(band: tenancy.priority_band)
+        return nil if !['red', 'amber', 'green'].include?(tenancy.priority_band)
+
+        tenancy.assigned_user = next_available_user_for(band: tenancy.priority_band) || Hackney::Income::Models::User.all.first
         tenancy.save
         tenancy.assigned_user_id
       end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -18,7 +18,8 @@ module Hackney
             restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
             patches: ENV.fetch('PERMITTED_PATCHES', [])
           ),
-          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
+          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new,
+          assign_tenancy_to_user: Hackney::Income::AssignTenancyToUser.new(user_assignment_gateway: Hackney::Income::SqlUsersGateway.new)
         )
       end
 

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -51,7 +51,8 @@ describe MyCasesController do
       expect(Hackney::Income::DangerousSyncCases).to receive(:new).with(
         prioritisation_gateway: instance_of(Hackney::Income::UniversalHousingPrioritisationGateway),
         uh_tenancies_gateway: instance_of(Hackney::Income::UniversalHousingTenanciesGateway),
-        stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway)
+        stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway),
+        assign_tenancy_to_user: instance_of(Hackney::Income::AssignTenancyToUser)
       ).and_call_original
 
       allow_any_instance_of(Hackney::Income::DangerousSyncCases)

--- a/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
+++ b/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Hackney::Income::AssignTenancyToUser do
+  let!(:user1) { Hackney::Income::Models::User.create(name: Faker::Name.name) }
+  let!(:user2) { Hackney::Income::Models::User.create(name: Faker::Name.name) }
+  let!(:assigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: user2) }
+  let!(:unassigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: nil) }
+
+  let(:gateway) { double('UserAssignmentGateway') }
+  subject { described_class.new(user_assignment_gateway: gateway)}
+
+  before do
+    allow(gateway).to receive(:assign_to_next_available_user).with(tenancy: unassigned_tenancy).and_return(user1.id)
+  end
+
+  context 'when trying to assign a tenancy already assigned' do
+    it 'should not assign the tenancy' do
+      expect(gateway).to_not receive(:assign_to_next_available_user)
+
+      expect(subject.assign(tenancy: assigned_tenancy)).to eq(user2.id)
+    end
+  end
+
+  context 'when trying to assign a new tenancy' do
+    it 'should pass the tenancy to the assignment gateway and return the assigned user id' do
+      expect(gateway).to receive(:assign_to_next_available_user).with(
+        tenancy: unassigned_tenancy
+      )
+
+      expect(subject.assign(tenancy: unassigned_tenancy)).to eq(user1.id)
+    end
+  end
+
+  def create_assigned_tenancy_model(band:, user:)
+    tenancy = Hackney::Income::Models::Tenancy.new.tap do |t|
+      t.tenancy_ref = Faker::Lorem.characters(5)
+      t.priority_band = band
+      t.priority_score = Faker::Lorem.characters(5)
+      t.assigned_user = user
+    end
+
+    tenancy.save
+    tenancy
+  end
+end

--- a/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
+++ b/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::AssignTenancyToUser do
-  let!(:user1) { Hackney::Income::Models::User.create(name: Faker::Name.name) }
-  let!(:user2) { Hackney::Income::Models::User.create(name: Faker::Name.name) }
+  let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
+  let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
   let!(:assigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: user2) }
   let!(:unassigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: nil) }
 
@@ -32,14 +32,11 @@ describe Hackney::Income::AssignTenancyToUser do
   end
 
   def create_assigned_tenancy_model(band:, user:)
-    tenancy = Hackney::Income::Models::Tenancy.new.tap do |t|
-      t.tenancy_ref = Faker::Lorem.characters(5)
-      t.priority_band = band
-      t.priority_score = Faker::Lorem.characters(5)
-      t.assigned_user = user
-    end
-
-    tenancy.save
-    tenancy
+    Hackney::Income::Models::Tenancy.create!(
+      tenancy_ref: Faker::Lorem.characters(5),
+      priority_band: band,
+      priority_score: Faker::Lorem.characters(5),
+      assigned_user: user
+    )
   end
 end

--- a/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
@@ -4,7 +4,7 @@ describe Hackney::Income::DangerousSyncCases do
   let(:uh_tenancies_gateway) { double(tenancies_in_arrears: []) }
   let(:stored_tenancies_gateway) { double(store_tenancy: nil) }
   let(:prioritisation_gateway) { PrioritisationGatewayDouble.new }
-  let(:assign_tenancy_to_user) { AssignTenancyToUserDouble.new }
+  let(:assign_tenancy_to_user) { double(assign_tenancy_to_user: nil) }
 
   let(:sync_cases) do
     described_class.new(
@@ -129,10 +129,5 @@ class PrioritisationGatewayDouble
       criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
       weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
     }
-  end
-end
-
-class AssignTenancyToUserDouble
-  def assign(tenancy:)
   end
 end

--- a/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
@@ -4,12 +4,14 @@ describe Hackney::Income::DangerousSyncCases do
   let(:uh_tenancies_gateway) { double(tenancies_in_arrears: []) }
   let(:stored_tenancies_gateway) { double(store_tenancy: nil) }
   let(:prioritisation_gateway) { PrioritisationGatewayDouble.new }
+  let(:assign_tenancy_to_user) { AssignTenancyToUserDouble.new }
 
   let(:sync_cases) do
     described_class.new(
       prioritisation_gateway: prioritisation_gateway,
       uh_tenancies_gateway: uh_tenancies_gateway,
-      stored_tenancies_gateway: stored_tenancies_gateway
+      stored_tenancies_gateway: stored_tenancies_gateway,
+      assign_tenancy_to_user: assign_tenancy_to_user
     )
   end
 
@@ -40,6 +42,8 @@ describe Hackney::Income::DangerousSyncCases do
           weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
+        expect(assign_tenancy_to_user).to receive(:assign)
+
         subject
       end
     end
@@ -60,6 +64,8 @@ describe Hackney::Income::DangerousSyncCases do
           criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
           weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
+
+        expect(assign_tenancy_to_user).to receive(:assign)
 
         subject
       end
@@ -103,6 +109,8 @@ describe Hackney::Income::DangerousSyncCases do
           weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
         )
 
+        expect(assign_tenancy_to_user).to receive(:assign).exactly(3).times
+
         subject
       end
     end
@@ -121,5 +129,10 @@ class PrioritisationGatewayDouble
       criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
       weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
     }
+  end
+end
+
+class AssignTenancyToUserDouble
+  def assign(tenancy:)
   end
 end

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+describe Hackney::Income::SqlTenancyCaseGateway do
+  subject { described_class.new }
+
+  context 'when persisting tenancies which do not exist in the database' do
+    let(:tenancies) do
+      random_size_array = (0..Faker::Number.between(1, 10)).to_a
+      random_size_array.map { create_tenancy_model }
+    end
+
+    before do
+      subject.persist(tenancies: tenancies)
+    end
+
+    it 'should save the tenancies in the database' do
+      tenancies.each do |tenancy|
+        expect(Hackney::Income::Models::Tenancy.exists?(tenancy_ref: tenancy.tenancy_ref)).to be_truthy
+      end
+    end
+  end
+
+  context 'when persisting a tenancy which already exists in the database' do
+    let(:tenancy) { create_tenancy_model }
+    let(:existing_tenancy_record) do
+      Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy.tenancy_ref)
+    end
+
+    before do
+      existing_tenancy_record
+      subject.persist(tenancies: [tenancy])
+    end
+
+    it 'should not create a new record' do
+      expect(Hackney::Income::Models::Tenancy.count).to eq(1)
+    end
+  end
+
+  context 'when assigning a user to a case' do
+    let!(:tenancy_ref) { Faker::Number.number(6) }
+    let!(:tenancy) { Hackney::Income::Models::Tenancy.create(tenancy_ref: tenancy_ref) }
+    let!(:user) { Hackney::Income::Models::User.create }
+
+    it 'should assign the user' do
+      subject.assign_user(tenancy_ref: tenancy_ref, user_id: user.id)
+      expect(tenancy.reload).to have_attributes(
+        assigned_user: user
+      )
+    end
+  end
+
+  context 'when retrieving cases assigned to a user' do
+    let(:assignee_id) { 1 }
+    let(:assigned_tenancies) { subject.assigned_tenancies(assignee_id: assignee_id) }
+
+    context 'and the user has no assigned cases' do
+      it 'should return no cases' do
+        expect(assigned_tenancies).to be_empty
+      end
+    end
+
+    context 'and the user has one assigned case' do
+      let(:tenancy) { persist_new_tenancy }
+      before { subject.assign_user(tenancy_ref: tenancy.tenancy_ref, user_id: assignee_id) }
+
+      it 'should return the user\'s case' do
+        expect(assigned_tenancies).to include(tenancy_ref: tenancy.tenancy_ref)
+      end
+    end
+
+    context 'and many users have assigned cases' do
+      let(:user_tenancy) { persist_new_tenancy }
+      let(:other_assignee_id) { 1234 }
+
+      before do
+        subject.assign_user(tenancy_ref: user_tenancy.tenancy_ref, user_id: assignee_id)
+        subject.assign_user(tenancy_ref: persist_new_tenancy.tenancy_ref, user_id: other_assignee_id)
+        subject.assign_user(tenancy_ref: persist_new_tenancy.tenancy_ref, user_id: other_assignee_id)
+      end
+
+      it 'should only return the user\'s cases' do
+        expect(assigned_tenancies).to eq([{
+          tenancy_ref: user_tenancy.tenancy_ref
+        }])
+      end
+    end
+
+    context 'when auto assigning users to cases' do
+      let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
+      let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
+
+      let!(:unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
+      let!(:unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
+      let!(:unassigned_red) { create_assigned_tenancy_model(band: 'red', user: nil) }
+      let!(:unassigned_case) { create_assigned_tenancy_model(band: 'error', user: nil) }
+      let!(:second_unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
+      let!(:u1c1) { create_assigned_tenancy_model(band: 'green', user: user1) }
+      let!(:u1c2) { create_assigned_tenancy_model(band: 'green', user: user1) }
+      let!(:u2c1) { create_assigned_tenancy_model(band: 'green', user: user2) }
+      let!(:u1amber1) { create_assigned_tenancy_model(band: 'amber', user: user1) }
+      let!(:u2amber1) { create_assigned_tenancy_model(band: 'amber', user: user2) }
+      let!(:u1red1) { create_assigned_tenancy_model(band: 'red', user: user1) }
+      let!(:u1red2) { create_assigned_tenancy_model(band: 'red', user: user1) }
+      let!(:u2red1) { create_assigned_tenancy_model(band: 'red', user: user2) }
+
+
+      context 'assigning a case which has a band that has a clear next user' do
+        it 'should assign it to the user who is next able to take on a green case' do
+          expect(subject.assign_to_next_available_user(tenancy: unassigned_green)).to eq(user2.id)
+          expect(unassigned_green.assigned_user).to eq(user2)
+        end
+
+        it 'should assign it to the user at the top of the list if there is no clear choice' do
+          expect(subject.assign_to_next_available_user(tenancy: unassigned_amber)).to eq(user1.id)
+          expect(unassigned_amber.assigned_user).to eq(user1)
+
+          expect(subject.assign_to_next_available_user(tenancy: second_unassigned_amber)).to eq(user2.id)
+          expect(second_unassigned_amber.assigned_user).to eq(user2)
+        end
+
+        it 'should behave the same way for each band' do
+          expect(subject.assign_to_next_available_user(tenancy: unassigned_red)).to eq(user2.id)
+          expect(unassigned_red.assigned_user).to eq(user2)
+        end
+      end
+
+      it 'should not assign if the band cannot be matched' do
+        expect(subject.assign_to_next_available_user(tenancy: unassigned_case)).to be_nil
+        expect(unassigned_case.assigned_user).to be_nil
+      end
+    end
+  end
+
+  def persist_new_tenancy
+    tenancy = create_tenancy_model
+    Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy.tenancy_ref)
+  end
+
+  def create_tenancy_model
+    Hackney::Income::Models::Tenancy.new.tap do |t|
+      t.tenancy_ref = Faker::Lorem.characters(5)
+      t.priority_band = Faker::Lorem.characters(5)
+      t.priority_score = Faker::Lorem.characters(5)
+    end
+  end
+
+  def create_assigned_tenancy_model(band:, user:)
+    tenancy = Hackney::Income::Models::Tenancy.new.tap do |t|
+      t.tenancy_ref = Faker::Lorem.characters(5)
+      t.priority_band = band
+      t.priority_score = Faker::Lorem.characters(5)
+      t.assigned_user = user
+    end
+
+    tenancy.save
+    tenancy
+  end
+end

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -89,20 +89,22 @@ describe Hackney::Income::SqlTenancyCaseGateway do
       let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
       let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
 
+      # create a pool of unassigned cases
       let!(:unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
       let!(:unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
+      let!(:second_unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
       let!(:unassigned_red) { create_assigned_tenancy_model(band: 'red', user: nil) }
       let!(:unassigned_case) { create_assigned_tenancy_model(band: 'error', user: nil) }
-      let!(:second_unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
-      let!(:u1c1) { create_assigned_tenancy_model(band: 'green', user: user1) }
-      let!(:u1c2) { create_assigned_tenancy_model(band: 'green', user: user1) }
-      let!(:u2c1) { create_assigned_tenancy_model(band: 'green', user: user2) }
-      let!(:u1amber1) { create_assigned_tenancy_model(band: 'amber', user: user1) }
-      let!(:u2amber1) { create_assigned_tenancy_model(band: 'amber', user: user2) }
-      let!(:u1red1) { create_assigned_tenancy_model(band: 'red', user: user1) }
-      let!(:u1red2) { create_assigned_tenancy_model(band: 'red', user: user1) }
-      let!(:u2red1) { create_assigned_tenancy_model(band: 'red', user: user2) }
 
+      # assign cases to users to set up current 'workloads'
+      let!(:user1_green_case1) { create_assigned_tenancy_model(band: 'green', user: user1) }
+      let!(:user1_green_case2) { create_assigned_tenancy_model(band: 'green', user: user1) }
+      let!(:user2_green_case1) { create_assigned_tenancy_model(band: 'green', user: user2) }
+      let!(:user1_amber_case1) { create_assigned_tenancy_model(band: 'amber', user: user1) }
+      let!(:user2_amber_case1) { create_assigned_tenancy_model(band: 'amber', user: user2) }
+      let!(:user1_red_case1) { create_assigned_tenancy_model(band: 'red', user: user1) }
+      let!(:user1_red_case2) { create_assigned_tenancy_model(band: 'red', user: user1) }
+      let!(:user2_red_case1) { create_assigned_tenancy_model(band: 'red', user: user2) }
 
       context 'assigning a case which has a band that has a clear next user' do
         it 'should assign it to the user who is next able to take on a green case' do
@@ -145,14 +147,11 @@ describe Hackney::Income::SqlTenancyCaseGateway do
   end
 
   def create_assigned_tenancy_model(band:, user:)
-    tenancy = Hackney::Income::Models::Tenancy.new.tap do |t|
-      t.tenancy_ref = Faker::Lorem.characters(5)
-      t.priority_band = band
-      t.priority_score = Faker::Lorem.characters(5)
-      t.assigned_user = user
-    end
-
-    tenancy.save
-    tenancy
+    Hackney::Income::Models::Tenancy.create!(
+      tenancy_ref: Faker::Lorem.characters(5),
+      priority_band: band,
+      priority_score: Faker::Lorem.characters(5),
+      assigned_user: user
+    )
   end
 end

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -90,18 +90,26 @@ describe Hackney::Income::SqlTenancyCaseGateway do
       let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
 
       let!(:unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
+      let!(:second_unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
       let!(:unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
       let!(:second_unassigned_amber) { create_assigned_tenancy_model(band: 'amber', user: nil) }
       let!(:unassigned_red) { create_assigned_tenancy_model(band: 'red', user: nil) }
       let!(:unassigned_case) { create_assigned_tenancy_model(band: 'error', user: nil) }
+
+      context 'when no cases have been assigned' do
+        it 'should assign to the first user in the list' do
+          expect(subject.assign_to_next_available_user(tenancy: unassigned_green)).to eq(user1.id)
+          expect(unassigned_green.assigned_user).to eq(user1)
+        end
+      end
 
       context 'assigning a case which has a band that has a clear next user' do
         it 'should assign it to the user who is next able to take on a green case' do
           2.times { create_assigned_tenancy_model(band: 'green', user: user1) }
           1.times { create_assigned_tenancy_model(band: 'green', user: user2) }
 
-          expect(subject.assign_to_next_available_user(tenancy: unassigned_green)).to eq(user2.id)
-          expect(unassigned_green.assigned_user).to eq(user2)
+          expect(subject.assign_to_next_available_user(tenancy: second_unassigned_green)).to eq(user2.id)
+          expect(second_unassigned_green.assigned_user).to eq(user2)
         end
 
         it 'should assign it to the user at the top of the list if there is no clear choice' do


### PR DESCRIPTION
Add use case that attempts to assign cases to the next available user, if the case is not already assigned.

Add the use case to the factory, call it for each synced tenancy.