### PR TITLE
Filter paused tenancies (gateway and usecase)

### DIFF
--- a/lib/hackney/income/dangerous_view_my_cases.rb
+++ b/lib/hackney/income/dangerous_view_my_cases.rb
@@ -22,7 +22,6 @@ module Hackney
           number_per_page: number_per_page,
           is_paused: is_paused
         )
-        return Response.new([], number_of_pages_for_user) if assigned_tenancies.length.zero?
 
         assigned_tenancy_refs = assigned_tenancies.map { |t| t.fetch(:tenancy_ref) }
         full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(assigned_tenancy_refs)

--- a/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/dangerous_view_my_cases_spec.rb
@@ -191,11 +191,11 @@ describe Hackney::Income::DangerousViewMyCases do
       @stored_tenancies_attributes = stored_tenancies_attributes
     end
 
-    def get_tenancies_for_user(user_id:, page_number:, number_per_page:)
+    def get_tenancies_for_user(user_id:, page_number:, number_per_page:, is_paused: nil)
       @stored_tenancies_attributes.values
     end
 
-    def number_of_pages_for_user(user_id:, number_per_page:)
+    def number_of_pages_for_user(user_id:, number_per_page:, is_paused: nil)
       @stored_tenancies_attributes.keys.count
     end
   end


### PR DESCRIPTION
This is part of the work for view only paused tenancies.

- gateway takes an optional is_paused arg
  - false filters on not paused
  - true filters on only paused (anticipating future paused cases tab in frontend)
- same for usecase

PS I am not entirely happy with the the early returns in the use case howerver this change would fix a bug we am seeing on senchry production (and new tests).