### PR TITLE
Add expiration to SendGreenInArrearsMsgJob

### DIFF
--- a/spec/hackney/income/jobs/send_green_in_arrears_msg_job_spec.rb
+++ b/spec/hackney/income/jobs/send_green_in_arrears_msg_job_spec.rb
@@ -39,4 +39,31 @@ describe Hackney::Income::Jobs::SendGreenInArrearsMsgJob do
       subject.set(wait_until: Time.now + 5.minutes).perform_later
     end.not_to raise_error
   end
+
+  describe 'job expiration' do
+    let(:job) { Delayed::Job.last }
+
+    before do
+      subject.perform_later(case_id: case_id)
+    end
+
+    context 'when the job was created 5 or more days ago' do
+      it 'does not send the message' do
+        job.update(created_at: Time.now - 5.days)
+
+        expect(mock_automated_message).not_to receive(:execute)
+        expect { job.invoke_job }.to raise_error('Error: Job expired!')
+      end
+    end
+
+    context 'when the job was created less than 5 days' do
+      it 'sends the message' do
+        job.update(created_at: Time.now - 5.days + 1.hour)
+
+        expect(mock_automated_message).to receive(:execute)
+
+        job.invoke_job
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add expiration to SendGreenInArrearsMsgJob.
If the job is older than 5 days, it raises an error and do not send the SMS.

Trello: https://trello.com/b/hCjSOWHF/hackney-ic-iteration-board
