### PR TITLE
Add user role column and exclude non-CC users from assignment

### DIFF
--- a/app/models/hackney/income/models/user.rb
+++ b/app/models/hackney/income/models/user.rb
@@ -3,6 +3,8 @@ module Hackney
     module Models
       class User < ApplicationRecord
         has_many :tenancies, foreign_key: :assigned_user_id
+
+        enum role: [ :developer, :credit_controller, :legal_case_worker, :manager ]
       end
     end
   end

--- a/app/models/hackney/income/models/user.rb
+++ b/app/models/hackney/income/models/user.rb
@@ -4,7 +4,7 @@ module Hackney
       class User < ApplicationRecord
         has_many :tenancies, foreign_key: :assigned_user_id
 
-        enum role: [ :developer, :credit_controller, :legal_case_worker, :manager ]
+        enum role: [:base_user, :credit_controller, :legal_case_worker, :manager, :developer]
       end
     end
   end

--- a/db/migrate/20180927140212_add_role_to_users.rb
+++ b/db/migrate/20180927140212_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180913132800) do
+ActiveRecord::Schema.define(version: 20180927140212) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20180913132800) do
   create_table "tenancies", force: :cascade do |t|
     t.string "tenancy_ref"
     t.string "priority_band"
-    t.decimal "priority_score"
+    t.integer "priority_score"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "balance_contribution"
@@ -53,12 +53,6 @@ ActiveRecord::Schema.define(version: 20180913132800) do
     t.boolean "broken_court_order"
     t.boolean "nosp_served"
     t.boolean "active_nosp"
-    t.string "current_arrears_agreement_status"
-    t.string "latest_action_code"
-    t.string "latest_action_date"
-    t.string "primary_contact_name"
-    t.string "primary_contact_short_address"
-    t.string "primary_contact_postcode"
     t.integer "assigned_user_id"
     t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
   end
@@ -71,6 +65,7 @@ ActiveRecord::Schema.define(version: 20180913132800) do
     t.string "first_name"
     t.string "last_name"
     t.string "provider_permissions"
+    t.integer "role", default: 0
   end
 
 end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -32,7 +32,7 @@ module Hackney
         Hackney::Income::Models::User
           .left_joins(:tenancies)
           .group('users.id')
-          .where('tenancies.id IS NULL OR tenancies.priority_band = ?', band)
+          .where('users.role = 1 AND tenancies.id IS NULL OR tenancies.priority_band = ?', band)
           .order('COUNT(tenancies.id) ASC')
           .first
       end

--- a/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
+++ b/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::AssignTenancyToUser do
-  let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
-  let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name) }
+  let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
+  let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
   let!(:assigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: user2) }
   let!(:unassigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: nil) }
 

--- a/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
+++ b/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::AssignTenancyToUser do
-  let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
-  let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
+  let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: :credit_controller) }
+  let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: :credit_controller) }
   let!(:assigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: user2) }
   let!(:unassigned_tenancy) { create_assigned_tenancy_model(band: 'green', user: nil) }
 

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -86,9 +86,9 @@ describe Hackney::Income::SqlTenancyCaseGateway do
     end
 
     context 'when auto assigning users to cases' do
-      let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
-      let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 1) }
-      let!(:user3) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: 0) }
+      let!(:user1) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: :credit_controller) }
+      let!(:user2) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: :credit_controller) }
+      let!(:user3) { Hackney::Income::Models::User.create!(name: Faker::Name.name, role: :base_user) }
 
       let!(:unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
       let!(:second_unassigned_green) { create_assigned_tenancy_model(band: 'green', user: nil) }
@@ -142,12 +142,12 @@ describe Hackney::Income::SqlTenancyCaseGateway do
     context 'when assigning several cases' do
       context 'and they are all in the same band' do
         it 'should assign them evenly to eligible users' do
-          user_a = Hackney::Income::Models::User.create!(role: 1)
-          user_b = Hackney::Income::Models::User.create!(role: 1)
-          user_c = Hackney::Income::Models::User.create!(role: 1)
-          user_d = Hackney::Income::Models::User.create!(role: 1)
-          user_e = Hackney::Income::Models::User.create!(role: 1)
-          user_f = Hackney::Income::Models::User.create!(role: 0)
+          user_a = Hackney::Income::Models::User.create!(role: :credit_controller)
+          user_b = Hackney::Income::Models::User.create!(role: :credit_controller)
+          user_c = Hackney::Income::Models::User.create!(role: :credit_controller)
+          user_d = Hackney::Income::Models::User.create!(role: :credit_controller)
+          user_e = Hackney::Income::Models::User.create!(role: :credit_controller)
+          user_f = Hackney::Income::Models::User.create!(role: :base_user)
 
           tenancy_a = Hackney::Income::Models::Tenancy.create!(priority_band: :red)
           tenancy_b = Hackney::Income::Models::Tenancy.create!(priority_band: :red)


### PR DESCRIPTION
What:
Add a role column to users and exclude users who do not have a role '1:credit_controller' from case assignment.

Why:
Currently assignment assigns cases evenly across all users, while some users in the system are devs/managers/legal case workers who will not need case assignment.

Future:
The income API needs some sort of management interface, and this interface will probably need to be able to modify the roles of users along with other management tasks like re-assigning cases manually.