### PR TITLE
Sync cases as individual background jobs nightly (with assignment)

### DIFF
--- a/app/jobs/hackney/income/jobs/sync_case_priority_job.rb
+++ b/app/jobs/hackney/income/jobs/sync_case_priority_job.rb
@@ -1,0 +1,13 @@
+module Hackney
+  module Income
+    module Jobs
+      class SyncCasePriorityJob < ApplicationJob
+        queue_as :default
+
+        def perform(tenancy_ref:)
+          income_use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/background_job_gateway.rb
+++ b/lib/hackney/income/background_job_gateway.rb
@@ -1,0 +1,10 @@
+module Hackney
+  module Income
+    class BackgroundJobGateway
+      def schedule_case_priority_sync(tenancy_ref:)
+        Hackney::Income::Jobs::SyncCasePriorityJob.perform_later(tenancy_ref: tenancy_ref)
+        nil
+      end
+    end
+  end
+end

--- a/lib/hackney/income/dangerous_sync_cases.rb
+++ b/lib/hackney/income/dangerous_sync_cases.rb
@@ -1,25 +1,14 @@
 module Hackney
   module Income
     class DangerousSyncCases
-      def initialize(prioritisation_gateway:, uh_tenancies_gateway:, stored_tenancies_gateway:, assign_tenancy_to_user:)
-        @prioritisation_gateway = prioritisation_gateway
+      def initialize(uh_tenancies_gateway:, background_job_gateway:)
         @uh_tenancies_gateway = uh_tenancies_gateway
-        @stored_tenancies_gateway = stored_tenancies_gateway
-        @assign_tenancy_to_user = assign_tenancy_to_user
+        @background_job_gateway = background_job_gateway
       end
 
       def execute
-        tenancy_refs = @uh_tenancies_gateway.tenancies_in_arrears
-        tenancy_refs.each do |tenancy_ref|
-          priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
-          tenancy = @stored_tenancies_gateway.store_tenancy(
-            tenancy_ref: tenancy_ref,
-            priority_band: priorities.fetch(:priority_band),
-            priority_score: priorities.fetch(:priority_score),
-            criteria: priorities.fetch(:criteria),
-            weightings: priorities.fetch(:weightings)
-          )
-          @assign_tenancy_to_user.assign(tenancy: tenancy)
+        @uh_tenancies_gateway.tenancies_in_arrears.each do |tenancy_ref|
+          @background_job_gateway.schedule_case_priority_sync(tenancy_ref: tenancy_ref)
         end
       end
     end

--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -1,20 +1,23 @@
 module Hackney
   module Income
     class SyncCasePriority
-      def initialize(prioritisation_gateway:, stored_tenancies_gateway:)
+      def initialize(prioritisation_gateway:, stored_tenancies_gateway:, assign_tenancy_to_user:)
         @prioritisation_gateway = prioritisation_gateway
         @stored_tenancies_gateway = stored_tenancies_gateway
+        @assign_tenancy_to_user = assign_tenancy_to_user
       end
 
       def execute(tenancy_ref:)
         priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
