### PR TITLE
Up UH timeout to 60sec from 30sec and log warn at 45

### DIFF
--- a/config/database_universal_housing.yml
+++ b/config/database_universal_housing.yml
@@ -5,7 +5,8 @@ default: &default
   host: <%= ENV['UH_DATABASE_HOST'] %>
   port: <%= ENV['UH_DATABASE_PORT'] %>
   database: <%= ENV['UH_DATABASE_NAME'] %>
-  timeout: 30
+  timeout: 60
+  log_warn_duration: 45
 
 development:
   <<: *default


### PR DESCRIPTION
We are seeing thousands of timeouts over the course of the week on the legacy database. 

This PR doubles the timeout to 60 seconds and make a warning log line if a query gets past 45 seconds (so we know when we are getting close to our timeout). 

Potential DB load may actually decrease as queries are retried 10 times at the moment after a timeout.