### PR TITLE
Migrate lcw worktray

### DIFF
--- a/lib/hackney/income/migrate_patch_to_lcw.rb
+++ b/lib/hackney/income/migrate_patch_to_lcw.rb
@@ -1,0 +1,17 @@
+module Hackney
+  module Income
+    class MigratePatchToLcw
+      def initialize(legal_cases_gateway:, user_assignment_gateway:)
+        @legal_cases_gateway = legal_cases_gateway
+        @user_assignment_gateway = user_assignment_gateway
+      end
+
+      def execute(patch:, user_id:)
+        tenancy_refs_in_legal_process = @legal_cases_gateway.get_tenancies_for_legal_process_for_patch(patch: patch)
+        tenancy_refs_in_legal_process.each do |ref|
+          @user_assignment_gateway.assign_user(tenancy_ref: ref, user_id: user_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/sql_legal_cases_gateway.rb
+++ b/lib/hackney/income/sql_legal_cases_gateway.rb
@@ -1,0 +1,30 @@
+module Hackney
+  module Income
+    class SqlLegalCasesGateway
+      def get_tenancies_for_legal_process_for_patch(patch:)
+        query = database[:tenagree]
+
+        query
+          .left_join(:property, prop_ref: :prop_ref)
+            .where(Sequel[:property][:arr_patch] => patch)
+            .where(Sequel[:tenagree][:tenure] => SECURE_TENURE_TYPE)
+            .where(Sequel[:tenagree][:terminated].cast(:integer) => 0)
+            .where(Sequel[:tenagree][:high_action] => LEGAL_STAGES)
+            .select { Sequel[:tenagree][:tag_ref].as(:tag_ref) }
+            .map { |record| record[:tag_ref].strip }
+      end
+
+      private
+
+      LEGAL_STAGES = ['4RS', '5RP', '6RC', '6RO', '7RE'].freeze
+      SECURE_TENURE_TYPE = 'SEC'.freeze
+
+      def database
+        Hackney::UniversalHousing::Client.connection.tap do |db|
+          db.extension :identifier_mangling
+          db.identifier_input_method = db.identifier_output_method = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -31,11 +31,22 @@ module Hackney
         )
       end
 
+      def migrate_patch_to_lcw
+        Hackney::Income::MigratePatchToLcw.new(
+          legal_cases_gateway: legal_cases_gateway,
+          user_assignment_gateway: user_assignment_gateway
+        )
+      end
+
       def assign_tenancy_to_user
         Hackney::Income::AssignTenancyToUser.new(user_assignment_gateway: user_assignment_gateway)
       end
 
       private
+
+      def legal_cases_gateway
+        Hackney::Income::SqlLegalCasesGateway.new
+      end
 
       def prioritisation_gateway
         Hackney::Income::UniversalHousingPrioritisationGateway.new

--- a/lib/tasks/income.rake
+++ b/lib/tasks/income.rake
@@ -3,4 +3,10 @@ namespace :income do
     use_case_factory = Hackney::Income::UseCaseFactory.new
     use_case_factory.sync_cases.execute
   end
+
+  desc 'Manual task, supply a 3 character patch code and the user ID for a user in our SQL database. All tenancies in that patch where the high action is 4RS or above will be assigned to that user.'
+  task :migrate_lcw_cases, [:patch, :user_id] do |task, args|
+    use_case_factory = Hackney::Income::UseCaseFactory.new
+    use_case_factory.migrate_patch_to_lcw.execute(patch: args.fetch(:patch), user_id: args.fetch(:user_id))
+  end
 end

--- a/spec/lib/hackney/income/migrate_patch_to_lcw_spec.rb
+++ b/spec/lib/hackney/income/migrate_patch_to_lcw_spec.rb
@@ -1,0 +1,25 @@
+describe Hackney::Income::MigratePatchToLcw do
+  subject { described_class.new(gateway: legal_cases_gateway) }
+  let(:legal_cases_gateway) { double('Universal Housing Gateway') }
+  let(:tenancy_persistance_gateway) { double('Tenancies Gateway') }
+
+  context 'given a user id and a patch, assigns all legal cases to that user' do
+    it 'should pass the patch to the SQL legal cases gateway' do
+      expect(legal_cases_gateway).to receive(:get_tenancies_for_legal_process_for_patch).with(
+        patch: '12345'
+      ).and_return(['12345', '56789'])
+
+      expect(tenancy_persistance_gateway).to receive(:assign_user).with(
+        tenancy_ref: '12345',
+        user_id: 1
+      )
+
+      expect(tenancy_persistance_gateway).to receive(:assign_user).with(
+        tenancy_ref: '56789',
+        user_id: 1
+      )
+
+      subject.execute(patch: '12345', user_id: 1)
+    end
+  end
+end

--- a/spec/lib/hackney/income/migrate_patch_to_lcw_spec.rb
+++ b/spec/lib/hackney/income/migrate_patch_to_lcw_spec.rb
@@ -1,25 +1,29 @@
 describe Hackney::Income::MigratePatchToLcw do
-  subject { described_class.new(gateway: legal_cases_gateway) }
+  subject { described_class.new(legal_cases_gateway: legal_cases_gateway, user_assignment_gateway: user_assignment_gateway) }
   let(:legal_cases_gateway) { double('Universal Housing Gateway') }
