### PR TITLE
remove default running and rely on external

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,3 @@ RUN bundle check || bundle install
 
 COPY . /app
 EXPOSE 3000
-
-CMD ["sh", "-c", "rails db:migrate ; rails s"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - universal_housing
     volumes:
       - .:/app
+    command: sh -c 'rails db:migrate ; rails s'
   universal_housing:
     image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - universal_housing
     volumes:
       - .:/app
-    command: sh -c 'rails db:migrate ; rails s'
+    command: sh -c 'rails db:migrate && rails s'
   universal_housing:
     image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:latest
     ports:


### PR DESCRIPTION
Preserves the functionality when using makefile - but won't leave dangling containers on AWS