### PR TITLE
add unique index to tenancies on tenancy_ref

### DIFF
--- a/db/migrate/20181119154931_add_index_to_tenancies.rb
+++ b/db/migrate/20181119154931_add_index_to_tenancies.rb
@@ -1,0 +1,5 @@
+class AddIndexToTenancies < ActiveRecord::Migration[5.1]
+  def change
+    add_index :tenancies, :tenancy_ref, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181022140440) do
+ActiveRecord::Schema.define(version: 20181119154931) do
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20181022140440) do
     t.integer "assigned_user_id"
     t.datetime "is_paused_until"
     t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
+    t.index ["tenancy_ref"], name: "index_tenancies_on_tenancy_ref", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -8,34 +8,38 @@ module Hackney
           criteria,
           weightings
         )
+        begin
+          Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).tap do |tenancy|
+            tenancy.update(
+              priority_band: priority_band,
+              priority_score: priority_score,
 
-        Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).tap do |tenancy|
-          tenancy.update(
-            priority_band: priority_band,
-            priority_score: priority_score,
+              balance_contribution: score_calculator.balance,
+              days_in_arrears_contribution: score_calculator.days_in_arrears,
+              days_since_last_payment_contribution: score_calculator.days_since_last_payment,
+              payment_amount_delta_contribution: score_calculator.payment_amount_delta,
+              payment_date_delta_contribution: score_calculator.payment_date_delta,
+              number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
+              active_agreement_contribution: score_calculator.active_agreement,
+              broken_court_order_contribution: score_calculator.broken_court_order,
+              nosp_served_contribution: score_calculator.nosp_served,
+              active_nosp_contribution: score_calculator.active_nosp,
 
-            balance_contribution: score_calculator.balance,
-            days_in_arrears_contribution: score_calculator.days_in_arrears,
-            days_since_last_payment_contribution: score_calculator.days_since_last_payment,
-            payment_amount_delta_contribution: score_calculator.payment_amount_delta,
-            payment_date_delta_contribution: score_calculator.payment_date_delta,
-            number_of_broken_agreements_contribution: score_calculator.number_of_broken_agreements,
-            active_agreement_contribution: score_calculator.active_agreement,
-            broken_court_order_contribution: score_calculator.broken_court_order,
-            nosp_served_contribution: score_calculator.nosp_served,
-            active_nosp_contribution: score_calculator.active_nosp,
-
-            balance: criteria.balance,
-            days_in_arrears: criteria.days_in_arrears,
-            days_since_last_payment: criteria.days_since_last_payment,
-            payment_amount_delta: criteria.payment_amount_delta,
-            payment_date_delta: criteria.payment_date_delta,
-            number_of_broken_agreements: criteria.number_of_broken_agreements,
-            active_agreement: criteria.active_agreement?,
-            broken_court_order: criteria.broken_court_order?,
-            nosp_served: criteria.nosp_served?,
-            active_nosp: criteria.active_nosp?
-          )
+              balance: criteria.balance,
+              days_in_arrears: criteria.days_in_arrears,
+              days_since_last_payment: criteria.days_since_last_payment,
+              payment_amount_delta: criteria.payment_amount_delta,
+              payment_date_delta: criteria.payment_date_delta,
+              number_of_broken_agreements: criteria.number_of_broken_agreements,
+              active_agreement: criteria.active_agreement?,
+              broken_court_order: criteria.broken_court_order?,
+              nosp_served: criteria.nosp_served?,
+              active_nosp: criteria.active_nosp?
+            )
+          end
+        rescue ActiveRecord::RecordNotUnique
+          Rails.logger.error("A Tenancy with tenancy_ref: '#{tenancy_ref}'' was inserted during find_or_create_by create operation, retrying...")
+          retry
         end
       end
 

--- a/spec/models/hackney/income/models/tenancy_spec.rb
+++ b/spec/models/hackney/income/models/tenancy_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe Hackney::Income::Models::Tenancy do
+
+  context 'when trying to create 2 tenancys with the same refrence' do
+    let(:tenancy_ref) { Faker::Internet.slug }
+
+    before do
+      Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy_ref)
+    end
+
+    it 'should thow an RecordNotUnique excption on the second insert' do
+      expect do
+        Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy_ref)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end
+ 
+ 


### PR DESCRIPTION
**Before merging**

1. Shut off sync in enviroments
2. Clean up tenancy table with the following
```ruby
def delete_identical_dups()
  ten_wiht_dups = Hackney::Income::Models::Tenancy.group(:tenancy_ref, :assigned_user_id).having('count(*) > 1').size
  ten_wiht_dups.each do |key, value|
    duplicates = Hackney::Income::Models::Tenancy
    .where(tenancy_ref: key[0], assigned_user_id: key[1])
    .order(updated_at: :desc)[1..value-1]

    duplicates.each do |it|
      Hackney::Income::Models::Tenancy.delete(it.id)
    end
  end
end

def delete_dup_assinments_favoring_older()
  ten_wiht_dups = Hackney::Income::Models::Tenancy.group(:tenancy_ref).having('count(*) > 1').size
  ten_wiht_dups.each do |key, value|
    duplicates = Hackney::Income::Models::Tenancy
    .where(tenancy_ref: key)
    .order(:id)[1..value-1]

    duplicates.each do |ten|
      Hackney::Income::Models::Tenancy.delete(ten.id)
    end
  end
end
```
3. Merge and deploy