### PR TITLE
Api version in app and action diary

### DIFF
--- a/app/controllers/action_diary_controller.rb
+++ b/app/controllers/action_diary_controller.rb
@@ -3,9 +3,16 @@ class ActionDiaryController < ApplicationController
 
   def create
     begin
-      income_use_case_factory.add_action_diary.execute(action_diary_params.to_h)
+      income_use_case_factory.add_action_diary.execute(
+        tenancy_ref: action_diary_params.fetch(:tenancy_ref),
+        action_code: action_diary_params.fetch(:action_code),
+        action_balance: action_diary_params.fetch(:action_balance),
+        comment: action_diary_params.fetch(:comment),
+        user_id: action_diary_params.fetch(:user_id)
+      )
     rescue ArgumentError => e
-      render(json: { status: 'error', code: 422, message: e.message }, status: :unprocessable_entity) && (return)
+      render(json: { status: 'error', code: 422, message: e.message }, status: :unprocessable_entity)
+      return
     end
     head(:no_content)
   end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -120,8 +120,8 @@ module Hackney
 
       def tenancy_api_gateway
         Hackney::Tenancy::Gateway::TenanciesGateway.new(
-          host: ENV['INCOME_COLLECTION_API_HOST'],
-          key: ENV['INCOME_COLLECTION_API_KEY']
+          host: ENV.fetch('TENANCY_API_HOST'),
+          key: ENV.fetch('TENANCY_API_KEY')
         )
       end
 
@@ -131,8 +131,8 @@ module Hackney
 
       def action_diary_gateway
         Hackney::Tenancy::Gateway::ActionDiaryGateway.new(
-          host: ENV['INCOME_COLLECTION_API_HOST'],
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          host: ENV.fetch('TENANCY_API_HOST'),
+          api_key: ENV.fetch('TENANCY_API_KEY')
         )
       end
 

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -12,9 +12,7 @@ module Hackney
         # if user_id look up
         username = user_id.nil? ? nil : @users_gateway.find_user(id: user_id)&.name
 
-        if !user_id.nil? && username.nil?
-          raise ArgumentError, 'user_id supplied does not exist'
-        end
+        raise ArgumentError, 'user_id supplied does not exist' if !user_id.nil? && username.nil?
 
         Rails.logger.info("Adding action diary comment to #{tenancy_ref} with username '#{username}'")
         @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, action_balance: action_balance, comment: comment, username: username)

--- a/lib/hackney/tenancy/exceptions/tenancy_api_exception.rb
+++ b/lib/hackney/tenancy/exceptions/tenancy_api_exception.rb
@@ -1,6 +1,8 @@
 module Hackney
   module Tenancy
-    class TenancyApiException < StandardError
+    module Exceptions
+      class TenancyApiException < StandardError
+      end
     end
   end
 end

--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -11,7 +11,11 @@ module Hackney
         def initialize(host:, api_key:)
           self.class.base_uri host
           @options = {
-            headers: { 'x-api-key': api_key }
+            headers: {
+              'X-Api-Key': api_key,
+              'Content-Type': 'application/json',
+              'Accept': 'application/json'
+            }
           }
         end
 

--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -25,9 +25,9 @@ module Hackney
           }
           body[:username] = username unless username.nil?
 
