### PR TITLE
add write to action diary route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'mysql2'
 gem 'sequel'
 gem 'tiny_tds'
 
+gem 'httparty'
+
 gem 'notifications-ruby-client'
 
 gem 'daemons'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
       guard (~> 2.0)
       rubocop (~> 0.20)
     hashdiff (0.3.7)
+    httparty (0.16.3)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jwt (2.1.0)
@@ -98,9 +101,13 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.5.2)
     nenv (0.3.0)
@@ -231,6 +238,7 @@ DEPENDENCIES
   faker
   guard-rspec
   guard-rubocop
+  httparty
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)
   mysql2

--- a/app/controllers/action_diary_controller.rb
+++ b/app/controllers/action_diary_controller.rb
@@ -1,0 +1,22 @@
+class ActionDiaryController < ApplicationController
+  REQUIRED_PARAMS = %i[tenancy_ref action_code action_balance comment user_id].freeze
+
+  def create
+    begin
+      income_use_case_factory.add_action_diary.execute(action_diary_params.to_h)
+    rescue ArgumentError => e
+      render(json: { status: 'error', code: 422, message: e.message }, status: :unprocessable_entity) && (return)
+    end
+    head(:no_content)
+  end
+
+  def action_diary_params
+    params.require(REQUIRED_PARAMS)
+    allowed_params = params.permit(REQUIRED_PARAMS)
+
+    allowed_params[:action_balance] = allowed_params[:action_balance].to_f
+    allowed_params[:user_id] = allowed_params[:user_id].to_i
+
+    allowed_params
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
   def send_sms
     income_use_case_factory.send_sms.execute(
+      user_id: params.fetch(:user_id),
       tenancy_ref: params.fetch(:tenancy_ref),
       template_id: params.fetch(:template_id),
       phone_number: params.fetch(:phone_number),

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,6 +11,7 @@ class MessagesController < ApplicationController
 
   def send_email
     income_use_case_factory.send_email.execute(
+      user_id: params.fetch(:user_id),
       tenancy_ref: params.fetch(:tenancy_ref),
       template_id: params.fetch(:template_id),
       recipient: params.fetch(:email_address),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     get '/sync-cases', to: 'my_cases#sync'
     post '/users/find-or-create', to: 'users#create'
     patch '/tenancies/:tenancy_ref', to: 'tenancies#update'
+    post '/tenancies/:tenancy_ref/action_diary', to: 'action_diary#create'
     post '/messages/send_sms', to: 'messages#send_sms'
     post '/messages/send_email', to: 'messages#send_email'
     get '/messages/get_templates', to: 'messages#get_templates'

--- a/lib/hackney/income/send_email.rb
+++ b/lib/hackney/income/send_email.rb
@@ -1,12 +1,13 @@
 module Hackney
   module Income
     class SendEmail
-      def initialize(notification_gateway:)
+      def initialize(notification_gateway:, add_action_diary_usecase:)
         # @tenancy_gateway = tenancy_gateway
         @notification_gateway = notification_gateway
+        @add_action_diary_usecase = add_action_diary_usecase
       end
 
-      def execute(tenancy_ref:, recipient:, template_id:, reference:, variables:)
+      def execute(user_id:, tenancy_ref:, recipient:, template_id:, reference:, variables:)
         # tenancy = @tenancy_gateway.get_tenancy(tenancy_ref: tenancy_ref)
         # FIXME: currently not getting email addresses or saving!
         @notification_gateway.send_email(
@@ -15,12 +16,13 @@ module Hackney
           reference: reference,
           variables: variables
         )
-      end
-
-      private
-
-      def reference_for(tenancy)
-        "manual_#{tenancy.ref}"
+        @add_action_diary_usecase.execute(
+          user_id: user_id,
+          tenancy_ref: tenancy_ref,
+          action_code: '', # this needs to be decided
+          action_balance: nil,
+          comment: "An email has been sent to '#{recipient}'"
+        )
       end
     end
   end

--- a/lib/hackney/income/send_sms.rb
+++ b/lib/hackney/income/send_sms.rb
@@ -14,13 +14,14 @@ module Hackney
           reference: reference,
           variables: variables
         )
-        @add_action_diary_usecase.execute(
-          user_id: user_id,
-          tenancy_ref: tenancy_ref,
-          action_code: '', # this needs to be decided
-          action_balance: nil,
-          comment: "An SMS has been sent to '#{phone_number}'"
-        )
+        # removed until there is an agreed action_code and comment
+        # @add_action_diary_usecase.execute(
+        #   user_id: user_id,
+        #   tenancy_ref: tenancy_ref,
+        #   action_code: '',
+        #   action_balance: nil,
+        #   comment: "An SMS has been sent to '#{phone_number}'"
+        # )
       end
     end
   end

--- a/lib/hackney/income/send_sms.rb
+++ b/lib/hackney/income/send_sms.rb
@@ -1,17 +1,25 @@
 module Hackney
   module Income
     class SendSms
-      def initialize(notification_gateway:)
+      def initialize(notification_gateway:, add_action_diary_usecase:)
         @notification_gateway = notification_gateway
+        @add_action_diary_usecase = add_action_diary_usecase
       end
 
-      def execute(tenancy_ref:, template_id:, phone_number:, reference:, variables:)
+      def execute(user_id:, tenancy_ref:, template_id:, phone_number:, reference:, variables:)
         # something will be done with the tenancy_ref here later
         @notification_gateway.send_text_message(
           phone_number: phone_number,
           template_id: template_id,
           reference: reference,
           variables: variables
+        )
+        @add_action_diary_usecase.execute(
+          user_id: user_id,
+          tenancy_ref: tenancy_ref,
+          action_code: '', # this needs to be decided
+          action_balance: nil,
+          comment: "An SMS has been sent to '#{phone_number}'"
         )
       end
     end

--- a/lib/hackney/income/sql_users_gateway.rb
+++ b/lib/hackney/income/sql_users_gateway.rb
@@ -7,6 +7,10 @@ module Hackney
 
         { id: user.id, name: user.name, email: user.email, first_name: user.first_name, last_name: user.last_name, provider_permissions: user.provider_permissions }
       end
+
+      def find_user(id:)
+        Hackney::Income::Models::User.find_by(id: id)
+      end
     end
   end
 end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -38,7 +38,7 @@ module Hackney
             )
           end
         rescue ActiveRecord::RecordNotUnique
