### PR TITLE
Renaming tenancies to case priorities

### DIFF
--- a/app/models/hackney/income/models/case_priority.rb
+++ b/app/models/hackney/income/models/case_priority.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Income
     module Models
-      class Tenancy < ApplicationRecord
+      class CasePriority < ApplicationRecord
         belongs_to :assigned_user, class_name: 'Hackney::Income::Models::User', optional: true
 
         def paused?

--- a/app/models/hackney/income/models/user.rb
+++ b/app/models/hackney/income/models/user.rb
@@ -2,13 +2,15 @@ module Hackney
   module Income
     module Models
       class User < ApplicationRecord
-        has_many :tenancies, foreign_key: :assigned_user_id
+        # TODO use appropriate convention user_id
+        has_many :case_priorities, foreign_key: :assigned_user_id
 
         enum role: %i[base_user credit_controller legal_case_worker manager developer]
 
         def self.with_tenancy_counts(of_priority_band:)
           where(role: :credit_controller).all.map do |u|
-            { id: u.id, count: Hackney::Income::Models::Tenancy.where(assigned_user_id: u.id, priority_band: of_priority_band).count }
+            # TODO rework .where query to use relationship
+            { id: u.id, count: Hackney::Income::Models::CasePriority.where(assigned_user_id: u.id, priority_band: of_priority_band).count }
           end
         end
       end

--- a/app/models/hackney/income/models/user.rb
+++ b/app/models/hackney/income/models/user.rb
@@ -2,14 +2,14 @@ module Hackney
   module Income
     module Models
       class User < ApplicationRecord
-        # TODO use appropriate convention user_id
+        # TODO: use appropriate convention user_id
         has_many :case_priorities, foreign_key: :assigned_user_id
 
         enum role: %i[base_user credit_controller legal_case_worker manager developer]
 
         def self.with_tenancy_counts(of_priority_band:)
           where(role: :credit_controller).all.map do |u|
-            # TODO rework .where query to use relationship
+            # TODO: rework .where query to use relationship
             { id: u.id, count: Hackney::Income::Models::CasePriority.where(assigned_user_id: u.id, priority_band: of_priority_band).count }
           end
         end

--- a/db/migrate/20190114103101_rename_tenancies_to_case_priorities.rb
+++ b/db/migrate/20190114103101_rename_tenancies_to_case_priorities.rb
@@ -1,0 +1,9 @@
+class RenameTenanciesToCasePriorities < ActiveRecord::Migration[5.1]
+  def self.up
+    rename_table :tenancies, :case_priorities
+  end
+
+  def self.down
+    rename_table :case_priorities, :tenancies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181126112318) do
+ActiveRecord::Schema.define(version: 20190114103101) do
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
-    t.integer "attempts", default: 0, null: false
-    t.text "handler", null: false
-    t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string "locked_by"
-    t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
-  end
-
-  create_table "tenancies", force: :cascade do |t|
+  create_table "case_priorities", force: :cascade do |t|
     t.string "tenancy_ref"
     t.string "priority_band"
     t.integer "priority_score"
@@ -57,8 +42,23 @@ ActiveRecord::Schema.define(version: 20181126112318) do
     t.datetime "is_paused_until"
     t.string "pause_reason"
     t.text "pause_comment"
-    t.index ["assigned_user_id"], name: "index_tenancies_on_assigned_user_id"
-    t.index ["tenancy_ref"], name: "index_tenancies_on_tenancy_ref", unique: true
+    t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
+    t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/hackney/income/assign_tenancy_to_user.rb
+++ b/lib/hackney/income/assign_tenancy_to_user.rb
@@ -1,5 +1,6 @@
 module Hackney
   module Income
+    # TODO: rework to assign users to cases
     class AssignTenancyToUser
       def initialize(user_assignment_gateway:)
         @user_assignment_gateway = user_assignment_gateway

--- a/lib/hackney/income/sql_pause_tenancy_gateway.rb
+++ b/lib/hackney/income/sql_pause_tenancy_gateway.rb
@@ -4,10 +4,10 @@ require 'active_record/errors'
 module Hackney
   module Income
     class SqlPauseTenancyGateway
-      CaseModel = Hackney::Income::Models::CasePriority
+      GatewayModel = Hackney::Income::Models::CasePriority
 
       def set_paused_until(tenancy_ref:, until_date:, pause_reason:, pause_comment:)