-          request = self.class.post('/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
-          raise Hackney::Tenancy::TenancyApiException unless request.success?
-          request
+          responce = self.class.post('/api/v2/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
+          raise Hackney::Tenancy::Exceptions::TenancyApiException, responce unless responce.success?
+          responce
         end
       end
     end

--- a/lib/hackney/tenancy/gateway/tenancies_gateway.rb
+++ b/lib/hackney/tenancy/gateway/tenancies_gateway.rb
@@ -14,14 +14,14 @@ module Hackney
         def get_tenancies_by_refs(refs)
           return [] if refs.empty?
 
-          uri = URI("#{@host}/tenancies?#{params_list('tenancy_refs', refs)}")
+          uri = URI("#{@host}/api/v1/tenancies?#{params_list('tenancy_refs', refs)}")
 
           req = Net::HTTP::Get.new(uri)
           req['X-Api-Key'] = @key
 
           res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
 
-          raise Hackney::Tenancy::TenancyApiException unless res.is_a? Net::HTTPSuccess
+          raise Hackney::Tenancy::Exceptions::TenancyApiException unless res.is_a? Net::HTTPSuccess
 
           body = JSON.parse(res.body)
 

--- a/spec/controllers/action_diary_controller_spec.rb
+++ b/spec/controllers/action_diary_controller_spec.rb
@@ -20,7 +20,7 @@ describe ActionDiaryController, type: :controller do
     allow(use_case_double).to receive(:new).and_return(use_case_double)
   end
 
-  it 'should be acessable' do
+  it 'should be accessible' do
     assert_generates '/api/v1/tenancies/1234/action_diary', controller: 'action_diary', action: 'create', tenancy_ref: 1234
   end
 
@@ -44,14 +44,14 @@ describe ActionDiaryController, type: :controller do
   context 'when receiving a user id that does not exist' do
     it 'should return a 422 error' do
       expect(use_case_double).to receive(:execute)
-        .and_raise(ArgumentError.new('user_id supplyed does not exist'))
+        .and_raise(ArgumentError.new('user_id supplied does not exist'))
         .once
 
       patch :create, params: action_diary_params
 
       expect(response.status).to eq(422)
       json = JSON.parse(response.body, symbolize_names: true)
-      expect(json).to eq(code: 422, message: 'user_id supplyed does not exist', status: 'error')
+      expect(json).to eq(code: 422, message: 'user_id supplied does not exist', status: 'error')
     end
   end
 end

--- a/spec/lib/hackney/income/tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/tenancies_gateway_spec.rb
@@ -11,7 +11,7 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
       let(:refs) { %w[123] }
 
       before do
-        stub_request(:get, 'https://other.com/tenancies?tenancy_refs%5B%5D=123').with(
+        stub_request(:get, 'https://other.com/api/v1/tenancies?tenancy_refs%5B%5D=123').with(
           headers: { 'x-api-key' => 'skeleton' }
         ).to_return(
           body: { 'tenancies' => [example_tenancy] }.to_json
@@ -20,7 +20,7 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
 
       it 'should use the host' do
         subject
-        expect(WebMock).to have_requested(:get, 'https://other.com/tenancies?tenancy_refs%5B%5D=123').once
+        expect(WebMock).to have_requested(:get, 'https://other.com/api/v1/tenancies?tenancy_refs%5B%5D=123').once
       end
     end
 
@@ -36,7 +36,7 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
       let(:refs) { %w[000015/01] }
 
       before do
-        stub_request(:get, 'https://example.com/tenancies?tenancy_refs%5B%5D=000015/01').with(
+        stub_request(:get, 'https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000015/01').with(
           headers: { 'x-api-key' => 'skeleton' }
         ).to_return(
           body: { 'tenancies' => [example_tenancy] }.to_json
@@ -65,7 +65,7 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
       let(:refs) { %w[000017/01] }
 
       before do
-        stub_request(:get, 'https://example.com/tenancies?tenancy_refs%5B%5D=000017/01')
+        stub_request(:get, 'https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000017/01')
           .to_return(body: { 'tenancies' => [example_tenancy_with_nils] }.to_json)
       end
 
@@ -84,7 +84,7 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
       let(:refs) { %w[000015/01 000017/01] }
 
       before do
-        stub_request(:get, 'https://example.com/tenancies?tenancy_refs%5B%5D=000017/01&tenancy_refs%5B%5D=000015/01')
+        stub_request(:get, 'https://example.com/api/v1/tenancies?tenancy_refs%5B%5D=000017/01&tenancy_refs%5B%5D=000015/01')
           .to_return(body: { 'tenancies' => [example_tenancy, example_tenancy_with_nils] }.to_json)
       end
 

--- a/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
@@ -27,7 +27,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
       )
 
       assert_requested(
-        :post, host + '/tenancies/arrears-action-diary',
+        :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: { API_HEADER_NAME => key },
         body: {
           tenancyAgreementRef: tenancy_ref,
@@ -47,7 +47,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
                            username: username)
 
       assert_requested(
-        :post, host + '/tenancies/arrears-action-diary',
+        :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: { API_HEADER_NAME => key },
         body: {
           tenancyAgreementRef: tenancy_ref,
@@ -75,7 +75,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
           comment: comment,
           username: username
         )
-      }.to raise_error(Hackney::Tenancy::TenancyApiException)
+      }.to raise_error(Hackney::Tenancy::Exceptions::TenancyApiException)
     end
   end
 end

--- a/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/action_diary_gateway_spec.rb
@@ -9,16 +9,22 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
   let(:action_code) { Faker::Internet.slug }
   let(:comment) { Faker::Lorem.paragraph }
 
-  API_HEADER_NAME = 'x-api-key'.freeze
+  let(:required_headers) do
+    {
+      'X-Api-Key' => key,
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
+  end
 
   subject { described_class.new(host: host, api_key: key) }
 
   context 'when creating an action diary entry' do
     before do
-      stub_request(:post, /#{host}/).with(headers: { API_HEADER_NAME => key }).to_return(status: 200)
+      stub_request(:post, /#{host}/).with(headers: required_headers).to_return(status: 200)
     end
 
-    it 'shoud create an system entry' do
+    it 'should create an system entry' do
       subject.create_entry(
         tenancy_ref: tenancy_ref,
         action_code: action_code,
@@ -28,7 +34,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
 
       assert_requested(
         :post, host + '/api/v2/tenancies/arrears-action-diary',
-        headers: { API_HEADER_NAME => key },
+        headers: required_headers,
         body: {
           tenancyAgreementRef: tenancy_ref,
           actionCode: action_code,
@@ -39,7 +45,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
       )
     end
 
-    it 'shoud create a entry with user user if username supplyed' do
+    it 'should create a entry with user user if username supplied' do
       subject.create_entry(tenancy_ref: tenancy_ref,
                            action_code: action_code,
                            action_balance: action_balance,
@@ -48,7 +54,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
 
       assert_requested(
         :post, host + '/api/v2/tenancies/arrears-action-diary',
-        headers: { API_HEADER_NAME => key },
+        headers: required_headers,
         body: {
           tenancyAgreementRef: tenancy_ref,
           actionCode: action_code,
@@ -63,7 +69,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
 
   context 'when tenancy api returns an error' do
     before do
-      stub_request(:post, /#{host}/).with(headers: { API_HEADER_NAME => key }).to_return(status: 500)
+      stub_request(:post, /#{host}/).with(headers: required_headers).to_return(status: 500)
     end
 
     it 'an exception should be thrown' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Universal Housing credentials do not look like the simulator!') if ENV['UH_DATABASE_NAME'] != 'uhsimulator'
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+abort('The Rails environment is not running in test mode!') unless Rails.env.test?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+ENV['RAILS_ENV'] = 'test'
+
+ENV['TENANCY_API_HOST'] = 'example.com'
+ENV['TENANCY_API_KEY'] = '1234'
+
 require 'support/faker'
 require 'support/tenancy_helper'
 


### PR DESCRIPTION
- This moves more of the tenancy API path into the app
   - in particular, the '/api/v1' part so that v2 routes can be accessed
   - the app now uses TENANCY_API_HOST and TENANCY_API_KEY (the old env vars can be removed once deployed)

- This fixes the ActionDiaryGateway that relied on using v2 