-          Rails.logger.error("A Tenancy with tenancy_ref: '#{tenancy_ref}'' was inserted during find_or_create_by create operation, retrying...")
+          Rails.logger.error("A Tenancy with tenancy_ref: '#{tenancy_ref}' was inserted during find_or_create_by create operation, retrying...")
           retry
         end
       end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -21,7 +21,8 @@ module Hackney
 
       def send_sms
         Hackney::Income::SendSms.new(
-          notification_gateway: notifications_gateway
+          notification_gateway: notifications_gateway,
+          add_action_diary_usecase: add_action_diary
         )
       end
 

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -25,6 +25,13 @@ module Hackney
         )
       end
 
+      def add_action_diary
+        Hackney::Tenancy::AddActionDiaryEntry.new(
+          action_diary_gateway: action_diary_gateway,
+          users_gateway: users_gateway
+        )
+      end
+
       def send_email
         Hackney::Income::SendEmail.new(
           notification_gateway: notifications_gateway
@@ -118,6 +125,13 @@ module Hackney
 
       def sql_tenancies_for_messages_gateway
         Hackney::Income::SqlTenanciesForMessagesGateway.new
+      end
+
+      def action_diary_gateway
+        Hackney::Tenancy::ActionDiaryGateway.new(
+          host: ENV['INCOME_COLLECTION_API_HOST'],
+          api_key: ENV['INCOME_COLLECTION_API_KEY']
+        )
       end
 
       def background_job_gateway

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -34,7 +34,8 @@ module Hackney
 
       def send_email
         Hackney::Income::SendEmail.new(
-          notification_gateway: notifications_gateway
+          notification_gateway: notifications_gateway,
+          add_action_diary_usecase: add_action_diary
         )
       end
 

--- a/lib/hackney/tenancy/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/action_diary_gateway.rb
@@ -1,0 +1,47 @@
+require 'httparty'
+
+module Hackney
+  module Tenancy
+    class ActionDiaryGateway
+      def initialize(host:, key:)
+        @action_diary_client = ActionDiary.new(host, key)
+      end
+
+      class ActionDiary
+        include HTTParty
+        base_uri @hostname
+
+        def initialize(hostname, api_key)
+          @hostname = hostname
+          @options = {
+            headers: { 'x-api-key': api_key }
+          }
+        end
+
+        def create_entry(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
+          url = File.join(@hostname + '/tenancies/arrears-action-diary')
+
+          body = {
+            tenancyAgreementRef: tenancy_ref,
+            actionCode: action_code,
+            actionBalance: action_balance,
+            comment: comment
+          }
+          body[:username] = username unless username.nil?
+
+          self.class.post(
+            url,
+            @options.merge(
+              body: body.to_json
+            )
+          )
+        end
+      end
+
+      def create_entry(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
+        Rails.logger.info('Adding comment to action diary')
+        @action_diary_client.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
+      end
+    end
+  end
+end

--- a/lib/hackney/tenancy/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/action_diary_gateway.rb
@@ -3,44 +3,30 @@ require 'httparty'
 module Hackney
   module Tenancy
     class ActionDiaryGateway
-      def initialize(host:, key:)
-        @action_diary_client = ActionDiary.new(host, key)
-      end
+      include HTTParty
 
-      class ActionDiary
-        include HTTParty
-        base_uri @hostname
-
-        def initialize(hostname, api_key)
-          @hostname = hostname
-          @options = {
-            headers: { 'x-api-key': api_key }
-          }
-        end
-
-        def create_entry(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
-          url = File.join(@hostname + '/tenancies/arrears-action-diary')
-
-          body = {
-            tenancyAgreementRef: tenancy_ref,
-            actionCode: action_code,
-            actionBalance: action_balance,
-            comment: comment
-          }
-          body[:username] = username unless username.nil?
-
-          self.class.post(
-            url,
-            @options.merge(
-              body: body.to_json
-            )
-          )
-        end
+      def initialize(host:, api_key:)
+        self.class.base_uri host
+        @options = {
+          headers: { 'x-api-key': api_key }
+        }
       end
 
       def create_entry(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
-        Rails.logger.info('Adding comment to action diary')
-        @action_diary_client.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
+        body = {
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: action_code,
+          actionBalance: action_balance,
+          comment: comment
+        }
+        body[:username] = username unless username.nil?
+
+        self.class.post(
+          '/tenancies/arrears-action-diary',
+          @options.merge(
+            body: body.to_json
+          )
+        )
       end
     end
   end

--- a/lib/hackney/tenancy/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/action_diary_gateway.rb
@@ -1,9 +1,11 @@
 require 'httparty'
+require_relative 'exceptions/tenancy_api_exception.rb'
 
 module Hackney
   module Tenancy
     class ActionDiaryGateway
       include HTTParty
+      format :json
 
       def initialize(host:, api_key:)
         self.class.base_uri host
@@ -21,12 +23,9 @@ module Hackney
         }
         body[:username] = username unless username.nil?
 
-        self.class.post(
-          '/tenancies/arrears-action-diary',
-          @options.merge(
-            body: body.to_json
-          )
-        )
+        request = self.class.post('/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
+        raise TenancyApiException unless request.success?
+        request
       end
     end
   end

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -1,0 +1,16 @@
+require 'httparty'
+
+module Hackney
+  module Tenancy
+    class AddActionDiaryEntry
+      def initialize(action_diary_gateway:)
+        @action_diary_gateway = action_diary_gateway
+      end
+
+      def execute(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
+        Rails.logger.info('Adding comment to action diary')
+        @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
+      end
+    end
+  end
+end

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -11,6 +11,11 @@ module Hackney
       def execute(tenancy_ref:, action_code:, action_balance:, comment:, user_id: nil)
         # if user_id look up
         username = user_id.nil? ? nil : @users_gateway.find_user(id: user_id)&.name
+
+        if !user_id.nil? && username.nil?
+          raise ArgumentError, 'user_id supplyed to AddActionDiaryEntry does not exist'
+        end
+
         Rails.logger.info('Adding comment to action diary')
         @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
       end

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -3,11 +3,14 @@ require 'httparty'
 module Hackney
   module Tenancy
     class AddActionDiaryEntry
-      def initialize(action_diary_gateway:)
+      def initialize(action_diary_gateway:, users_gateway:)
         @action_diary_gateway = action_diary_gateway
+        @users_gateway = users_gateway
       end
 
-      def execute(tenancy_ref:, action_code:, action_balance:, comment:, username: nil)
+      def execute(tenancy_ref:, action_code:, action_balance:, comment:, user_id: nil)
+        # if user_id look up
+        username = user_id.nil? ? nil : @users_gateway.find_user(id: user_id)&.name
         Rails.logger.info('Adding comment to action diary')
         @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
       end

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -13,7 +13,7 @@ module Hackney
         username = user_id.nil? ? nil : @users_gateway.find_user(id: user_id)&.name
 
         if !user_id.nil? && username.nil?
-          raise ArgumentError, 'user_id supplyed to AddActionDiaryEntry does not exist'
+          raise ArgumentError, 'user_id supplyed does not exist'
         end
 
         Rails.logger.info('Adding comment to action diary')

--- a/lib/hackney/tenancy/exceptions/tenancy_api_exception.rb
+++ b/lib/hackney/tenancy/exceptions/tenancy_api_exception.rb
@@ -1,0 +1,6 @@
+module Hackney
+  module Tenancy
+    class TenancyApiException < StandardError
+    end
+  end
+end

--- a/spec/controllers/action_diary_controller_spec.rb
+++ b/spec/controllers/action_diary_controller_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActionDiaryController, type: :controller do
+  let(:action_diary_params) do
+    {
+      user_id: Faker::Number.number(2).to_i,
+      tenancy_ref: Faker::Lorem.characters(8),
+      action_balance: Faker::Commerce.price,
+      action_code: Faker::Internet.slug,
+      comment: Faker::Lorem.paragraph
+    }
+  end
+
+  let(:use_case_double) { double(Hackney::Tenancy::AddActionDiaryEntry) }
+
+  before do
+    stub_const('Hackney::Tenancy::AddActionDiaryEntry', use_case_double)
+    allow(use_case_double).to receive(:new).and_return(use_case_double)
+  end
+
+  it 'should be acessable' do
+    assert_generates '/api/v1/tenancies/1234/action_diary', controller: 'action_diary', action: 'create', tenancy_ref: 1234
+  end
+
+  context 'when receiving valid params' do
+    it 'should pass the correct params to the use case' do
+      expect(use_case_double).to receive(:execute)
+        .with(action_diary_params)
+        .and_return(nil)
+        .once
+
+      patch :create, params: action_diary_params
+    end
+
+    it 'should return a 200 response' do
+      expect(use_case_double).to receive(:execute).and_return(nil).once
+      patch :create, params: action_diary_params
+      expect(response.status).to eq(204)
+    end
+  end
+
+  context 'when receiving a user id that does not exist' do
+    it 'should return a 422 error' do
+      expect(use_case_double).to receive(:execute)
+        .and_raise(ArgumentError.new('user_id supplyed does not exist'))
+        .once
+
+      patch :create, params: action_diary_params
+
+      expect(response.status).to eq(422)
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json).to eq(code: 422, message: 'user_id supplyed does not exist', status: 'error')
+    end
+  end
+end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -30,7 +30,7 @@ describe MessagesController, type: :controller do
     }
   end
 
-  let(:dummy_action_diary_gateway) { double(Hackney::Tenancy::ActionDiaryGateway) }
+  let(:dummy_action_diary_usecase) { double(Hackney::Tenancy::AddActionDiaryEntry) }
 
   before do
     stub_const(
@@ -39,9 +39,9 @@ describe MessagesController, type: :controller do
       transfer_nested_constants: true
     )
 
-    stub_const('Hackney::Tenancy::ActionDiaryGateway', dummy_action_diary_gateway)
-    allow(dummy_action_diary_gateway).to receive(:new).and_return(dummy_action_diary_gateway)
-    allow(dummy_action_diary_gateway).to receive(:create_entry)
+    stub_const('Hackney::Tenancy::AddActionDiaryEntry', dummy_action_diary_usecase)
+    allow(dummy_action_diary_usecase).to receive(:new).and_return(dummy_action_diary_usecase)
+    allow(dummy_action_diary_usecase).to receive(:execute)
   end
 
   let(:expeted_templates) do
@@ -49,8 +49,6 @@ describe MessagesController, type: :controller do
   end
 
   it 'sends an sms' do
-    expect(dummy_action_diary_gateway).to receive(:create_entry)
-
     expect_any_instance_of(Hackney::Income::SendSms).to receive(:execute).with(
       user_id: sms_params.fetch(:user_id),
       tenancy_ref: sms_params.fetch(:tenancy_ref),
@@ -66,8 +64,6 @@ describe MessagesController, type: :controller do
   end
 
   it 'sends an email' do
-    expect(dummy_action_diary_gateway).to receive(:create_entry)
-
     expect_any_instance_of(Hackney::Income::SendEmail).to receive(:execute).with(
       user_id: email_params.fetch(:user_id),
       tenancy_ref: email_params.fetch(:tenancy_ref),

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -7,6 +7,7 @@ describe MessagesController, type: :controller do
 
   let(:sms_params) do
     {
+      user_id: Faker::Number.number(2),
       tenancy_ref: "#{Faker::Number.number(8)}/#{Faker::Number.number(2)}",
       template_id: Faker::HitchhikersGuideToTheGalaxy.planet,
       phone_number: Faker::PhoneNumber.phone_number,
@@ -48,7 +49,10 @@ describe MessagesController, type: :controller do
   end
 
   it 'sends an sms' do
+    expect(dummy_action_diary_gateway).to receive(:create_entry)
+
     expect_any_instance_of(Hackney::Income::SendSms).to receive(:execute).with(
+      user_id: sms_params.fetch(:user_id),
       tenancy_ref: sms_params.fetch(:tenancy_ref),
       template_id: sms_params.fetch(:template_id),
       phone_number: sms_params.fetch(:phone_number),

--- a/spec/lib/hackney/income/send_sms_spec.rb
+++ b/spec/lib/hackney/income/send_sms_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
 describe Hackney::Income::SendSms do
-  let(:tenancy_1) { create_tenancy_model }
+  let(:tenancy) { create_tenancy_model }
   let(:notification_gateway) { Hackney::Income::StubNotificationsGateway.new }
+  let(:add_action_diary_usecase) { double(Hackney::Tenancy::AddActionDiaryEntry) }
 
   before do
-    tenancy_1.save
+    tenancy.save
   end
 
   let(:send_sms) do
     described_class.new(
       notification_gateway: notification_gateway,
-      # events_gateway: events_gateway
+      add_action_diary_usecase: add_action_diary_usecase
     )
   end
 
@@ -20,10 +21,16 @@ describe Hackney::Income::SendSms do
     let(:phone_number) { Faker::Number.leading_zero_number(11) }
     let(:reference) { Faker::Superhero.prefix }
     let(:first_name) { Faker::Superhero.name }
+    let(:user_id) { Faker::Number.number(2) }
+
+    before do
+      allow(add_action_diary_usecase).to receive(:execute)
+    end
 
     subject do
       send_sms.execute(
-        tenancy_ref: tenancy_1.tenancy_ref,
+        user_id: user_id,
+        tenancy_ref: tenancy.tenancy_ref,
         template_id: template_id,
         phone_number: phone_number,
         reference: reference,
@@ -58,6 +65,20 @@ describe Hackney::Income::SendSms do
       expect(subject).to include(
         reference: reference
       )
+    end
+
+    it 'should call action_diary_usecase' do
+      expect(add_action_diary_usecase).to receive(:execute)
+      .with(
+        user_id: user_id,
+        tenancy_ref: tenancy.tenancy_ref,
+        action_code: '', # TODO: this needs to be decided
+        action_balance: nil, # TODO: this should not be required
+        comment: "An SMS has been sent to '#{phone_number}'"
+      )
+      .once
+
+      subject
     end
   end
 end

--- a/spec/lib/hackney/income/send_sms_spec.rb
+++ b/spec/lib/hackney/income/send_sms_spec.rb
@@ -67,7 +67,7 @@ describe Hackney::Income::SendSms do
       )
     end
 
-    it 'should call action_diary_usecase' do
+    xit 'should write a entry to the action diary' do
       expect(add_action_diary_usecase).to receive(:execute)
       .with(
         user_id: user_id,

--- a/spec/lib/hackney/income/sql_users_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_users_gateway_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe Hackney::Income::SqlUsersGateway do
   let(:gateway) { described_class.new }
 
@@ -60,6 +62,36 @@ describe Hackney::Income::SqlUsersGateway do
           id: 1,
           name: 'Robert Smith'
         )
+      end
+    end
+  end
+
+  context 'when finding a individual User' do
+    subject do
+      gateway.find_user(
+        id: user.id
+      )
+    end
+
+    context 'and this user does not already exist' do
+      let(:user) do
+        Hackney::Income::Models::User.new(
+          provider_uid: 'close-to-me',
+          provider: 'universal',
+          name: 'Robert Smith',
+          email: 'old-email@the-cure.com',
+          first_name: 'Robert',
+          last_name: 'Smith',
+          provider_permissions: '12345.98765'
+        )
+      end
+
+      before do
+        user.save!
+      end
+
+      it 'should create a new User instance for that user' do
+        expect(subject).to eq(user)
       end
     end
   end

--- a/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
@@ -6,10 +6,12 @@ describe Hackney::Tenancy::ActionDiaryGateway do
   let(:tenancy_ref) { Faker::Lorem.characters(8) }
   let(:action_balance) { Faker::Commerce.price }
   let(:username) { Faker::Name.name }
+  let(:action_code) { Faker::Internet.slug }
+  let(:comment) { Faker::Lorem.paragraph }
 
   API_HEADER_NAME = 'x-api-key'.freeze
 
-  subject { described_class.new(host: host, key: key) }
+  subject { described_class.new(host: host, api_key: key) }
 
   context 'when creating an action diary entry' do
     before do
@@ -19,9 +21,9 @@ describe Hackney::Tenancy::ActionDiaryGateway do
     it 'shoud create an system entry' do
       subject.create_entry(
         tenancy_ref: tenancy_ref,
-        action_code: '111',
+        action_code: action_code,
         action_balance: action_balance,
-        comment: 'bar'
+        comment: comment
       )
 
       assert_requested(
@@ -29,9 +31,9 @@ describe Hackney::Tenancy::ActionDiaryGateway do
         headers: { API_HEADER_NAME => key },
         body: {
           tenancyAgreementRef: tenancy_ref,
-          actionCode: '111',
+          actionCode: action_code,
           actionBalance: action_balance,
-          comment: 'bar'
+          comment: comment
         }.to_json,
         times: 1
       )
@@ -39,9 +41,9 @@ describe Hackney::Tenancy::ActionDiaryGateway do
 
     it 'shoud create a entry with user user if username supplyed' do
       subject.create_entry(tenancy_ref: tenancy_ref,
-                           action_code: '111',
+                           action_code: action_code,
                            action_balance: action_balance,
-                           comment: 'bar',
+                           comment: comment,
                            username: username)
 
       assert_requested(
@@ -49,9 +51,9 @@ describe Hackney::Tenancy::ActionDiaryGateway do
         headers: { API_HEADER_NAME => key },
         body: {
           tenancyAgreementRef: tenancy_ref,
-          actionCode: '111',
+          actionCode: action_code,
           actionBalance: action_balance,
-          comment: 'bar',
+          comment: comment,
           username: username
         }.to_json,
         times: 1

--- a/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Hackney::Tenancy::ActionDiaryGateway do
+  let(:host) { Faker::Internet.url('example.com') }
+  let(:key) { SecureRandom.uuid }
+  let(:tenancy_ref) { Faker::Lorem.characters(8) }
+  let(:action_balance) { Faker::Commerce.price }
+  let(:username) { Faker::Name.name }
+
+  API_HEADER_NAME = 'x-api-key'.freeze
+
+  subject { described_class.new(host: host, key: key) }
+
+  context 'when creating an action diary entry' do
+    before do
+      stub_request(:post, /#{host}/).with(headers: { API_HEADER_NAME => key }).to_return(status: 200)
+    end
+
+    it 'shoud create an system entry' do
+      subject.create_entry(
+        tenancy_ref: tenancy_ref,
+        action_code: '111',
+        action_balance: action_balance,
+        comment: 'bar'
+      )
+
+      assert_requested(
+        :post, host + '/tenancies/arrears-action-diary',
+        headers: { API_HEADER_NAME => key },
+        body: {
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: '111',
+          actionBalance: action_balance,
+          comment: 'bar'
+        }.to_json,
+        times: 1
+      )
+    end
+
+    it 'shoud create a entry with user user if username supplyed' do
+      subject.create_entry(tenancy_ref: tenancy_ref,
+                           action_code: '111',
+                           action_balance: action_balance,
+                           comment: 'bar',
+                           username: username)
+
+      assert_requested(
+        :post, host + '/tenancies/arrears-action-diary',
+        headers: { API_HEADER_NAME => key },
+        body: {
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: '111',
+          actionBalance: action_balance,
+          comment: 'bar',
+          username: username
+        }.to_json,
+        times: 1
+      )
+    end
+  end
+end

--- a/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
@@ -60,4 +60,22 @@ describe Hackney::Tenancy::ActionDiaryGateway do
       )
     end
   end
+
+  context 'when tenancy api returns an error' do
+    before do
+      stub_request(:post, /#{host}/).with(headers: { API_HEADER_NAME => key }).to_return(status: 500)
+    end
+
+    it 'an exception should be thrown' do
+      expect {
+        subject.create_entry(
+          tenancy_ref: tenancy_ref,
+          action_code: action_code,
+          action_balance: action_balance,
+          comment: comment,
+          username: username
+        )
+      }.to raise_error(Hackney::Tenancy::TenancyApiException)
+    end
+  end
 end

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -47,7 +47,7 @@ describe Hackney::Tenancy::AddActionDiaryEntry do
     it 'should thow an invalid argument exption' do
       expect(users_gateway).to receive(:find_user).with(id: user_id).and_return(nil).once
 
-      expect { subject }.to raise_error(ArgumentError, 'user_id supplyed to AddActionDiaryEntry does not exist')
+      expect { subject }.to raise_error(ArgumentError, 'user_id supplyed does not exist')
     end
   end
 end

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Hackney::Tenancy::AddActionDiaryEntry do
+  let(:action_diary_gateway) { double(Hackney::Tenancy::ActionDiaryGateway) }
+
+  let(:usecase) { described_class.new(action_diary_gateway: action_diary_gateway) }
+
+  let(:tenancy_ref) { Faker::Lorem.characters(8) }
+  let(:action_balance) { Faker::Commerce.price }
+  let(:username) { Faker::Name.name }
+  let(:action_code) { Faker::Internet.slug }
+  let(:comment) { Faker::Lorem.paragraph }
+
+  subject { usecase.execute(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username) }
+
+  it 'should call the action_diary_gateway' do
+    expect(action_diary_gateway).to receive(:create_entry)
+      .with(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
+      .once
+
+    subject
+  end
+end

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -2,22 +2,40 @@ require 'rails_helper'
 
 describe Hackney::Tenancy::AddActionDiaryEntry do
   let(:action_diary_gateway) { double(Hackney::Tenancy::ActionDiaryGateway) }
+  let(:users_gateway) { double(Hackney::Income::SqlUsersGateway) }
 
-  let(:usecase) { described_class.new(action_diary_gateway: action_diary_gateway) }
+  let(:usecase) { described_class.new(action_diary_gateway: action_diary_gateway, users_gateway: users_gateway) }
 
   let(:tenancy_ref) { Faker::Lorem.characters(8) }
   let(:action_balance) { Faker::Commerce.price }
-  let(:username) { Faker::Name.name }
   let(:action_code) { Faker::Internet.slug }
   let(:comment) { Faker::Lorem.paragraph }
 
-  subject { usecase.execute(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username) }
+  context 'when the system wants to add an action diary message' do
+    subject { usecase.execute(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment) }
 
-  it 'should call the action_diary_gateway' do
-    expect(action_diary_gateway).to receive(:create_entry)
-      .with(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)
-      .once
+    it 'should call the action_diary_gateway' do
+      expect(action_diary_gateway).to receive(:create_entry)
+        .with(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: nil)
+        .once
 
-    subject
+      subject
+    end
+  end
+
+  context 'when a user wants to add an action diary message' do
+    let(:user) { OpenStruct.new(name: Faker::Name.name, id: Faker::Number.number(3).to_i) }
+
+    subject { usecase.execute(user_id: user.id, tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment) }
+
+    it 'should call the action_diary_gateway' do
+      expect(users_gateway).to receive(:find_user).with(id: user.id).and_return(user).once
+
+      expect(action_diary_gateway).to receive(:create_entry)
+        .with(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: user.name)
+        .once
+
+      subject
+    end
   end
 end

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -38,4 +38,16 @@ describe Hackney::Tenancy::AddActionDiaryEntry do
       subject
     end
   end
+
+  context 'when using a non existing user id' do
+    let(:user_id) { SecureRandom.uuid }
+
+    subject { usecase.execute(user_id: user_id, tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment) }
+
+    it 'should thow an invalid argument exption' do
+      expect(users_gateway).to receive(:find_user).with(id: user_id).and_return(nil).once
+
+      expect { subject }.to raise_error(ArgumentError, 'user_id supplyed to AddActionDiaryEntry does not exist')
+    end
+  end
 end


### PR DESCRIPTION
- API consumers can Post to `/tenancies/:tenancy_ref/action_diary`
- adds HTTPary as Gem
- Manual SMS/email writes to action diary (commented call/test out until action code agreed on)
