### PR TITLE
Make preamble optional

### DIFF
--- a/app/models/hackney/service_charge/letter.rb
+++ b/app/models/hackney/service_charge/letter.rb
@@ -2,7 +2,7 @@ module Hackney
   module ServiceCharge
     class Letter
       MANDATORY_LETTER_FIELDS = %i[payment_ref lessee_full_name
-                                   correspondence_address1 correspondence_address2
+                                   correspondence_address2 correspondence_address3
                                    correspondence_postcode property_address
                                    total_collectable_arrears_balance].freeze
 
@@ -18,12 +18,12 @@ module Hackney
         validated_params = validate_mandatory_fields(params)
 
         @tenancy_ref = validated_params[:tenancy_ref]
-        @correspondence_address1 = validated_params[:correspondence_address1]
-        @correspondence_address2 = validated_params[:correspondence_address2]
-        @correspondence_address3 = validated_params[:correspondence_address3]
-        @correspondence_address4 = validated_params[:correspondence_address4]
-        @correspondence_address5 = validated_params[:correspondence_address5]
-        @correspondence_postcode = validated_params[:correspondence_postcode]
+        @correspondence_address1 = validated_params[:correspondence_address1] # corr_preamble ( the flat number/house Name)
+        @correspondence_address2 = validated_params[:correspondence_address2] # desig + aline1
+        @correspondence_address3 = validated_params[:correspondence_address3] # aline2
+        @correspondence_address4 = validated_params[:correspondence_address4] # aline3 (City)
+        @correspondence_address5 = validated_params[:correspondence_address5] # aline4 (Country)
+        @correspondence_postcode = validated_params[:correspondence_postcode] # corr_postcode
         @property_address = validated_params[:property_address]
         @payment_ref = validated_params[:payment_ref]
         @balance = validated_params[:balance]

--- a/spec/controllers/letters_controller_spec.rb
+++ b/spec/controllers/letters_controller_spec.rb
@@ -89,7 +89,7 @@ describe LettersController, type: :controller do
       context 'when the missing data is optional' do
         let(:payment_ref) { Faker::Number.number(4) }
 
-        let(:optional_fields) { %i[correspondence_address3] }
+        let(:optional_fields) { %i[correspondence_address1] } # the address preamble
 
         it 'returns no errors' do
           expect_any_instance_of(Hackney::Income::UniversalHousingLeaseholdGateway)
@@ -104,7 +104,7 @@ describe LettersController, type: :controller do
 
       context 'when the missing data mandatory' do
         let(:payment_ref) { Faker::Number.number(4) }
-        let(:mandatory_fields) { %i[correspondence_address1] }
+        let(:mandatory_fields) { Hackney::ServiceCharge::Letter::MANDATORY_LETTER_FIELDS }
 
         it 'returns errors' do
           expect_any_instance_of(Hackney::Income::UniversalHousingLeaseholdGateway)
@@ -115,7 +115,13 @@ describe LettersController, type: :controller do
           post :create, params: { payment_ref: payment_ref, template_id: template_id }
 
           expect(response_json['errors']).to eq(
-            [{ 'message' => 'missing mandatory field', 'name' => 'correspondence_address1' }]
+            [{ 'message' => 'missing mandatory field', 'name' => 'payment_ref' },
+             { 'message' => 'missing mandatory field', 'name' => 'lessee_full_name' },
+             { 'message' => 'missing mandatory field', 'name' => 'correspondence_address2' },
+             { 'message' => 'missing mandatory field', 'name' => 'correspondence_address3' },
+             { 'message' => 'missing mandatory field', 'name' => 'correspondence_postcode' },
+             { 'message' => 'missing mandatory field', 'name' => 'property_address' },
+             { 'message' => 'missing mandatory field', 'name' => 'total_collectable_arrears_balance' }]
           )
         end
       end

--- a/spec/lib/hackney/pdf/preview_generator_spec.rb
+++ b/spec/lib/hackney/pdf/preview_generator_spec.rb
@@ -56,9 +56,9 @@ describe Hackney::PDF::PreviewGenerator do
       expect(preview_with_errors[:html]).to eq(translated_html)
       expect(preview_with_errors[:errors]).to eq([
         {
-          message: 'missing mandatory field', name: 'correspondence_address1'
-        }, {
           message: 'missing mandatory field', name: 'correspondence_address2'
+        }, {
+          message: 'missing mandatory field', name: 'correspondence_address3'
         }, {
           message: 'missing mandatory field', name: 'correspondence_postcode'
         }

--- a/spec/lib/hackney/pdf/preview_spec.rb
+++ b/spec/lib/hackney/pdf/preview_spec.rb
@@ -95,10 +95,10 @@ describe Hackney::PDF::Preview do
         preview: translated_html,
         errors: [
           {
-            name: 'correspondence_address1',
+            name: 'correspondence_address2',
             message: 'missing mandatory field'
           }, {
-            name: 'correspondence_address2',
+            name: 'correspondence_address3',
             message: 'missing mandatory field'
           }, {
             name: 'correspondence_postcode',


### PR DESCRIPTION
The preamble, that usually is the house name, should be optional (and most of the time is empty) 