-        @stored_tenancies_gateway.store_tenancy(
+        tenancy = @stored_tenancies_gateway.store_tenancy(
           tenancy_ref: tenancy_ref,
           priority_band: priorities.fetch(:priority_band),
           priority_score: priorities.fetch(:priority_score),
           criteria: priorities.fetch(:criteria),
           weightings: priorities.fetch(:weightings)
         )
+
+        @assign_tenancy_to_user.assign(tenancy: tenancy)
 
         nil
       end

--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -1,0 +1,23 @@
+module Hackney
+  module Income
+    class SyncCasePriority
+      def initialize(prioritisation_gateway:, stored_tenancies_gateway:)
+        @prioritisation_gateway = prioritisation_gateway
+        @stored_tenancies_gateway = stored_tenancies_gateway
+      end
+
+      def execute(tenancy_ref:)
+        priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
+        @stored_tenancies_gateway.store_tenancy(
+          tenancy_ref: tenancy_ref,
+          priority_band: priorities.fetch(:priority_band),
+          priority_score: priorities.fetch(:priority_score),
+          criteria: priorities.fetch(:criteria),
+          weightings: priorities.fetch(:weightings)
+        )
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -22,8 +22,13 @@ module Hackney
       def sync_case_priority
         Hackney::Income::SyncCasePriority.new(
           prioritisation_gateway: prioritisation_gateway,
-          stored_tenancies_gateway: stored_tenancies_gateway
+          stored_tenancies_gateway: stored_tenancies_gateway,
+          assign_tenancy_to_user: assign_tenancy_to_user
         )
+      end
+
+      def assign_tenancy_to_user
+        Hackney::Income::AssignTenancyToUser.new(user_assignment_gateway: users_gateway)
       end
 
       private

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -3,28 +3,59 @@ module Hackney
     class UseCaseFactory
       def view_my_cases
         Hackney::Income::DangerousViewMyCases.new(
-          tenancy_api_gateway: Hackney::Income::TenancyApiGateway.new(
-            host: ENV['INCOME_COLLECTION_API_HOST'],
-            key: ENV['INCOME_COLLECTION_API_KEY']
-          ),
-          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new
+          tenancy_api_gateway: tenancy_api_gateway,
+          stored_tenancies_gateway: stored_tenancies_gateway
         )
       end
 
       def sync_cases
         Hackney::Income::DangerousSyncCases.new(
-          prioritisation_gateway: Hackney::Income::UniversalHousingPrioritisationGateway.new,
-          uh_tenancies_gateway: Hackney::Income::UniversalHousingTenanciesGateway.new(
-            restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
-            patches: ENV.fetch('PERMITTED_PATCHES', [])
-          ),
-          stored_tenancies_gateway: Hackney::Income::StoredTenanciesGateway.new,
-          assign_tenancy_to_user: Hackney::Income::AssignTenancyToUser.new(user_assignment_gateway: Hackney::Income::SqlUsersGateway.new)
+          uh_tenancies_gateway: uh_tenancies_gateway,
+          background_job_gateway: background_job_gateway
         )
       end
 
       def find_or_create_user
-        Hackney::Income::FindOrCreateUser.new(users_gateway: Hackney::Income::SqlUsersGateway.new)
+        Hackney::Income::FindOrCreateUser.new(users_gateway: users_gateway)
+      end
+
+      def sync_case_priority
+        Hackney::Income::SyncCasePriority.new(
+          prioritisation_gateway: prioritisation_gateway,
+          stored_tenancies_gateway: stored_tenancies_gateway
+        )
+      end
+
+      private
+
+      def prioritisation_gateway
+        Hackney::Income::UniversalHousingPrioritisationGateway.new
+      end
+
+      def stored_tenancies_gateway
+        Hackney::Income::StoredTenanciesGateway.new
+      end
+
+      def users_gateway
+        Hackney::Income::SqlUsersGateway.new
+      end
+
+      def uh_tenancies_gateway
+        Hackney::Income::UniversalHousingTenanciesGateway.new(
+          restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
+          patches: ENV.fetch('PERMITTED_PATCHES', [])
+        )
+      end
+
+      def tenancy_api_gateway
+        Hackney::Income::TenancyApiGateway.new(
+          host: ENV['INCOME_COLLECTION_API_HOST'],
+          key: ENV['INCOME_COLLECTION_API_KEY']
+        )
+      end
+
+      def background_job_gateway
+        Hackney::Income::BackgroundJobGateway.new
       end
     end
   end

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -49,10 +49,8 @@ describe MyCasesController do
   describe '#sync' do
     it 'should create the sync tenancies use case' do
       expect(Hackney::Income::DangerousSyncCases).to receive(:new).with(
-        prioritisation_gateway: instance_of(Hackney::Income::UniversalHousingPrioritisationGateway),
         uh_tenancies_gateway: instance_of(Hackney::Income::UniversalHousingTenanciesGateway),
-        stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway),
-        assign_tenancy_to_user: instance_of(Hackney::Income::AssignTenancyToUser)
+        background_job_gateway: instance_of(Hackney::Income::BackgroundJobGateway)
       ).and_call_original
 
       allow_any_instance_of(Hackney::Income::DangerousSyncCases)

--- a/spec/hackney/income/jobs/sync_case_priority_job_spec.rb
+++ b/spec/hackney/income/jobs/sync_case_priority_job_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Hackney::Income::Jobs::SyncCasePriorityJob do
+  let(:tenancy_ref) { Faker::IDNumber.valid }
+  subject { described_class }
+
+  it 'should run the SyncCasePriority use case' do
+    expect_any_instance_of(Hackney::Income::SyncCasePriority).to receive(:execute).with(tenancy_ref: tenancy_ref)
+    subject.perform_now(tenancy_ref: tenancy_ref)
+  end
+
+  it 'should be able to be scheduled' do
+    expect {
+      subject.set(wait_until: Time.now + 5.minutes).perform_later
+    }.to_not raise_error
+  end
+end

