### PR TITLE
Pause status

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -5,6 +5,6 @@ class TenanciesController < ApplicationController
       status: params.fetch(:status)
     )
 
-    render :json, :status => 200 if result.nil?
+    render head: :no_content
   end
 end

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -2,9 +2,9 @@ class TenanciesController < ApplicationController
   def update
     result = income_use_case_factory.set_tenancy_paused_status.execute(
       tenancy_ref: params.fetch(:tenancy_ref),
-      status: params.fetch(:status)
+      status: params.fetch(:is_paused)
     )
 
-    render head: :no_content
+    return head(:no_content)
   end
 end

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -1,0 +1,10 @@
+class TenanciesController < ApplicationController
+  def update
+    result = income_use_case_factory.set_tenancy_paused_status.execute(
+      tenancy_ref: params.fetch(:tenancy_ref),
+      status: params.fetch(:status)
+    )
+
+    render :json, :status => 200 if result.nil?
+  end
+end

--- a/app/models/hackney/income/models/tenancy.rb
+++ b/app/models/hackney/income/models/tenancy.rb
@@ -3,10 +3,6 @@ module Hackney
     module Models
       class Tenancy < ApplicationRecord
         belongs_to :assigned_user, class_name: 'Hackney::Income::Models::User', optional: true
-
-        def paused?
-          self.pause_status
-        end
       end
     end
   end

--- a/app/models/hackney/income/models/tenancy.rb
+++ b/app/models/hackney/income/models/tenancy.rb
@@ -3,6 +3,10 @@ module Hackney
     module Models
       class Tenancy < ApplicationRecord
         belongs_to :assigned_user, class_name: 'Hackney::Income::Models::User', optional: true
+
+        def paused?
+          self.pause_status
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
-  get '/api/v1/my-cases', to: 'my_cases#index'
-  get '/api/v1/sync-cases', to: 'my_cases#sync'
-  post '/api/v1/users/find-or-create', to: 'users#create'
-  patch '/api/v1/tenancies/set-pause-status', to: 'tenancies#update'
+  scope '/api/v1' do
+    get '/my-cases', to: 'my_cases#index'
+    get '/sync-cases', to: 'my_cases#sync'
+    post '/users/find-or-create', to: 'users#create'
+    patch '/tenancies/set-pause-status', to: 'tenancies#update'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   get '/api/v1/my-cases', to: 'my_cases#index'
   get '/api/v1/sync-cases', to: 'my_cases#sync'
   post '/api/v1/users/find-or-create', to: 'users#create'
+  post '/api/v1/tenancies/set-pause-status', to: 'tenancies#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
     get '/my-cases', to: 'my_cases#index'
     get '/sync-cases', to: 'my_cases#sync'
     post '/users/find-or-create', to: 'users#create'
-    patch '/tenancies/set-pause-status', to: 'tenancies#update'
+    patch '/tenancies/:tenancy_ref', to: 'tenancies#update'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   get '/api/v1/my-cases', to: 'my_cases#index'
   get '/api/v1/sync-cases', to: 'my_cases#sync'
   post '/api/v1/users/find-or-create', to: 'users#create'
-  post '/api/v1/tenancies/set-pause-status', to: 'tenancies#update'
+  patch '/api/v1/tenancies/set-pause-status', to: 'tenancies#update'
 end

--- a/db/migrate/20181010141355_add_pause_to_tenancies.rb
+++ b/db/migrate/20181010141355_add_pause_to_tenancies.rb
@@ -1,0 +1,5 @@
+class AddPauseToTenancies < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tenancies, :pause_status, :boolean, default: false
+  end
+end

--- a/db/migrate/20181010141355_add_pause_to_tenancies.rb
+++ b/db/migrate/20181010141355_add_pause_to_tenancies.rb
@@ -1,5 +1,5 @@
 class AddPauseToTenancies < ActiveRecord::Migration[5.1]
   def change
-    add_column :tenancies, :pause_status, :boolean, default: false
+    add_column :tenancies, :is_paused, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180927140212) do
+ActiveRecord::Schema.define(version: 20181010141355) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20180927140212) do
     t.boolean "nosp_served"
     t.boolean "active_nosp"
     t.integer "assigned_user_id"
