### PR TITLE
Fix integration issue breaking assignment

### DIFF
--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -7,32 +7,34 @@ module Hackney
           weightings,
         )
 
-        Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).update(
-          priority_band: priority_band,
-          priority_score: priority_score,
+        Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).tap do |tenancy|
+          tenancy.update(
+            priority_band: priority_band,
+            priority_score: priority_score,
 
-          balance_contribution: score_calculator.balance,
-          days_in_arrears_contribution: score_calculator.days_in_arrears,
-          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-          payment_date_delta_contribution: score_calculator.payment_date_delta,
-          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-          active_agreement_contribution: score_calculator.active_agreement,
-          broken_court_order_contribution: score_calculator.broken_court_order,
-          nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp,
+            balance_contribution: score_calculator.balance,
+            days_in_arrears_contribution: score_calculator.days_in_arrears,
+            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+            payment_date_delta_contribution: score_calculator.payment_date_delta,
+            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+            active_agreement_contribution: score_calculator.active_agreement,
+            broken_court_order_contribution: score_calculator.broken_court_order,
+            nosp_served_contribution: score_calculator.nosp_served,
+            active_nosp_contribution: score_calculator.active_nosp,
 
-          balance: criteria.balance,
-          days_in_arrears: criteria.days_in_arrears,
-          days_since_last_payment: criteria.days_since_last_payment,
-          payment_amount_delta: criteria.payment_amount_delta,
-          payment_date_delta: criteria.payment_date_delta,
-          number_of_broken_agreements: criteria.number_of_broken_agreements,
-          active_agreement: criteria.active_agreement?,
-          broken_court_order: criteria.broken_court_order?,
-          nosp_served: criteria.nosp_served?,
-          active_nosp: criteria.active_nosp?
-        )
+            balance: criteria.balance,
+            days_in_arrears: criteria.days_in_arrears,
+            days_since_last_payment: criteria.days_since_last_payment,
+            payment_amount_delta: criteria.payment_amount_delta,
+            payment_date_delta: criteria.payment_date_delta,
+            number_of_broken_agreements: criteria.number_of_broken_agreements,
+            active_agreement: criteria.active_agreement?,
+            broken_court_order: criteria.broken_court_order?,
+            nosp_served: criteria.nosp_served?,
+            active_nosp: criteria.active_nosp?
+          )
+        end
       end
 
       def get_tenancies_for_user(user_id:, page_number: nil, number_per_page: nil)

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -39,22 +39,14 @@ describe Hackney::Income::StoredTenanciesGateway do
         expect(created_tenancy).to have_attributes(expected_serialised_tenancy(attributes))
       end
 
-          balance: attributes.fetch(:criteria).balance,
-          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
-          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
-          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
-          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
-          active_agreement: attributes.fetch(:criteria).active_agreement?,
-          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
-          nosp_served: attributes.fetch(:criteria).nosp_served?,
-          active_nosp: attributes.fetch(:criteria).active_nosp?
-        )
+      # FIXME: shouldn't return AR models from gateways
+      it 'should return the tenancy' do
+        expect(store_tenancy).to eq(created_tenancy)
       end
     end
 
     context 'and the tenancy already exists' do