--- a/spec/lib/hackney/income/background_job_gateway_spec.rb
+++ b/spec/lib/hackney/income/background_job_gateway_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Hackney::Income::BackgroundJobGateway do
+  before { ActiveJob::Base.queue_adapter = :test }
+
+  context 'when scheduling a job to sync priority for a case' do
+    let(:tenancy_ref) { Faker::IDNumber.valid }
+    subject { described_class.new.schedule_case_priority_sync(tenancy_ref: tenancy_ref) }
+
+    it 'should enqueue the job to run as soon as possible' do
+      expect { subject }.to have_enqueued_job(Hackney::Income::Jobs::SyncCasePriorityJob)
+        .with(tenancy_ref: tenancy_ref)
+    end
+  end
+end

--- a/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
@@ -41,8 +41,6 @@ describe Hackney::Income::DangerousSyncCases do
         expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: '000011/01')
         expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: '000012/01')
 
-        expect(assign_tenancy_to_user).to receive(:assign).exactly(3).times
-
         subject
       end
     end

--- a/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_sync_cases_spec.rb
@@ -2,16 +2,12 @@ require_relative '../../../../lib/hackney/income/dangerous_sync_cases'
 
 describe Hackney::Income::DangerousSyncCases do
   let(:uh_tenancies_gateway) { double(tenancies_in_arrears: []) }
-  let(:stored_tenancies_gateway) { double(store_tenancy: nil) }
-  let(:prioritisation_gateway) { PrioritisationGatewayDouble.new }
-  let(:assign_tenancy_to_user) { double(assign_tenancy_to_user: nil) }
+  let(:background_job_gateway) { double(schedule_case_priority_sync: nil) }
 
   let(:sync_cases) do
     described_class.new(
-      prioritisation_gateway: prioritisation_gateway,
       uh_tenancies_gateway: uh_tenancies_gateway,
-      stored_tenancies_gateway: stored_tenancies_gateway,
-      assign_tenancy_to_user: assign_tenancy_to_user
+      background_job_gateway: background_job_gateway
     )
   end
 
@@ -19,54 +15,18 @@ describe Hackney::Income::DangerousSyncCases do
 
   context 'when syncing cases' do
     context 'and finding no cases' do
-      it 'should sync nothing' do
-        expect(stored_tenancies_gateway).not_to receive(:store_tenancy)
+      it 'should queue no jobs' do
+        expect(background_job_gateway).not_to receive(:schedule_case_priority_sync)
         subject
       end
     end
 
     context 'and finding a case' do
-      let(:uh_tenancies_gateway) { double(tenancies_in_arrears: ['000009/01']) }
-      let(:prioritisation_gateway) do
-        PrioritisationGatewayDouble.new(
-          '000009/01' => { priority_band: :green, priority_score: 1000 }
-        )
-      end
+      let(:tenancy_ref) { Faker::IDNumber.valid }
+      let(:uh_tenancies_gateway) { double(tenancies_in_arrears: [tenancy_ref]) }
 
-      it 'should sync the case\'s priority score' do
-        expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
-          tenancy_ref: '000009/01',
-          priority_band: :green,
-          priority_score: 1000,
-          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
-          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
-        )
-
-        expect(assign_tenancy_to_user).to receive(:assign)
-
-        subject
-      end
-    end
-
-    context 'and finding a different case' do
-      let(:uh_tenancies_gateway) { double(tenancies_in_arrears: ['000010/01']) }
-      let(:prioritisation_gateway) do
-        PrioritisationGatewayDouble.new(
-          '000010/01' => { priority_band: :red, priority_score: 5000 }
-        )
-      end
-
-      it 'should sync the case\'s priority score' do
-        expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
-          tenancy_ref: '000010/01',
-          priority_band: :red,
-          priority_score: 5000,
-          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
-          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
-        )
-
-        expect(assign_tenancy_to_user).to receive(:assign)
-
+      it 'should queue a job to sync that case' do
+        expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: tenancy_ref)
         subject
       end
     end
@@ -76,58 +36,15 @@ describe Hackney::Income::DangerousSyncCases do
         double(tenancies_in_arrears: ['000010/01', '000011/01', '000012/01'])
       end
 
