### PR TITLE
Add support for KMS and client-side encryption

### DIFF
--- a/app/jobs/hackney/cloud/jobs/save_to_cloud_job.rb
+++ b/app/jobs/hackney/cloud/jobs/save_to_cloud_job.rb
@@ -7,7 +7,9 @@ module Hackney
         queue_as :cloud_storage
 
         def perform(bucket_name:, filename:, new_filename:, model_document:, uuid:)
-          url = cloud_provider.upload(bucket_name, filename, new_filename)
+          url = cloud_provider.upload(bucket_name: bucket_name,
+                                      filename: filename,
+                                      new_filename: new_filename)
 
           document(model_document, uuid).update(url: url, status: UPLOADED_CLOUD_STATUS)
         end

--- a/config/cloud_storage.yml
+++ b/config/cloud_storage.yml
@@ -1,11 +1,15 @@
 test:
   bucket_docs: hackney-docs-test
+  customer_managed_key: '-'
 
 development:
   bucket_docs: hackney-docs-development
+  customer_managed_key: <%= ENV['CUSTOMER_MANAGED_KEY'] %>
 
 production:
   bucket_docs: hackney-docs-production
+  customer_managed_key: <%= ENV['CUSTOMER_MANAGED_KEY'] %>
 
 staging:
   bucket_docs: hackney-docs-staging
+  customer_managed_key: <%= ENV['CUSTOMER_MANAGED_KEY'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,5 +46,7 @@ Rails.application.configure do
 
   config.gov_notify_api_key = 'DevApiKEY12345'
 
-  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new(stub: true)
+  # Configure the Cloud storage service
+  encryption_client = Hackney::Cloud::EncryptionClient.new(config_for('cloud_storage')['customer_managed_key']).create
+  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new(encryption_client)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,7 @@ Rails.application.configure do
 
   config.x.gov_notify.api_key = ENV.fetch('GOV_NOTIFY_API_KEY')
 
-  # This specify the Cloud storage service that we are using
-  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new
+  # Configure the Cloud storage service
+  encryption_client = Hackney::Cloud::EncryptionClient.new(config_for('cloud_storage')['customer_managed_key']).create
+  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new(encryption_client)
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,6 +80,7 @@ Rails.application.configure do
 
   config.x.gov_notify.api_key = ENV.fetch('GOV_NOTIFY_API_KEY')
 
-  # This specify the Cloud storage service that we are using
-  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new
+  # Configure the Cloud storage service
+  encryption_client = Hackney::Cloud::EncryptionClient.new(config_for('cloud_storage')['customer_managed_key']).create
+  config.cloud_adapter = Hackney::Cloud::Adapter::AwsS3.new(encryption_client)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,5 +44,7 @@ Rails.application.configure do
   config.x.gov_notify.api_key = 'TestApiKEY12345'
 
   config.active_job.queue_adapter = :test
+
+  # Configure the Cloud storage service
   config.cloud_adapter = Hackney::Cloud::Adapter::Fake.new
 end

--- a/lib/hackney/cloud/adapter/fake.rb
+++ b/lib/hackney/cloud/adapter/fake.rb
@@ -2,8 +2,8 @@ module Hackney
   module Cloud
     module Adapter
       class Fake
-        def upload(bucketname, _filename, new_filename)
-          "https://#{bucketname}/#{new_filename}"
+        def upload(bucket_name:, filename:, new_filename:)
+          "https://#{bucket_name}/#{new_filename}"
         end
       end
     end

--- a/lib/hackney/cloud/encryption_client.rb
+++ b/lib/hackney/cloud/encryption_client.rb
@@ -1,0 +1,18 @@
+module Hackney
+  module Cloud
+    class EncryptionClient
+      def initialize(customer_managed_key)
+        @customer_managed_key = customer_managed_key
+      end
+
+      def create
+        kms = Aws::KMS::Client.new
+
+        Aws::S3::Encryption::Client.new(
+          kms_key_id: @customer_managed_key,
+          kms_client: kms
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/cloud/adapter/aws_s3_spec.rb
+++ b/spec/lib/hackney/cloud/adapter/aws_s3_spec.rb
@@ -1,14 +1,51 @@
 require 'rails_helper'
 
 describe Hackney::Cloud::Adapter::AwsS3 do
-  subject(:s3) { described_class.new(stub: true) }
+  subject(:s3) { described_class.new(encryption_client_double) }
+
+  let(:encryption_client_double) { double }
+
+  let(:new_filename) { 'new_filename.txt' }
 
   let(:filename) { './spec/lib/hackney/cloud/adapter/upload_test.txt' }
-  let(:new_filename) { SecureRandom.uuid }
+  let(:content) { File.read(filename) }
 
-  it 'uploads a file on S3' do
-    s3_url = s3.upload('my-bucket', filename, new_filename)
+  context 'when there are NOT upload errors' do
+    let(:upload_response) { double(successful?: true) }
 
-    expect(s3_url).to match `https:\/\/my-bucket.*#{new_filename}`
+    it 'successfully uploads the S3' do
+      allow(encryption_client_double).to receive(:put_object)
+        .with(body: content, bucket: 'my-bucket', key: new_filename)
+        .and_return(upload_response)
+
+      expect(
+        s3.upload(bucket_name: 'my-bucket',
+                  filename: filename,
+                  new_filename: new_filename)
+      ).to be true
+    end
+  end
+
+  context 'when there are upload errors' do
+    let(:upload_response) { double(successful?: false) }
+
+    it 'raises an exception' do
+      allow(encryption_client_double).to receive(:put_object)
+        .with(body: content, bucket: 'my-bucket', key: new_filename)
+        .and_return(upload_response)
+
+      expect {
+        s3.upload(bucket_name: 'my-bucket',
+                  filename: filename,
+                  new_filename: new_filename)
+      }.to raise_exception('Cloud Storage Error!')
+    end
+  end
+
+  it 'downloads a file from S3' do
+    expect(encryption_client_double).to receive(:get_object)
+      .with(bucket: 'my-bucket', key: filename)
+
+    s3.download('my-bucket', filename)
   end
 end

--- a/spec/lib/hackney/cloud/encryption_client_spec.rb
+++ b/spec/lib/hackney/cloud/encryption_client_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require './lib/hackney/cloud/encryption_client'
+
+describe Hackney::Cloud::EncryptionClient do
+  let(:kms_double) { double }
+
+  it 'returns a new Encryption client' do
+    allow(Aws::KMS::Client).to receive(:new).and_return(kms_double)
+
+    expect(Aws::S3::Encryption::Client).to receive(:new).with(kms_key_id: '123', kms_client: kms_double)
+
+    described_class.new('123').create
+  end
+end


### PR DESCRIPTION
This PR add the Client-Side encryption and support for KMS
(to know how it works read: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html)

Trello: https://trello.com/c/MfQ2yWRX/152-kms-envelope-encryption-implementation 