### PR TITLE
rescuing when tenancy is not found

### DIFF
--- a/lib/hackney/income/migrate_patch_to_lcw.rb
+++ b/lib/hackney/income/migrate_patch_to_lcw.rb
@@ -10,13 +10,11 @@ module Hackney
         tenancy_refs_in_legal_process = @legal_cases_gateway.get_tenancies_for_legal_process_for_patch(patch: patch)
         tenancy_refs_not_found = []
         tenancy_refs_in_legal_process.each do |ref|
-          begin
-            @user_assignment_gateway.assign_user(tenancy_ref: ref, user_id: user_id)
-          rescue
-            tenancy_refs_not_found << ref
-          end
+          @user_assignment_gateway.assign_user(tenancy_ref: ref, user_id: user_id)
+        rescue StandardError
+          tenancy_refs_not_found << ref
         end
-        {tenancy_refs_in_legal_process: tenancy_refs_in_legal_process, tenancy_refs_not_found: tenancy_refs_not_found}
+        { tenancy_refs_in_legal_process: tenancy_refs_in_legal_process, tenancy_refs_not_found: tenancy_refs_not_found }
       end
     end
   end

--- a/lib/hackney/income/migrate_patch_to_lcw.rb
+++ b/lib/hackney/income/migrate_patch_to_lcw.rb
@@ -8,9 +8,15 @@ module Hackney
 
       def execute(patch:, user_id:)
         tenancy_refs_in_legal_process = @legal_cases_gateway.get_tenancies_for_legal_process_for_patch(patch: patch)
+        tenancy_refs_not_found = []
         tenancy_refs_in_legal_process.each do |ref|
-          @user_assignment_gateway.assign_user(tenancy_ref: ref, user_id: user_id)
+          begin
+            @user_assignment_gateway.assign_user(tenancy_ref: ref, user_id: user_id)
+          rescue
+            tenancy_refs_not_found << ref
+          end
         end
+        {tenancy_refs_in_legal_process: tenancy_refs_in_legal_process, tenancy_refs_not_found: tenancy_refs_not_found}
       end
     end
   end

--- a/lib/tasks/income/income.rake
+++ b/lib/tasks/income/income.rake
@@ -4,7 +4,11 @@ namespace :income do
          'All tenancies in that patch where the high action is 4RS or above will be assigned to that user.'
     task :migrate_lcw_cases, [:patch, :user_id] do |_task, args|
       use_case_factory = Hackney::Income::UseCaseFactory.new
-      use_case_factory.migrate_patch_to_lcw.execute(patch: args.fetch(:patch), user_id: args.fetch(:user_id))
+      result = use_case_factory.migrate_patch_to_lcw.execute(patch: args.fetch(:patch), user_id: args.fetch(:user_id))
+      puts '---------------'
+      puts "Found #{result[:tenancy_refs_in_legal_process].length}, failed to assign: #{result[:tenancy_refs_not_found].length}"
+      puts '---------------'
+      puts result[:tenancy_refs_not_found]
     end
 
     desc 'Manual task, list all tenancies that match criteria for green in arrears messages'


### PR DESCRIPTION
since the assignment of legal case workers fails when a case is not found and kills the whole process, this fix is not ideal but it will give you a list of not found tenancy refs
