### PR TITLE
faker temporarily moving into production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'puma', '~> 3.7'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'faker'
 
 gem 'httparty'
 gem 'mysql2'
@@ -52,7 +53,6 @@ group :development, :test do
   gem 'brakeman', '~> 4.3', '>= 4.3.1'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot'
-  gem 'faker'
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'rspec-its'

--- a/lib/hackney/service_charge/gateway/service_charge_adapter.rb
+++ b/lib/hackney/service_charge/gateway/service_charge_adapter.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'faker'
 require "#{Rails.root}/lib/hackney/service_charge/exceptions/service_charge_api_exception"
 
 module Hackney


### PR DESCRIPTION
I need faker to temporarily run in staging/production to demo letter generation, once we have a proper api endpoint faker will be exiled back into test only