-      let(:prioritisation_gateway) do
-        PrioritisationGatewayDouble.new(
-          '000010/01' => { priority_band: :red, priority_score: 300 },
-          '000011/01' => { priority_band: :green, priority_score: 100 },
-          '000012/01' => { priority_band: :amber, priority_score: 200 },
-        )
-      end
-
-      it 'should sync the cases priority scores' do
-        expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
-          tenancy_ref: '000010/01',
-          priority_band: :red,
-          priority_score: 300,
-          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
-          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
-        )
-
-        expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
-          tenancy_ref: '000011/01',
-          priority_band: :green,
-          priority_score: 100,
-          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
-          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
-        )
-
-        expect(stored_tenancies_gateway).to receive(:store_tenancy).with(
-          tenancy_ref: '000012/01',
-          priority_band: :amber,
-          priority_score: 200,
-          criteria: an_instance_of(Hackney::Income::TenancyPrioritiser::StubCriteria),
-          weightings: an_instance_of(Hackney::Income::TenancyPrioritiser::PriorityWeightings)
-        )
+      it 'should queue a job for each case individually' do
+        expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: '000010/01')
+        expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: '000011/01')
+        expect(background_job_gateway).to receive(:schedule_case_priority_sync).with(tenancy_ref: '000012/01')
 
         expect(assign_tenancy_to_user).to receive(:assign).exactly(3).times
 
         subject
       end
     end
-  end
-end
-
-class PrioritisationGatewayDouble
-  def initialize(tenancy_refs_to_scores = {})
-    @tenancy_refs_to_scores = tenancy_refs_to_scores
-  end
-
-  def priorities_for_tenancy(tenancy_ref)
-    {
-      priority_score: @tenancy_refs_to_scores.dig(tenancy_ref, :priority_score),
-      priority_band: @tenancy_refs_to_scores.dig(tenancy_ref, :priority_band),
-      criteria: Hackney::Income::TenancyPrioritiser::StubCriteria.new,
-      weightings: Hackney::Income::TenancyPrioritiser::PriorityWeightings.new
-    }
   end
 end

--- a/spec/lib/hackney/income/sync_case_priority_spec.rb
+++ b/spec/lib/hackney/income/sync_case_priority_spec.rb
@@ -3,7 +3,9 @@ require_relative '../../../../lib/hackney/income/tenancy_prioritiser/priority_we
 require_relative '../../../../lib/hackney/income/sync_case_priority'
 
 describe Hackney::Income::SyncCasePriority do
-  let(:stored_tenancies_gateway) { double(store_tenancy: nil) }
+  let(:stub_tenancy_object) { double }
+  let(:stored_tenancies_gateway) { double(store_tenancy: stub_tenancy_object) }
+  let(:assign_tenancy_to_user) { double(assign_tenancy_to_user: nil) }
   let(:criteria) { Hackney::Income::TenancyPrioritiser::StubCriteria.new }
   let(:weightings) { Hackney::Income::TenancyPrioritiser::PriorityWeightings.new }
 
@@ -21,7 +23,8 @@ describe Hackney::Income::SyncCasePriority do
   let(:sync_case) do
     described_class.new(
       prioritisation_gateway: prioritisation_gateway,
-      stored_tenancies_gateway: stored_tenancies_gateway
+      stored_tenancies_gateway: stored_tenancies_gateway,
+      assign_tenancy_to_user: assign_tenancy_to_user
     )
   end
 
@@ -41,6 +44,8 @@ describe Hackney::Income::SyncCasePriority do
         weightings: weightings
       )
 
+      expect(assign_tenancy_to_user).to receive(:assign).with(tenancy: stub_tenancy_object)
+
       subject
     end
   end
@@ -58,6 +63,8 @@ describe Hackney::Income::SyncCasePriority do
         criteria: criteria,
         weightings: weightings
       )
+
+      expect(assign_tenancy_to_user).to receive(:assign).with(tenancy: stub_tenancy_object)
 
       subject
     end


### PR DESCRIPTION
- The job running all cases in band is taking way too long. Giving it more time would be a poor fix, as four hours should be more than enough, and it would risk overlapping business hours.
- This updates the DangerousSyncCases use case to schedule a background job for each tenancy in arrears, so multiple workers can pick them up concurrently, rather than attempting to sync them all sequentially in the same job.
- Have been working on optimising the SQL separately, but conscious most of the bottleneck here is poor UH performance (and lack of parallelism.)

**Todo**

- [x] Increase memory and worker count on ECS to accomodate.