+    t.boolean "pause_status", default: false
     t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20181010141355) do
     t.boolean "nosp_served"
     t.boolean "active_nosp"
     t.integer "assigned_user_id"
-    t.boolean "pause_status", default: false
+    t.boolean "is_paused", default: false
     t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
   end
 

--- a/lib/hackney/income/set_tenancy_paused_status.rb
+++ b/lib/hackney/income/set_tenancy_paused_status.rb
@@ -1,0 +1,13 @@
+module Hackney
+  module Income
+    class SetTenancyPausedStatus
+      def initialize(gateway:)
+        @gateway = gateway
+      end
+
+      def execute(tenancy_ref:, status:)
+        @gateway.set_paused_status(tenancy_ref: tenancy_ref, status: status)
+      end
+    end
+  end
+end

--- a/lib/hackney/income/sql_pause_tenancy_gateway.rb
+++ b/lib/hackney/income/sql_pause_tenancy_gateway.rb
@@ -1,0 +1,11 @@
+module Hackney
+  module Income
+    class SqlPauseTenancyGateway
+      def set_paused_status(tenancy_ref:, status:)
+        tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
+        raise "Unable to pause tenancy: #{tenancy_ref} - tenancy not found." if tenancy.nil?
+        tenancy.update!(pause_status: status)
+      end
+    end
+  end
+end

--- a/lib/hackney/income/sql_pause_tenancy_gateway.rb
+++ b/lib/hackney/income/sql_pause_tenancy_gateway.rb
@@ -4,7 +4,7 @@ module Hackney
       def set_paused_status(tenancy_ref:, status:)
         tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
         raise "Unable to pause tenancy: #{tenancy_ref} - tenancy not found." if tenancy.nil?
-        tenancy.update!(pause_status: status)
+        tenancy.update!(is_paused: status)
       end
     end
   end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -19,6 +19,10 @@ module Hackney
         Hackney::Income::FindOrCreateUser.new(users_gateway: users_gateway)
       end
 
+      def set_tenancy_paused_status
+        Hackney::Income::SetTenancyPausedStatus.new(gateway: sql_pause_tenancy_gateway)
+      end
+
       def sync_case_priority
         Hackney::Income::SyncCasePriority.new(
           prioritisation_gateway: prioritisation_gateway,
@@ -35,6 +39,10 @@ module Hackney
 
       def prioritisation_gateway
         Hackney::Income::UniversalHousingPrioritisationGateway.new
+      end
+
+      def sql_pause_tenancy_gateway
+          Hackney::Income::SqlPauseTenancyGateway.new
       end
 
       def stored_tenancies_gateway

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-describe TenanciesController do
+describe TenanciesController, type: :controller do
   let(:params1) do
     {
       tenancy_ref: Faker::Lorem.characters(8),
-      status: true
+      is_paused: true
     }
   end
   let(:params2) do
     {
       tenancy_ref: Faker::Lorem.characters(8),
-      status: false
+      is_paused: false
     }
   end
 
@@ -22,7 +22,7 @@ describe TenanciesController do
     it 'should pass the correct params to the use case' do
       expect_any_instance_of(Hackney::Income::SetTenancyPausedStatus).to receive(:execute).with(
         tenancy_ref: params1.fetch(:tenancy_ref),
-        status: params1.fetch(:status).to_s
+        status: params1.fetch(:is_paused).to_s
       ).and_return(nil)
 
       patch :update, params: params1
@@ -31,12 +31,12 @@ describe TenanciesController do
     it 'should return a 200 response' do
       expect_any_instance_of(Hackney::Income::SetTenancyPausedStatus).to receive(:execute).with(
         tenancy_ref: params2.fetch(:tenancy_ref),
-        status: params2.fetch(:status).to_s
+        status: params2.fetch(:is_paused).to_s
       ).and_return(nil)
 
       patch :update, params: params2
 
-      expect(response.status).to eq(200)
+      expect(response.status).to eq(204)
     end
   end
 
@@ -57,12 +57,8 @@ describe TenanciesController do
   context 'when receiving a request missing params' do
     it 'should return a 400 - bad request' do
       assert_incomplete_params({
-          tenancy_ref: Faker::Lorem.characters(8),
-        })
-
-      assert_incomplete_params({
-          status: true
-        })
+        tenancy_ref: Faker::Lorem.characters(8)
+      })
     end
   end
 

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -25,7 +25,7 @@ describe TenanciesController do
         status: params1.fetch(:status).to_s
       ).and_return(nil)
 