-        tenancy = CaseModel.find_by(tenancy_ref: tenancy_ref)
+        tenancy = GatewayModel.find_by(tenancy_ref: tenancy_ref)
         raise "Unable to pause tenancy: #{tenancy_ref} - tenancy not found." if tenancy.nil?
         date = Time.iso8601(until_date)
         tenancy.update!(is_paused_until: date, pause_reason: pause_reason, pause_comment: pause_comment)
@@ -18,7 +18,7 @@ module Hackney
       end
 
       def get_tenancy_pause(tenancy_ref:)
-        tenancy = CaseModel.find_by(tenancy_ref: tenancy_ref)
+        tenancy = GatewayModel.find_by(tenancy_ref: tenancy_ref)
         if tenancy.nil?
           Rails.logger.error("Failed to retrieve tenancy pause with tenancy_ref: '#{tenancy_ref}' ")
           raise PauseNotFoundError, "Unable to pause tenancy: #{tenancy_ref} - tenancy not found."

--- a/lib/hackney/income/sql_pause_tenancy_gateway.rb
+++ b/lib/hackney/income/sql_pause_tenancy_gateway.rb
@@ -4,8 +4,10 @@ require 'active_record/errors'
 module Hackney
   module Income
     class SqlPauseTenancyGateway
+      CaseModel = Hackney::Income::Models::CasePriority
+
       def set_paused_until(tenancy_ref:, until_date:, pause_reason:, pause_comment:)
-        tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
+        tenancy = CaseModel.find_by(tenancy_ref: tenancy_ref)
         raise "Unable to pause tenancy: #{tenancy_ref} - tenancy not found." if tenancy.nil?
         date = Time.iso8601(until_date)
         tenancy.update!(is_paused_until: date, pause_reason: pause_reason, pause_comment: pause_comment)
@@ -16,7 +18,7 @@ module Hackney
       end
 
       def get_tenancy_pause(tenancy_ref:)
-        tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
+        tenancy = CaseModel.find_by(tenancy_ref: tenancy_ref)
         if tenancy.nil?
           Rails.logger.error("Failed to retrieve tenancy pause with tenancy_ref: '#{tenancy_ref}' ")
           raise PauseNotFoundError, "Unable to pause tenancy: #{tenancy_ref} - tenancy not found."

--- a/lib/hackney/income/sql_tenancies_matching_criteria_gateway.rb
+++ b/lib/hackney/income/sql_tenancies_matching_criteria_gateway.rb
@@ -1,8 +1,9 @@
 module Hackney
   module Income
     class SqlTenanciesMatchingCriteriaGateway
+      GatewayModel = Hackney::Income::Models::CasePriority
       def criteria_for_green_in_arrears
-        Hackney::Income::Models::Tenancy.criteria_for_green_in_arrears
+        GatewayModel.criteria_for_green_in_arrears
       end
     end
   end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -1,20 +1,22 @@
 module Hackney
   module Income
     class SqlTenancyCaseGateway
+      GatewayModel = Hackney::Income::Models::CasePriority
+
       # TODO: rename from tenancies
       def persist(tenancies:)
         tenancies.each do |tenancy|
-          Hackney::Income::Models::CasePriority.find_or_create_by!(tenancy_ref: tenancy.tenancy_ref)
+          GatewayModel.find_or_create_by!(tenancy_ref: tenancy.tenancy_ref)
         end
       end
 
       def assign_user(tenancy_ref:, user_id:)
-        tenancy = Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)
+        tenancy = GatewayModel.find_by(tenancy_ref: tenancy_ref)
         tenancy.update!(assigned_user_id: user_id)
       end
 
       def assigned_tenancies(assignee_id:)
-        Hackney::Income::Models::CasePriority
+        GatewayModel
           .where(assigned_user_id: assignee_id)
           .map { |t| { tenancy_ref: t.tenancy_ref } }
       end

--- a/lib/hackney/income/sql_tenancy_case_gateway.rb
+++ b/lib/hackney/income/sql_tenancy_case_gateway.rb
@@ -1,19 +1,20 @@
 module Hackney
   module Income
     class SqlTenancyCaseGateway
+      # TODO: rename from tenancies
       def persist(tenancies:)
         tenancies.each do |tenancy|
