### PR TITLE
Mr sanitizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'notifications-ruby-client'
 gem 'daemons'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
+gem 'sentry-raven'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -64,7 +65,6 @@ end
 
 group :staging, :production do
   gem 'newrelic_rpm'
-  gem 'sentry-raven'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::API
-  before_action :set_raven_context, if: :sentry_configured?
+  before_action :set_raven_context
 
   def income_use_case_factory
     @income_use_case_factory ||= Hackney::Income::UseCaseFactory.new
@@ -7,9 +7,5 @@ class ApplicationController < ActionController::API
 
   def set_raven_context
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
-  end
-
-  def sentry_configured?
-    ENV.key?('SENTRY_DSN')
   end
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters +=
+  [:password, :tenancy_ref, :email_address,
+   'first name', 'last name', 'full name']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,4 @@
 Raven.configure do |config|
+  config.dsn = ENV.fetch('SENTRY_DSN', nil)
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end if defined? Raven

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,3 @@
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end if defined? Raven

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
 Raven.configure do |config|
   config.dsn = ENV.fetch('SENTRY_DSN', nil)
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-end if defined? Raven
+end


### PR DESCRIPTION
sets up raven according to the docs and gains parity - `Raven 2.7.4 configured not to capture errors: DSN not set` for other environments.

Sanitises params with potentially identifiable data