### PR TITLE
Update uh simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-COMPOSE_FILES = -f docker-compose.yml -f docker-compose.local.yml
 
 .PHONY: docker-build
 docker-build:
-	docker-compose $(COMPOSE_FILES) build
+	docker-compose build
 
 .PHONY: docker-down
 docker-down:
@@ -18,7 +17,7 @@ setup: docker-build bundle
 .PHONY: serve
 serve:
 	-rm tmp/pids/server.pid &> /dev/null
-	docker-compose $(COMPOSE_FILES) up
+	docker-compose up
 
 .PHONY: test
 test:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,4 +1,0 @@
-version: '3.1'
-services:
-  universal_housing:
-    build: ../lbh-universal-housing-simulator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - .:/app
     command: sh -c 'rails db:migrate && rails s'
   universal_housing_simulator:
-    image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:140ad3ef65f4a44d8bbbb3add55968a157625647
+    image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:1d1aae5c5812cfa86f62aa9592397ac4498b7f68
     ports:
       - 1433:1433
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - .:/app
     command: sh -c 'rails db:migrate && rails s'
   universal_housing_simulator:
-    image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:1d1aae5c5812cfa86f62aa9592397ac4498b7f68
+    image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator:9855e4d527519516e8138a026e900ae26b4be5f3
     ports:
       - 1433:1433
 

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -63,7 +63,7 @@ module UniversalHousingHelper
       none_rent: false,
       receipted: 0.0,
       line_segno: false,
-      vat: '1'
+      vat: false
     )
   end
 

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -62,7 +62,8 @@ module UniversalHousingHelper
       prop_deb: false,
       none_rent: false,
       receipted: 0.0,
-      line_segno: false
+      line_segno: false,
+      vat: '1'
     )
   end
 


### PR DESCRIPTION
- the simulator now matches `uhlive` instead of `uhdev`
- removed the local reference (this will speed build time and ensure we are using the correct pinned version on local test runs)