### PR TITLE
POC to update the stack level on the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG RAILS_ENV=development
 FROM ruby:2.5.1
 WORKDIR /app
 
+ENV RUBY_THREAD_VM_STACK_SIZE=5000000
+
 RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.27.tar.gz && \
   tar -xzf freetds-1.00.27.tar.gz && \
   cd freetds-1.00.27 && \

--- a/bin/stack_test.rb
+++ b/bin/stack_test.rb
@@ -1,0 +1,12 @@
+def factorial(n)
+  raise InvalidArgument, "negative input given" if n < 0
+
+  return 1 if n == 0
+  return factorial(n - 1) * n
+end
+
+puts 1_000
+factorial(1_000).to_s.size
+
+puts 100_000
+factorial(100_000).to_s.size


### PR DESCRIPTION
This is an attempt to fix `stack level too deep` when running the sql updates. The provided ruby `./bin/stack_test.rb`  should not throw an error if the env setup is successful.

TBD: if 5mb is enough