-  let(:tenancy_persistance_gateway) { double('Tenancies Gateway') }
+  let(:user_assignment_gateway) { double('Tenancies Gateway') }
+
+  let(:patch_code) { Faker::Lorem.characters(3) }
+  let(:user_id) { Faker::Number.number(2) }
+  let(:tenancy_ref_array) { [Faker::Lorem.characters(8), Faker::Lorem.characters(8)] }
 
   context 'given a user id and a patch, assigns all legal cases to that user' do
     it 'should pass the patch to the SQL legal cases gateway' do
       expect(legal_cases_gateway).to receive(:get_tenancies_for_legal_process_for_patch).with(
-        patch: '12345'
-      ).and_return(['12345', '56789'])
+        patch: patch_code
+      ).and_return(tenancy_ref_array)
 
-      expect(tenancy_persistance_gateway).to receive(:assign_user).with(
-        tenancy_ref: '12345',
-        user_id: 1
+      expect(user_assignment_gateway).to receive(:assign_user).with(
+        tenancy_ref: tenancy_ref_array[0],
+        user_id: user_id
       )
 
-      expect(tenancy_persistance_gateway).to receive(:assign_user).with(
-        tenancy_ref: '56789',
-        user_id: 1
+      expect(user_assignment_gateway).to receive(:assign_user).with(
+        tenancy_ref: tenancy_ref_array[1],
+        user_id: user_id
       )
 
-      subject.execute(patch: '12345', user_id: 1)
+      subject.execute(patch: patch_code, user_id: user_id)
     end
   end
 end

--- a/spec/lib/hackney/income/sql_legal_cases_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_legal_cases_gateway_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Hackney::Income::SqlLegalCasesGateway, universal: true do
+  subject { described_class.new }
+
+  after { truncate_uh_tables }
+
+  context 'given a patch, get all tenancies above stage 4' do
+    before do
+      create_uh_tenancy_agreement_with_property(tenancy_ref: 'not_a_legal_case', prop_ref: '1234', arr_patch: 'W01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/01', high_action: '4RS', prop_ref: '0987', arr_patch: 'E01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/02', high_action: '5RP', prop_ref: '0986', arr_patch: 'E01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/03', high_action: '6RC', prop_ref: '0985', arr_patch: 'E01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/04', high_action: '6RO', prop_ref: '0984', arr_patch: 'E01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/05', high_action: '7RE', prop_ref: '0983', arr_patch: 'E01')
+    end
+
+    it 'should return the tenancy refs for that patch' do
+      expect(subject.get_tenancies_for_legal_process_for_patch(patch: 'E01')).to eq(
+        [
+          '1234/01',
+          '1234/02',
+          '1234/03',
+          '1234/04',
+          '1234/05',
+        ]
+      )
+    end
+  end
+
+  context 'given a patch with no tenancies with a high_action above stage 4' do
+    before do
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/01', high_action: '111', prop_ref: '0987', arr_patch: 'E01')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/02', high_action: '111', prop_ref: '0986', arr_patch: 'W02')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/03', high_action: '111', prop_ref: '0985', arr_patch: 'E02')
+      create_uh_tenancy_agreement_with_property(tenancy_ref: '1234/04', high_action: '111', prop_ref: '0984', arr_patch: 'E02')
+    end
+
+    it 'should return an empty array' do
+      expect(subject.get_tenancies_for_legal_process_for_patch(patch: 'E01')).to eq([])
+      expect(subject.get_tenancies_for_legal_process_for_patch(patch: 'E02')).to eq([])
+      expect(subject.get_tenancies_for_legal_process_for_patch(patch: 'W02')).to eq([])
+    end
+  end
+end

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -1,6 +1,11 @@
 module UniversalHousingHelper
-  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, property_ref: '', terminated: false, tenure_type: 'SEC')
-    Hackney::UniversalHousing::Client.connection[:tenagree].insert(tag_ref: tenancy_ref, cur_bal: current_balance, prop_ref: property_ref, terminated: terminated ? 1 : 0, tenure: tenure_type)
+  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, property_ref: '', terminated: false, tenure_type: 'SEC', high_action: '111')
+    Hackney::UniversalHousing::Client.connection[:tenagree].insert(tag_ref: tenancy_ref, cur_bal: current_balance, prop_ref: property_ref, terminated: terminated ? 1 : 0, tenure: tenure_type, high_action: high_action)
+  end
+
+  def create_uh_tenancy_agreement_with_property(tenancy_ref:, current_balance: 0.0, prop_ref: '', arr_patch: '', terminated: false, tenure_type: 'SEC', high_action: '111')
+    Hackney::UniversalHousing::Client.connection[:property].insert(prop_ref: prop_ref, arr_patch: arr_patch)
+    create_uh_tenancy_agreement(tenancy_ref: tenancy_ref, current_balance: current_balance, property_ref: prop_ref, terminated: terminated, tenure_type: tenure_type, high_action: high_action)
   end
 
   def create_uh_transaction(tenancy_ref:, amount: 0.0, date: Date.today, type: '')


### PR DESCRIPTION
Added a rake task which allows manual migration of synced tenancies in a given patch to a given user ID.

Usage: `rake income:migrate_lcw_cases['patch',user_id]`