-          Hackney::Income::Models::Tenancy.find_or_create_by!(tenancy_ref: tenancy.tenancy_ref)
+          Hackney::Income::Models::CasePriority.find_or_create_by!(tenancy_ref: tenancy.tenancy_ref)
         end
       end
 
       def assign_user(tenancy_ref:, user_id:)
-        tenancy = Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_ref)
+        tenancy = Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)
         tenancy.update!(assigned_user_id: user_id)
       end
 
       def assigned_tenancies(assignee_id:)
-        Hackney::Income::Models::Tenancy
+        Hackney::Income::Models::CasePriority
           .where(assigned_user_id: assignee_id)
           .map { |t| { tenancy_ref: t.tenancy_ref } }
       end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -3,13 +3,15 @@
 module Hackney
   module Income
     class StoredTenanciesGateway
+      GatewayModel = Hackney::Income::Models::CasePriority
+
       def store_tenancy(tenancy_ref:, priority_band:, priority_score:, criteria:, weightings:)
         score_calculator = Hackney::Income::TenancyPrioritiser::Score.new(
           criteria,
           weightings
         )
         begin
-          Hackney::Income::Models::Tenancy.find_or_create_by(tenancy_ref: tenancy_ref).tap do |tenancy|
+          GatewayModel.find_or_create_by(tenancy_ref: tenancy_ref).tap do |tenancy|
             tenancy.update(
               priority_band: priority_band,
               priority_score: priority_score,
@@ -60,9 +62,9 @@ module Hackney
       private
 
       def tenancy_filtered_by_paused_state_for(user_id, is_paused)
-        query = Hackney::Income::Models::Tenancy.where('
-          tenancies.assigned_user_id = ? AND
-          tenancies.balance > 0', user_id)
+        query = GatewayModel.where('
+          assigned_user_id = ? AND
+          balance > ?', user_id, 0)
 
         return query if is_paused.nil?
 

--- a/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
+++ b/spec/lib/hackney/income/assign_tenancy_to_user_spec.rb
@@ -32,7 +32,7 @@ describe Hackney::Income::AssignTenancyToUser do
   end
 
   def create_assigned_tenancy_model(band:, user:)
-    Hackney::Income::Models::Tenancy.create!(
+    Hackney::Income::Models::CasePriority.create!(
       tenancy_ref: Faker::Lorem.characters(5),
       priority_band: band,
       priority_score: Faker::Lorem.characters(5),

--- a/spec/lib/hackney/income/sql_arrears_message_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_arrears_message_gateway_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
   subject { described_class.new }
+  let(:gateway_model) { described_class::GatewayModel}
+      # GatewayModel = Hackney::Income::Models::CasePriority
 
   it 'returns an empty array when critira do not match' do
     expect(subject.criteria_for_green_in_arrears).to eq([])
@@ -19,7 +21,7 @@ describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
 
     it 'returns only green tennacys' do
       expect(subject.criteria_for_green_in_arrears.count).to eq(1)
-      expect(subject.criteria_for_green_in_arrears).to all(be_an(Hackney::Income::Models::Tenancy))
+      expect(subject.criteria_for_green_in_arrears).to all(be_an(gateway_model))
     end
   end
 
@@ -35,7 +37,7 @@ describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
 
     it 'returns only tennacys that are over £9.99' do
       expect(subject.criteria_for_green_in_arrears.count).to eq(2)
-      expect(subject.criteria_for_green_in_arrears).to all(be_an(Hackney::Income::Models::Tenancy))
+      expect(subject.criteria_for_green_in_arrears).to all(be_an(gateway_model))
     end
   end
 
@@ -54,7 +56,7 @@ describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
 
     it 'returns only tennacys in arrers for more than 4 days' do
       expect(subject.criteria_for_green_in_arrears.count).to eq(num_tenancy_over_and_at_5_days)
-      expect(subject.criteria_for_green_in_arrears).to all(be_an(Hackney::Income::Models::Tenancy))
+      expect(subject.criteria_for_green_in_arrears).to all(be_an(gateway_model))
     end
   end
 
@@ -73,7 +75,7 @@ describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
 
     it 'returns only tennacys that do not have an active agrement' do
       expect(subject.criteria_for_green_in_arrears.count).to eq(num_tenancy_inactive)
-      expect(subject.criteria_for_green_in_arrears).to all(be_an(Hackney::Income::Models::Tenancy))
+      expect(subject.criteria_for_green_in_arrears).to all(be_an(gateway_model))
     end
   end
 
@@ -94,7 +96,7 @@ describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
 
     it 'returns only unpaused tenancies' do
       expect(subject.criteria_for_green_in_arrears.count).to eq(num_tenancy_unpaused)
-      expect(subject.criteria_for_green_in_arrears).to all(be_an(Hackney::Income::Models::Tenancy))
+      expect(subject.criteria_for_green_in_arrears).to all(be_an(gateway_model))
     end
   end
 end
@@ -102,7 +104,7 @@ end
 def create_tenancy(user:, band: 'green', balance: nil, days_in_arrears: nil, active_agreement: false, is_paused_until: nil)
   balance = Faker::Commerce.price(10..1000.0) if balance.nil?
   days_in_arrears = Faker::Number.between(5, 1000) if days_in_arrears.nil?
-  Hackney::Income::Models::Tenancy.create!(
+  gateway_model.create!(
     priority_band: band,
     balance: balance,
     days_in_arrears: days_in_arrears,

--- a/spec/lib/hackney/income/sql_arrears_message_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_arrears_message_gateway_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 describe Hackney::Income::SqlTenanciesMatchingCriteriaGateway do
   subject { described_class.new }
-  let(:gateway_model) { described_class::GatewayModel}
-      # GatewayModel = Hackney::Income::Models::CasePriority
+  let(:gateway_model) { described_class::GatewayModel }
 
   it 'returns an empty array when critira do not match' do
     expect(subject.criteria_for_green_in_arrears).to eq([])

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -6,6 +6,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
   let(:pause_comment) { Faker::Lorem.paragraph }
   let(:future_date) { Faker::Time.forward(23).iso8601 }
   let(:invalid_string) { SecureRandom.uuid }
+  let(:case_model) {described_class::CaseModel}
 
   subject { described_class.new }
 
@@ -56,7 +57,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
         pause_comment: pause_comment
       )
 
-      expect(Hackney::Income::Models::Tenancy.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
+      expect(case_model.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
     end
   end
 

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -6,7 +6,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
   let(:pause_comment) { Faker::Lorem.paragraph }
   let(:future_date) { Faker::Time.forward(23).iso8601 }
   let(:invalid_string) { SecureRandom.uuid }
-  let(:case_model) { described_class::CaseModel }
+  let(:gateway_model) { described_class::GatewayModel }
 
   subject { described_class.new }
 
@@ -57,7 +57,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
         pause_comment: pause_comment
       )
 
-      expect(case_model.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
+      expect(gateway_model.find_by(tenancy_ref: tenancy_1.tenancy_ref).paused?).to be(true)
     end
   end
 

--- a/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_pause_tenancy_gateway_spec.rb
@@ -6,7 +6,7 @@ describe Hackney::Income::SqlPauseTenancyGateway do
   let(:pause_comment) { Faker::Lorem.paragraph }
   let(:future_date) { Faker::Time.forward(23).iso8601 }
   let(:invalid_string) { SecureRandom.uuid }
-  let(:case_model) {described_class::CaseModel}
+  let(:case_model) { described_class::CaseModel }
 
   subject { described_class.new }
 

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Hackney::Income::SqlTenancyCaseGateway do
   subject { described_class.new }
+  let(:tenancy_model) { Hackney::Income::Models::CasePriority }
 
   context 'when persisting tenancies which do not exist in the database' do
     let(:tenancies) do
@@ -15,7 +16,7 @@ describe Hackney::Income::SqlTenancyCaseGateway do
 
     it 'should save the tenancies in the database' do
       tenancies.each do |tenancy|
-        expect(Hackney::Income::Models::Tenancy.exists?(tenancy_ref: tenancy.tenancy_ref)).to be_truthy
+        expect(tenancy_model.exists?(tenancy_ref: tenancy.tenancy_ref)).to be_truthy
       end
     end
   end
@@ -23,7 +24,7 @@ describe Hackney::Income::SqlTenancyCaseGateway do
   context 'when persisting a tenancy which already exists in the database' do
     let(:tenancy) { create_tenancy_model }
     let(:existing_tenancy_record) do
-      Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy.tenancy_ref)
+      tenancy_model.create!(tenancy_ref: tenancy.tenancy_ref)
     end
 
     before do
@@ -32,13 +33,13 @@ describe Hackney::Income::SqlTenancyCaseGateway do
     end
 
     it 'should not create a new record' do
-      expect(Hackney::Income::Models::Tenancy.count).to eq(1)
+      expect(tenancy_model.count).to eq(1)
     end
   end
 
   context 'when assigning a user to a case' do
     let!(:tenancy_ref) { Faker::Number.number(6) }
-    let!(:tenancy) { Hackney::Income::Models::Tenancy.create(tenancy_ref: tenancy_ref) }
+    let!(:tenancy) { tenancy_model.create(tenancy_ref: tenancy_ref) }
     let!(:user) { Hackney::Income::Models::User.create }
 
     it 'should assign the user' do
@@ -150,15 +151,15 @@ describe Hackney::Income::SqlTenancyCaseGateway do
           user_f = Hackney::Income::Models::User.create!(role: :base_user)
           user_g = Hackney::Income::Models::User.create!(role: :legal_case_worker)
 
-          tenancy_a = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_b = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_c = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_d = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_e = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_f = Hackney::Income::Models::Tenancy.create!(priority_band: 'red')
-          tenancy_g = Hackney::Income::Models::Tenancy.create!(priority_band: 'green')
-          tenancy_h = Hackney::Income::Models::Tenancy.create!(priority_band: 'green')
-          tenancy_i = Hackney::Income::Models::Tenancy.create!(priority_band: 'green')
+          tenancy_a = tenancy_model.create!(priority_band: 'red')
+          tenancy_b = tenancy_model.create!(priority_band: 'red')
+          tenancy_c = tenancy_model.create!(priority_band: 'red')
+          tenancy_d = tenancy_model.create!(priority_band: 'red')
+          tenancy_e = tenancy_model.create!(priority_band: 'red')
+          tenancy_f = tenancy_model.create!(priority_band: 'red')
+          tenancy_g = tenancy_model.create!(priority_band: 'green')
+          tenancy_h = tenancy_model.create!(priority_band: 'green')
+          tenancy_i = tenancy_model.create!(priority_band: 'green')
 
           subject.assign_to_next_available_user(tenancy: tenancy_a)
           subject.assign_to_next_available_user(tenancy: tenancy_b)
@@ -170,13 +171,13 @@ describe Hackney::Income::SqlTenancyCaseGateway do
           subject.assign_to_next_available_user(tenancy: tenancy_h)
           subject.assign_to_next_available_user(tenancy: tenancy_i)
 
-          expect(user_a.tenancies.count).to eq(3)
-          expect(user_b.tenancies.count).to eq(2)
-          expect(user_c.tenancies.count).to eq(2)
-          expect(user_d.tenancies.count).to eq(1)
-          expect(user_e.tenancies.count).to eq(1)
-          expect(user_f.tenancies.count).to eq(0)
-          expect(user_g.tenancies.count).to eq(0)
+          expect(user_a.case_priorities.count).to eq(3)
+          expect(user_b.case_priorities.count).to eq(2)
+          expect(user_c.case_priorities.count).to eq(2)
+          expect(user_d.case_priorities.count).to eq(1)
+          expect(user_e.case_priorities.count).to eq(1)
+          expect(user_f.case_priorities.count).to eq(0)
+          expect(user_g.case_priorities.count).to eq(0)
         end
       end
     end
@@ -184,11 +185,11 @@ describe Hackney::Income::SqlTenancyCaseGateway do
 
   def persist_new_tenancy
     tenancy = create_tenancy_model
-    Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy.tenancy_ref)
+    tenancy_model.create!(tenancy_ref: tenancy.tenancy_ref)
   end
 
   def create_assigned_tenancy_model(band:, user:)
-    Hackney::Income::Models::Tenancy.create!(
+    tenancy_model.create!(
       tenancy_ref: Faker::Lorem.characters(5),
       priority_band: band,
       priority_score: Faker::Lorem.characters(5),

--- a/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
+++ b/spec/lib/hackney/income/sql_tenancy_case_gateway_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Hackney::Income::SqlTenancyCaseGateway do
   subject { described_class.new }
-  let(:tenancy_model) { Hackney::Income::Models::CasePriority }
+  let(:gateway_model) { described_class::GatewayModel }
 
   context 'when persisting tenancies which do not exist in the database' do
     let(:tenancies) do
@@ -16,7 +16,7 @@ describe Hackney::Income::SqlTenancyCaseGateway do
 
     it 'should save the tenancies in the database' do
       tenancies.each do |tenancy|
-        expect(tenancy_model.exists?(tenancy_ref: tenancy.tenancy_ref)).to be_truthy
+        expect(gateway_model.exists?(tenancy_ref: tenancy.tenancy_ref)).to be_truthy
       end
     end
   end
@@ -24,7 +24,7 @@ describe Hackney::Income::SqlTenancyCaseGateway do
   context 'when persisting a tenancy which already exists in the database' do
     let(:tenancy) { create_tenancy_model }
     let(:existing_tenancy_record) do
-      tenancy_model.create!(tenancy_ref: tenancy.tenancy_ref)
+      gateway_model.create!(tenancy_ref: tenancy.tenancy_ref)
     end
 
     before do
@@ -33,13 +33,13 @@ describe Hackney::Income::SqlTenancyCaseGateway do
     end
 
     it 'should not create a new record' do
-      expect(tenancy_model.count).to eq(1)
+      expect(gateway_model.count).to eq(1)
     end
   end
 
   context 'when assigning a user to a case' do
     let!(:tenancy_ref) { Faker::Number.number(6) }
-    let!(:tenancy) { tenancy_model.create(tenancy_ref: tenancy_ref) }
+    let!(:tenancy) { gateway_model.create(tenancy_ref: tenancy_ref) }
     let!(:user) { Hackney::Income::Models::User.create }
 
     it 'should assign the user' do
@@ -151,15 +151,15 @@ describe Hackney::Income::SqlTenancyCaseGateway do
           user_f = Hackney::Income::Models::User.create!(role: :base_user)
           user_g = Hackney::Income::Models::User.create!(role: :legal_case_worker)
 
-          tenancy_a = tenancy_model.create!(priority_band: 'red')
-          tenancy_b = tenancy_model.create!(priority_band: 'red')
-          tenancy_c = tenancy_model.create!(priority_band: 'red')
-          tenancy_d = tenancy_model.create!(priority_band: 'red')
-          tenancy_e = tenancy_model.create!(priority_band: 'red')
-          tenancy_f = tenancy_model.create!(priority_band: 'red')
-          tenancy_g = tenancy_model.create!(priority_band: 'green')
-          tenancy_h = tenancy_model.create!(priority_band: 'green')
-          tenancy_i = tenancy_model.create!(priority_band: 'green')
+          tenancy_a = gateway_model.create!(priority_band: 'red')
+          tenancy_b = gateway_model.create!(priority_band: 'red')
+          tenancy_c = gateway_model.create!(priority_band: 'red')
+          tenancy_d = gateway_model.create!(priority_band: 'red')
+          tenancy_e = gateway_model.create!(priority_band: 'red')
+          tenancy_f = gateway_model.create!(priority_band: 'red')
+          tenancy_g = gateway_model.create!(priority_band: 'green')
+          tenancy_h = gateway_model.create!(priority_band: 'green')
+          tenancy_i = gateway_model.create!(priority_band: 'green')
 
           subject.assign_to_next_available_user(tenancy: tenancy_a)
           subject.assign_to_next_available_user(tenancy: tenancy_b)
@@ -185,11 +185,11 @@ describe Hackney::Income::SqlTenancyCaseGateway do
 
   def persist_new_tenancy
     tenancy = create_tenancy_model
-    tenancy_model.create!(tenancy_ref: tenancy.tenancy_ref)
+    gateway_model.create!(tenancy_ref: tenancy.tenancy_ref)
   end
 
   def create_assigned_tenancy_model(band:, user:)
-    tenancy_model.create!(
+    gateway_model.create!(
       tenancy_ref: Faker::Lorem.characters(5),
       priority_band: band,
       priority_score: Faker::Lorem.characters(5),

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 describe Hackney::Income::StoredTenanciesGateway do
   let(:gateway) { described_class.new }
 
+  let(:tenancy_model) { Hackney::Income::Models::CasePriority }
+
   context 'when storing a tenancy' do
     let(:attributes) do
       {
@@ -34,7 +36,7 @@ describe Hackney::Income::StoredTenanciesGateway do
     end
 
     context 'and the tenancy does not already exist' do
-      let(:created_tenancy) { Hackney::Income::Models::Tenancy.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
+      let(:created_tenancy) { tenancy_model.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
 
       it 'should create the tenancy' do
         store_tenancy
@@ -49,7 +51,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
     context 'and the tenancy already exists' do
       let!(:pre_existing_tenancy) do
-        Hackney::Income::Models::Tenancy.create!(
+        tenancy_model.create!(
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
           priority_score: attributes.fetch(:priority_score),
@@ -78,7 +80,7 @@ describe Hackney::Income::StoredTenanciesGateway do
         )
       end
 
-      let(:stored_tenancy) { Hackney::Income::Models::Tenancy.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
+      let(:stored_tenancy) { tenancy_model.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
 
       it 'should update the tenancy' do
         store_tenancy
@@ -87,7 +89,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
       it 'should not create a new tenancy' do
         store_tenancy
-        expect(Hackney::Income::Models::Tenancy.count).to eq(1)
+        expect(tenancy_model.count).to eq(1)
       end
 
       # FIXME: shouldn't return AR models from gateways
@@ -127,7 +129,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       end
 
       before do
-        Hackney::Income::Models::Tenancy.create!(
+        tenancy_model.create!(
           assigned_user_id: user_id,
           tenancy_ref: attributes.fetch(:tenancy_ref),
           priority_band: attributes.fetch(:priority_band),
@@ -178,7 +180,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'and the tenancies exist' do
         before do
           multiple_attributes.map do |attributes|
-            Hackney::Income::Models::Tenancy.create!(
+            tenancy_model.create!(
               assigned_user_id: user_id,
               tenancy_ref: attributes.fetch(:tenancy_ref),
               priority_band: attributes.fetch(:priority_band),
@@ -257,9 +259,9 @@ describe Hackney::Income::StoredTenanciesGateway do
 
     context 'and tenancies exist which aren\'t assigned to the user' do
       before do
-        Hackney::Income::Models::Tenancy.create!(assigned_user_id: user_id, balance: 1)
-        Hackney::Income::Models::Tenancy.create!(assigned_user_id: other_user_id, balance: 1)
-        Hackney::Income::Models::Tenancy.create!(assigned_user_id: user_id, balance: 1)
+        tenancy_model.create!(assigned_user_id: user_id, balance: 1)
+        tenancy_model.create!(assigned_user_id: other_user_id, balance: 1)
+        tenancy_model.create!(assigned_user_id: user_id, balance: 1)
       end
 
       it 'should only return the user\'s tenancies' do
@@ -409,7 +411,7 @@ describe Hackney::Income::StoredTenanciesGateway do
   end
 
   def create_tenancy(user_id: nil, balance: 1, is_paused_until: nil)
-    Hackney::Income::Models::Tenancy.create(assigned_user_id: user_id, balance: balance, is_paused_until: is_paused_until)
+    tenancy_model.create(assigned_user_id: user_id, balance: balance, is_paused_until: is_paused_until)
   end
 
   def expected_serialised_tenancy(attributes)

--- a/spec/models/hackney/income/models/case_priorities_spec.rb
+++ b/spec/models/hackney/income/models/case_priorities_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-describe Hackney::Income::Models::Tenancy do
+describe Hackney::Income::Models::CasePriority do
   context 'when trying to create 2 tenancies with the same reference' do
     let(:tenancy_ref) { Faker::Internet.slug }
 
     before do
-      Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy_ref)
+      described_class.create!(tenancy_ref: tenancy_ref)
     end
 
     it 'should throw an RecordNotUnique exception on the second insert' do
       expect do
-        Hackney::Income::Models::Tenancy.create!(tenancy_ref: tenancy_ref)
+        described_class.create!(tenancy_ref: tenancy_ref)
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end

--- a/spec/support/tenancy_helper.rb
+++ b/spec/support/tenancy_helper.rb
@@ -64,8 +64,9 @@ module TenancyHelper
     )
   end
 
+  # TODO: rename with CasePriority
   def create_tenancy_model
-    Hackney::Income::Models::Tenancy.new.tap do |t|
+    Hackney::Income::Models::CasePriority.new.tap do |t|
       t.tenancy_ref = Faker::Lorem.characters(5)
       t.priority_band = Faker::Lorem.characters(5)
       t.priority_score = Faker::Lorem.characters(5)


### PR DESCRIPTION
Step #1 in making tenancies generic enough to support cases
Renames the tables and cleans the relationships between models, gateways, etc.

Includes NO functional changes to the existing api.