-      post :update, params: params1
+      patch :update, params: params1
     end
 
     it 'should return a 200 response' do
@@ -34,7 +34,7 @@ describe TenanciesController do
         status: params2.fetch(:status).to_s
       ).and_return(nil)
 
-      post :update, params: params2
+      patch :update, params: params2
 
       expect(response.status).to eq(200)
     end
@@ -47,7 +47,7 @@ describe TenanciesController do
 
     it 'should return an exception detailing the unknown tenancy ref' do
       expect {
-        post :update, params: params1
+        patch :update, params: params1
       }.to raise_error.with_message(
         /#{params1.fetch(:tenancy_ref)}/
       )
@@ -68,7 +68,7 @@ describe TenanciesController do
 
   def assert_incomplete_params(params_hash)
     expect {
-      post :update, params: params_hash
+      patch :update, params: params_hash
     }.to raise_error ActionController::ParameterMissing
   end
 end

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe TenanciesController do
+  let(:params1) do
+    {
+      tenancy_ref: Faker::Lorem.characters(8),
+      status: true
+    }
+  end
+  let(:params2) do
+    {
+      tenancy_ref: Faker::Lorem.characters(8),
+      status: false
+    }
+  end
+
+  before do
+    stub_const('Hackney::Income::SetTenancyPausedStatus', StubSetTenancyPausedStatus)
+  end
+
+  context 'when receiving valid params' do
+    it 'should pass the correct params to the use case' do
+      expect_any_instance_of(Hackney::Income::SetTenancyPausedStatus).to receive(:execute).with(
+        tenancy_ref: params1.fetch(:tenancy_ref),
+        status: params1.fetch(:status).to_s
+      ).and_return(nil)
+
+      post :update, params: params1
+    end
+
+    it 'should return a 200 response' do
+      expect_any_instance_of(Hackney::Income::SetTenancyPausedStatus).to receive(:execute).with(
+        tenancy_ref: params2.fetch(:tenancy_ref),
+        status: params2.fetch(:status).to_s
+      ).and_return(nil)
+
+      post :update, params: params2
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context 'when receiving a tenancy id that does not exist' do
+    before do
+      stub_const('Hackney::Income::SetTenancyPausedStatus', StubSetUnknownTenancyPausedStatus)
+    end
+
+    it 'should return an exception detailing the unknown tenancy ref' do
+      expect {
+        post :update, params: params1
+      }.to raise_error.with_message(
+        /#{params1.fetch(:tenancy_ref)}/
+      )
+    end
+  end
+
+  context 'when receiving a request missing params' do
+    it 'should return a 400 - bad request' do
+      assert_incomplete_params({
+          tenancy_ref: Faker::Lorem.characters(8),
+        })
+
+      assert_incomplete_params({
+          status: true
+        })
+    end
+  end
+
+  def assert_incomplete_params(params_hash)
+    expect {
+      post :update, params: params_hash
+    }.to raise_error ActionController::ParameterMissing
+  end
+end
+
+class StubSetUnknownTenancyPausedStatus
+  def initialize(gateway:); end
+
+  def execute(tenancy_ref:, status:)
+    raise "Raised on #{tenancy_ref}"
+  end
+end
+
+class StubSetTenancyPausedStatus
+  def initialize(gateway:); end
+  def execute(tenancy_ref:, status:); end
+end

