### PR TITLE
Add default pr reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# doc for this file https://help.github.com/articles/about-code-owners/
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+*       @cob16 @alexdesi @mrosel @elena-vi


### PR DESCRIPTION
This uses Github's [documented method](https://help.github.com/articles/about-code-owners/) of created default reviewers using a code owners file