### PR TITLE
matches the real failed value

### DIFF
--- a/app/models/hackney/cloud/document.rb
+++ b/app/models/hackney/cloud/document.rb
@@ -1,7 +1,11 @@
 module Hackney
   module Cloud
     class Document < ApplicationRecord
-      enum status: { uploading: 0, uploaded: 1, received: 2, accepted: 3, failed: 4 }
+      enum status: { uploading: 0, uploaded: 1, received: 2, accepted: 3, 'validation-failed' => 4 }
+
+      def failed?
+        status == 'validation-failed'
+      end
     end
   end
 end

--- a/lib/hackney/notification/enqueue_request_all_precompiled_letter_states.rb
+++ b/lib/hackney/notification/enqueue_request_all_precompiled_letter_states.rb
@@ -12,7 +12,7 @@ module Hackney
         self.document_store = document_store
         self.documents =
           document_store.where('updated_at >= ?', Time.now - 7.days)
-                        .where.not(status: %i[nil failed accepted])
+                        .where.not(status: %i[nil validation-failed accepted])
       end
 
       def execute

--- a/lib/hackney/notification/request_precompiled_letter_state.rb
+++ b/lib/hackney/notification/request_precompiled_letter_state.rb
@@ -13,7 +13,7 @@ module Hackney
 
       def update_document(message_id:, status:)
         store = Hackney::Cloud::Document
-        doc = store.find_by!(uuid: message_id)
+        doc = store.find_by!(ext_message_id: message_id)
         doc.status = status
 
         Raven.send_event("Document has failed - id: #{doc.id}, uuid: #{doc.uuid}") if doc.failed?

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -48,7 +48,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:uploaded) { create(:document, status: :uploaded) }
       let!(:received) { create(:document, status: :received) }
       let!(:accepted) { create(:document, status: :accepted) }
-      let!(:failed) { create(:document, status: :failed) }
+      let!(:failed) { create(:document, status: 'validation-failed') }
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }

--- a/spec/lib/hackney/notification/request_precompiled_letter_state_spec.rb
+++ b/spec/lib/hackney/notification/request_precompiled_letter_state_spec.rb
@@ -20,7 +20,7 @@ describe Hackney::Notification::RequestPrecompiledLetterState do
            status: 'uploaded')
   end
 
-  let(:response) { notification_response.execute(message_id: document.uuid) }
+  let(:response) { notification_response.execute(message_id: document.ext_message_id) }
 
   describe '#execute' do
     it 'gets request' do
@@ -37,10 +37,10 @@ describe Hackney::Notification::RequestPrecompiledLetterState do
   context 'when failure' do
     let(:doc) { Hackney::Cloud::Document.find(document.id) }
 
-    before { expect(notification_gateway).to receive(:precompiled_letter_state).and_return(status: 'failed') }
+    before { expect(notification_gateway).to receive(:precompiled_letter_state).and_return(status: 'validation-failed') }
 
     it 'change to failure raises Sentry notification' do
-      expect { response }.to change { doc.reload.status }.from('uploaded').to('failed')
+      expect { response }.to change { doc.reload.status }.from('uploaded').to('validation-failed')
     end
 
     it 'raises Sentry notification' do


### PR DESCRIPTION
1. documents weren't found because Gov notify uses its own ID which we mapped to `ext_message_id`
2.`'validation-failed` not just `failed`