-      before do
+      let!(:pre_existing_tenancy) do
         Hackney::Income::Models::Tenancy.create!(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
@@ -94,6 +86,11 @@ describe Hackney::Income::StoredTenanciesGateway do
       it 'should not create a new tenancy' do
         store_tenancy
         expect(Hackney::Income::Models::Tenancy.count).to eq(1)
+      end
+
+      # FIXME: shouldn't return AR models from gateways
+      it 'should return the tenancy' do
+        expect(store_tenancy).to eq(pre_existing_tenancy)
       end
     end
   end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -36,21 +36,8 @@ describe Hackney::Income::StoredTenanciesGateway do
 
       it 'should create the tenancy' do
         store_tenancy
-        expect(created_tenancy).to have_attributes(
-          tenancy_ref: attributes.fetch(:tenancy_ref),
-          priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score),
-
-          balance_contribution: score_calculator.balance,
-          days_in_arrears_contribution: score_calculator.days_in_arrears,
-          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-          payment_date_delta_contribution: score_calculator.payment_date_delta,
-          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-          active_agreement_contribution: score_calculator.active_agreement,
-          broken_court_order_contribution: score_calculator.broken_court_order,
-          nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp,
+        expect(created_tenancy).to have_attributes(expected_serialised_tenancy(attributes))
+      end
 
           balance: attributes.fetch(:criteria).balance,
           days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
@@ -101,33 +88,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
       it 'should update the tenancy' do
         store_tenancy
-        expect(stored_tenancy).to have_attributes(
-          tenancy_ref: attributes.fetch(:tenancy_ref),
-          priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score),
-
-          balance_contribution: score_calculator.balance,
-          days_in_arrears_contribution: score_calculator.days_in_arrears,
-          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-          payment_date_delta_contribution: score_calculator.payment_date_delta,
-          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-          active_agreement_contribution: score_calculator.active_agreement,
-          broken_court_order_contribution: score_calculator.broken_court_order,
-          nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp,
-
-          balance: attributes.fetch(:criteria).balance,
-          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
-          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
-          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
-          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
-          active_agreement: attributes.fetch(:criteria).active_agreement?,
-          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
-          nosp_served: attributes.fetch(:criteria).nosp_served?,
-          active_nosp: attributes.fetch(:criteria).active_nosp?
-        )
+        expect(stored_tenancy).to have_attributes(expected_serialised_tenancy(attributes))
       end
 
       it 'should not create a new tenancy' do
@@ -198,33 +159,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
       it 'should include the tenancy\'s ref, band and score' do
         expect(subject.count).to eq(1)
-        expect(subject).to include(a_hash_including(
-          tenancy_ref: attributes.fetch(:tenancy_ref),
-          priority_band: attributes.fetch(:priority_band),
-          priority_score: attributes.fetch(:priority_score),
-
-          balance_contribution: score_calculator.balance,
-          days_in_arrears_contribution: score_calculator.days_in_arrears,
-          days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-          payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-          payment_date_delta_contribution: score_calculator.payment_date_delta,
-          number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-          active_agreement_contribution: score_calculator.active_agreement,
-          broken_court_order_contribution: score_calculator.broken_court_order,
-          nosp_served_contribution: score_calculator.nosp_served,
-          active_nosp_contribution: score_calculator.active_nosp,
-
-          balance: attributes.fetch(:criteria).balance,
-          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
-          days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-          payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
-          payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
-          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
-          active_agreement: attributes.fetch(:criteria).active_agreement?,
-          broken_court_order: attributes.fetch(:criteria).broken_court_order?,
-          nosp_served: attributes.fetch(:criteria).nosp_served?,
-          active_nosp: attributes.fetch(:criteria).active_nosp?
-        ))
+        expect(subject).to include(a_hash_including(expected_serialised_tenancy(attributes)))
       end
     end
 
@@ -379,5 +314,35 @@ describe Hackney::Income::StoredTenanciesGateway do
 
   def create_tenancy(user_id: nil)
     Hackney::Income::Models::Tenancy.create(assigned_user_id: user_id)
+  end
+
+  def expected_serialised_tenancy(attributes)
+    {
+      tenancy_ref: attributes.fetch(:tenancy_ref),
+      priority_band: attributes.fetch(:priority_band),
+      priority_score: attributes.fetch(:priority_score),
+
+      balance_contribution: score_calculator.balance,
+      days_in_arrears_contribution: score_calculator.days_in_arrears,
+      days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+      payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+      payment_date_delta_contribution: score_calculator.payment_date_delta,
+      number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+      active_agreement_contribution: score_calculator.active_agreement,
+      broken_court_order_contribution: score_calculator.broken_court_order,
+      nosp_served_contribution: score_calculator.nosp_served,
+      active_nosp_contribution: score_calculator.active_nosp,
+
+      balance: attributes.fetch(:criteria).balance,
+      days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
+      days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
+      payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,
+      payment_date_delta: attributes.fetch(:criteria).payment_date_delta,
+      number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
+      active_agreement: attributes.fetch(:criteria).active_agreement?,
+      broken_court_order: attributes.fetch(:criteria).broken_court_order?,
+      nosp_served: attributes.fetch(:criteria).nosp_served?,
+      active_nosp: attributes.fetch(:criteria).active_nosp?
+    }
   end
 end


### PR DESCRIPTION
The SyncCasePriority use case expects the StoredTenanciesGateway to return an ActiveRecord Tenancy object (this is not good, but we'll address later.) However, it's not being returned, so the user assignment logic is receiving the `update` call's `true` return value, rather than the `Tenancy` model.