### PR TITLE
Add queue support for cloud storage + bug fix on cloud_storage.rake

### DIFF
--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -8,7 +8,7 @@ require 'delayed/command'
 job_identifier_prefix = '--identifier=' + rand(1_000...1_000_000).to_s
 
 queues = [
-  '--queues=action_diary_writer,message_jobs,uh_sync_cases'
+  '--queues=action_diary_writer,message_jobs,uh_sync_cases,cloud_storage'
   # this is currency being used with the 'run' command,
   # this seems to disable separate threads. Therefore until:
   #  - jobs are run using 'start'

--- a/lib/tasks/income/cloud_storage.rake
+++ b/lib/tasks/income/cloud_storage.rake
@@ -3,7 +3,7 @@ namespace :cloud do
   task :save, [:filename] do |_task, args|
     puts 'Saving to the cloud'
 
-    storage = Hackney::Cloud::Storage.new(Rails.configuration.cloud_adapter, Hackney::Document)
+    storage = Hackney::Cloud::Storage.new(Rails.configuration.cloud_adapter, Hackney::Cloud::Document)
     response = storage.save(args[:filename])
 
     if response[:errors].empty?


### PR DESCRIPTION
This PR
- Setup the `cloud_storage` to be processed
- Bug fix in the rake task