--- a/spec/lib/hackney/income/set_tenancy_paused_status_spec.rb
+++ b/spec/lib/hackney/income/set_tenancy_paused_status_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe Hackney::Income::SetTenancyPausedStatus do
+  subject { described_class.new(gateway: PauseGatewayDouble.new) }
+  let(:tenancy_ref) { Faker::Lorem.characters(8) }
+
+  context 'setting the pause status for a case' do
+    context 'when the operation is successful' do
+      it 'should pass the required params to the gateway' do
+        expect_any_instance_of(PauseGatewayDouble).to receive(:set_paused_status)
+          .with(tenancy_ref: tenancy_ref, status: true)
+
+        subject.execute(tenancy_ref: tenancy_ref, status: true)
+      end
+    end
+
+    context 'when the operation is unsuccessful' do
+      subject { described_class.new(gateway: PauseGatewayDouble.new(true)) }
+
+      it 'should not catch the exception raised' do
+        expect { subject.execute(tenancy_ref: tenancy_ref, status: true) }.to raise_error
+          .with_message(/#{tenancy_ref}/)
+      end
+    end
+  end
+end
+
+class PauseGatewayDouble
+  def initialize(raise_exc = false)
+    @raise = raise_exc
+  end
+
+  def set_paused_status(tenancy_ref:, status:)
+    raise "Raised on #{tenancy_ref}" if @raise
+  end
+end

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -19,13 +19,13 @@ describe Hackney::Income::SqlPauseTenancyGateway do
     end
 
     it 'should default to unpaused' do
-      expect(tenancy_1.paused?).to be(false)
+      expect(tenancy_1.is_paused?).to be(false)
     end
 
     it 'should update with the given status' do
       subject.set_paused_status(tenancy_ref: tenancy_1.tenancy_ref, status: true)
 
-      expect(Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
+      expect(Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_1.tenancy_ref).is_paused?).to be(true)
     end
   end
 end

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Hackney::Income::SqlPauseTenancyGateway do
+  let(:tenancy_1) { create_tenancy_model }
+
+  subject { described_class.new }
+
+  before do
+    tenancy_1.save
+  end
+
+  context 'set pause status' do
+    context ' when the tenancy does not exist' do
+      it 'should raise an exception' do
+        expect { subject.set_paused_status(tenancy_ref: 'does_not_exist', status: true) }
+          .to raise_error
+          .with_message(/does_not_exist/)
+      end
+    end
+
+    it 'should default to unpaused' do
+      expect(tenancy_1.paused?).to be(false)
+    end
+
+    it 'should update with the given status' do
+      subject.set_paused_status(tenancy_ref: tenancy_1.tenancy_ref, status: true)
+
+      expect(Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
+    end
+  end
+end

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -11,7 +11,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
 
   context 'set pause status' do
     context ' when the tenancy does not exist' do
-      it 'should raise an exception' do
+      it 'should raise an exception containing the tenancy ref' do
         expect { subject.set_paused_status(tenancy_ref: 'does_not_exist', status: true) }
           .to raise_error
           .with_message(/does_not_exist/)

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -187,14 +187,6 @@ describe Hackney::Income::SqlTenancyCaseGateway do
     Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy.tenancy_ref)
   end
 
-  def create_tenancy_model
-    Hackney::Income::Models::Tenancy.new.tap do |t|
-      t.tenancy_ref = Faker::Lorem.characters(5)
-      t.priority_band = Faker::Lorem.characters(5)
-      t.priority_score = Faker::Lorem.characters(5)
-    end
-  end
-
   def create_assigned_tenancy_model(band:, user:)
     Hackney::Income::Models::Tenancy.create!(
       tenancy_ref: Faker::Lorem.characters(5),

--- a/spec/support/tenancy_helper.rb
+++ b/spec/support/tenancy_helper.rb
@@ -63,4 +63,12 @@ module TenancyHelper
       description: 'this tenant is in arrears!'
     )
   end
+
+  def create_tenancy_model
+    Hackney::Income::Models::Tenancy.new.tap do |t|
+      t.tenancy_ref = Faker::Lorem.characters(5)
+      t.priority_band = Faker::Lorem.characters(5)
+      t.priority_score = Faker::Lorem.characters(5)
+    end
+  end
 end


### PR DESCRIPTION
WHAT:
Add an endpoint that sets the new field on our persisted tenancy model, _paused status_ to the status given for the tenancy ref provided.

WHY:
We will need to use this status to determine if a tenancy should be displayed in a worktray, exempt from automation and potentially even more in future. The IC app will need some way to update this status.