### PR TITLE
Sms content in action diary

### DIFF
--- a/lib/hackney/income/domain/notification_receipt.rb
+++ b/lib/hackney/income/domain/notification_receipt.rb
@@ -4,6 +4,10 @@ module Hackney
       class NotificationReceipt
         attr_accessor :body
 
+        def initialize(body:)
+          @body = body
+        end
+
         def body_without_newlines
           @body&.squish
         end

--- a/lib/hackney/income/domain/notification_receipt.rb
+++ b/lib/hackney/income/domain/notification_receipt.rb
@@ -1,0 +1,13 @@
+module Hackney
+  module Income
+    module Domain
+      class NotificationReceipt
+        attr_accessor :body
+
+        def body_without_newlines
+          @body&.squish
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/gov_notify_gateway.rb
+++ b/lib/hackney/income/gov_notify_gateway.rb
@@ -12,22 +12,24 @@ module Hackney
       end
 
       def send_text_message(phone_number:, template_id:, reference:, variables:)
-        @client.send_sms(
+        responce = @client.send_sms(
           phone_number: pre_release_phone_number(phone_number),
           template_id: template_id,
           personalisation: variables,
           reference: reference,
           sms_sender_id: @sms_sender_id
         )
+        create_notification_receipt(responce)
       end
 
       def send_email(recipient:, template_id:, reference:, variables:)
-        @client.send_email(
+        responce = @client.send_email(
           email_address: pre_release_email(recipient),
           template_id: template_id,
           personalisation: variables,
           reference: reference
         )
+        create_notification_receipt(responce)
       end
 
       def get_template_name(template_id)
@@ -44,6 +46,12 @@ module Hackney
       end
 
       private
+
+      def create_notification_receipt(responce)
+        Hackney::Income::Domain::NotificationReceipt.new.tap do |notification_receipt|
+          notification_receipt.body = responce.content&.fetch('body', nil)
+        end
+      end
 
       def all_templates_request
         @client.get_all_templates.collection.map do |template|

--- a/lib/hackney/income/gov_notify_gateway.rb
+++ b/lib/hackney/income/gov_notify_gateway.rb
@@ -48,9 +48,8 @@ module Hackney
       private
 
       def create_notification_receipt(responce)
-        Hackney::Income::Domain::NotificationReceipt.new.tap do |notification_receipt|
-          notification_receipt.body = responce.content&.fetch('body', nil)
-        end
+        body = responce.content&.fetch('body', nil)
+        Hackney::Income::Domain::NotificationReceipt.new(body: body)
       end
 
       def all_templates_request

--- a/lib/hackney/income/send_automated_sms.rb
+++ b/lib/hackney/income/send_automated_sms.rb
@@ -11,7 +11,7 @@ module Hackney
       def execute(tenancy_ref:, template_id:, phone_number:, reference:, variables:)
         phone = Phonelib.parse(phone_number)
         if phone.valid?
-          @notification_gateway.send_text_message(
+          notification_receipt = @notification_gateway.send_text_message(
             phone_number: phone.full_e164,
             template_id: template_id,
             reference: reference,
@@ -23,7 +23,7 @@ module Hackney
           @background_job_gateway.add_action_diary_entry(
             tenancy_ref: tenancy_ref,
             action_code: Hackney::Tenancy::ActionCodes::AUTOMATED_SMS_ACTION_CODE,
-            comment: "'#{template_name}' SMS sent to '#{phone.full_e164}'"
+            comment: "'#{template_name}' SMS sent to '#{phone.full_e164}' with content '#{notification_receipt.body_without_newlines}'"
           )
         else
           # don't log the phone number to keep our logs free from personal data

--- a/spec/lib/hackney/income/domain/notification_receipt_spec.rb
+++ b/spec/lib/hackney/income/domain/notification_receipt_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 describe Hackney::Income::Domain::NotificationReceipt do
   subject do
-    described_class.new.tap do |nr|
-      nr.body = body
-    end
+    described_class.new(body: body)
   end
 
   context 'with a nil body' do

--- a/spec/lib/hackney/income/domain/notification_receipt_spec.rb
+++ b/spec/lib/hackney/income/domain/notification_receipt_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Hackney::Income::Domain::NotificationReceipt do
+  subject do
+    described_class.new.tap do |nr|
+      nr.body = body
+    end
+  end
+
+  context 'with a nil body' do
+    let(:body) { nil }
+
+    it 'does not throw when body_without_newlines' do
+      expect(subject.body_without_newlines).to eq(nil)
+    end
+  end
+
+  context 'with a body that contains newlines' do
+    let(:body) { "some body\n text with perhaps a \newline?" }
+
+    it 'is stripped away with body_without_newlines' do
+      expect(subject.body_without_newlines).to eq('some body text with perhaps a ewline?')
+    end
+  end
+end

--- a/spec/lib/hackney/income/send_automated_sms_spec.rb
+++ b/spec/lib/hackney/income/send_automated_sms_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Hackney::Income::SendAutomatedSms do
   let(:tenancy) { create_tenancy_model }
   let(:notification_gateway) { instance_double(Hackney::Income::GovNotifyGateway) }
-  let(:send_responce) { Hackney::Income::Domain::NotificationReceipt.new }
+  let(:send_responce) { Hackney::Income::Domain::NotificationReceipt.new(body: nil) }
   let(:background_job_gateway) { double(Hackney::Income::BackgroundJobGateway) }
   let(:gov_notify_template_name) { Faker::Superhero.name }
   let(:send_sms) do
@@ -80,9 +80,9 @@ describe Hackney::Income::SendAutomatedSms do
 
       context 'when a message body is returned' do
         let(:send_responce) do
-          Hackney::Income::Domain::NotificationReceipt.new.tap do |nr|
-            nr.body = "some body text with perhaps a \newline?"
-          end
+          Hackney::Income::Domain::NotificationReceipt.new(
+            body: "some body text with perhaps a \newline?"
+          )
         end
 
         it 'queues a job to write to the action diary' do

--- a/spec/lib/hackney/income/send_automated_sms_spec.rb
+++ b/spec/lib/hackney/income/send_automated_sms_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe Hackney::Income::SendAutomatedSms do
   let(:tenancy) { create_tenancy_model }
-  let(:notification_gateway) { double(Hackney::Income::GovNotifyGateway) }
+  let(:notification_gateway) { instance_double(Hackney::Income::GovNotifyGateway) }
+  let(:send_responce) { Hackney::Income::Domain::NotificationReceipt.new }
   let(:background_job_gateway) { double(Hackney::Income::BackgroundJobGateway) }
   let(:gov_notify_template_name) { Faker::Superhero.name }
   let(:send_sms) do
@@ -40,15 +41,14 @@ describe Hackney::Income::SendAutomatedSms do
 
       it 'passes vars to the gateway' do
         allow(background_job_gateway).to receive(:add_action_diary_entry)
-        expect(notification_gateway).to receive(:send_text_message)
-          .with(
-            variables: {
-              'first name': first_name
-            },
-            phone_number: e164_phone_number,
-            template_id: template_id,
-            reference: reference
-          ).once
+        expect(notification_gateway).to receive(:send_text_message).with(
+          variables: {
+            'first name': first_name
+          },
+          phone_number: e164_phone_number,
+          template_id: template_id,
+          reference: reference
+        ).and_return(send_responce).once
         subject
       end
 
@@ -58,20 +58,43 @@ describe Hackney::Income::SendAutomatedSms do
         expect(notification_gateway)
           .to receive(:send_text_message)
           .with(include(phone_number: e164_phone_number))
+          .and_return(send_responce)
           .once
 
         subject
       end
 
       it 'queues a job to write to the action diary' do
-        allow(notification_gateway).to receive(:send_text_message)
-        expect(background_job_gateway).to receive(:add_action_diary_entry)
-          .with(
+        expect(notification_gateway).to receive(:send_text_message)
+          .and_return(send_responce)
+          .once
+
+        expect(background_job_gateway).to receive(:add_action_diary_entry).with(
+          a_hash_including(
             tenancy_ref: tenancy.tenancy_ref,
-            action_code: Hackney::Tenancy::ActionCodes::AUTOMATED_SMS_ACTION_CODE,
-            comment: "'#{gov_notify_template_name}' SMS sent to '#{e164_phone_number}'"
+            action_code: Hackney::Tenancy::ActionCodes::AUTOMATED_SMS_ACTION_CODE
           )
+        ).once
         subject
+      end
+
+      context 'when a message body is returned' do
+        let(:send_responce) do
+          Hackney::Income::Domain::NotificationReceipt.new.tap do |nr|
+            nr.body = "some body text with perhaps a \newline?"
+          end
+        end
+
+        it 'queues a job to write to the action diary' do
+          expect(notification_gateway).to receive(:send_text_message).and_return(send_responce).once
+
+          expect(background_job_gateway).to receive(:add_action_diary_entry)
+            .with(a_hash_including(
+                    comment: "'#{gov_notify_template_name}' SMS sent to '#{e164_phone_number}' with content 'some body text with perhaps a ewline?'"
+                  )).once
+
+          subject
+        end
       end
     end
 

--- a/spec/lib/hackney/tenancy/gateway/contacts_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/gateway/contacts_gateway_spec.rb
@@ -24,7 +24,7 @@ describe Hackney::Tenancy::Gateway::ContactsGateway do
       expect(WebMock).to have_requested(:get, hostname + "/api/v1/tenancies/#{tenancy_ref_url_encoded}/contacts").once
     end
 
-    it 'returns an array of Hackney::Income::Domain::Contact objects' do
+    it 'returns an array of Hackney::Income::domain::Contact objects' do
       expect(subject).to all(be_an(Hackney::Income::Domain::Contact))
     end
 

--- a/spec/support/stubs/stub_notifications_gateway.rb
+++ b/spec/support/stubs/stub_notifications_gateway.rb
@@ -35,6 +35,7 @@ module Hackney
           reference: reference,
           variables: variables
         }
+        Hackney::Income::Domain::NotificationReceipt.new
       end
 
       def send_email(recipient:, template_id:, reference:, variables:)
@@ -44,6 +45,7 @@ module Hackney
           reference: reference,
           variables: variables
         }
+        Hackney::Income::Domain::NotificationReceipt.new
       end
     end
   end

--- a/spec/support/stubs/stub_notifications_gateway.rb
+++ b/spec/support/stubs/stub_notifications_gateway.rb
@@ -35,7 +35,8 @@ module Hackney
           reference: reference,
           variables: variables
         }
-        Hackney::Income::Domain::NotificationReceipt.new
+        body = @templates.find { |template| template[:id] == template_id }&.body
+        Hackney::Income::Domain::NotificationReceipt.new(body: body)
       end
 
       def send_email(recipient:, template_id:, reference:, variables:)
@@ -45,7 +46,8 @@ module Hackney
           reference: reference,
           variables: variables
         }
-        Hackney::Income::Domain::NotificationReceipt.new
+        body = @templates.find { |template| template[:id] == template_id }&.body
+        Hackney::Income::Domain::NotificationReceipt.new(body: body)
       end
     end
   end


### PR DESCRIPTION
~Do not merge until #104 is merged~

- GovNotifyGateway returns the "notification_receipt" domain object that contains the body of the sent message

- This is used to create the action diary message

