### PR TITLE
Add conversion to bigdecimal to fix bigdecimal-float comparison flaky…

### DIFF
--- a/spec/hackney/income/jobs/send_green_in_arrears_msg_job_spec.rb
+++ b/spec/hackney/income/jobs/send_green_in_arrears_msg_job_spec.rb
@@ -6,7 +6,7 @@ describe Hackney::Income::Jobs::SendGreenInArrearsMsgJob do
   let(:mock_automated_message) { instance_double(Hackney::Income::SendAutomatedMessageToTenancy) }
   let(:mock_automated_message_class) { class_double(Hackney::Income::SendAutomatedMessageToTenancy) }
   let(:tenancy_ref) { Faker::Internet.slug }
-  let(:balance) { Faker::Commerce.price(100.0..199.99) }
+  let(:balance) { Faker::Commerce.price.to_d }
   let(:case_id) { Faker::Number.number }
 
   before do


### PR DESCRIPTION
This fix a flaky test due to  comparison of random float to bigdecimal (without explicit conversion)