### PR TITLE
HF config to handle default timeouts from 4hrs

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,2 @@
+# set timeout for delayed job workers
+Delayed::Worker.max_run_time = 10.minutes


### PR DESCRIPTION
Config change that is keeping jobs from completing on production - delayed job is not handing threads for long running tasks appropriately and the 4hr timeout by default is causing long running syncs - This has a higher impact with less # of workers