### PR TITLE
Get action codes for Manual SMSs based on the template name

### DIFF
--- a/lib/hackney/notification/manual_action_code.rb
+++ b/lib/hackney/notification/manual_action_code.rb
@@ -1,4 +1,3 @@
-
 module Hackney
   module Notification
     class ManualActionCode
@@ -23,4 +22,3 @@ module Hackney
     end
   end
 end
-

--- a/lib/hackney/notification/manual_action_code.rb
+++ b/lib/hackney/notification/manual_action_code.rb
@@ -1,0 +1,26 @@
+
+module Hackney
+  module Notification
+    class ManualActionCode
+      class << self
+        def get_by_sms_template_name(template_name:)
+          if template_name.start_with?('Green')
+            Hackney::Tenancy::ActionCodes::MANUAL_GREEN_SMS_ACTION_CODE
+          elsif template_name.start_with?('Amber')
+            Hackney::Tenancy::ActionCodes::MANUAL_AMBER_SMS_ACTION_CODE
+          else
+            warn("unknown sms template: #{template_name}")
+            Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE
+          end
+        end
+
+        private
+
+        def warn(message)
+          Rails.logger.warn('Notification::ManualActionCode') { message }
+        end
+      end
+    end
+  end
+end
+

--- a/lib/hackney/notification/send_manual_sms.rb
+++ b/lib/hackney/notification/send_manual_sms.rb
@@ -18,7 +18,7 @@ module Hackney
           @add_action_diary_usecase.execute(
             user_id: user_id,
             tenancy_ref: tenancy_ref,
-            action_code: Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE,
+            action_code: Hackney::Notification::ManualActionCode.get_by_sms_template_name(template_name: template_name),
             comment: "#{template_name}' SMS sent to '#{phone.full_e164}' with content '#{notification_receipt.body_without_newlines}'"
           )
         else

--- a/lib/hackney/tenancy/action_codes.rb
+++ b/lib/hackney/tenancy/action_codes.rb
@@ -7,6 +7,9 @@ module Hackney
       MANUAL_SMS_ACTION_CODE = 'GMS'.freeze
       MANUAL_EMAIL_ACTION_CODE = 'GME'.freeze
 
+      MANUAL_GREEN_SMS_ACTION_CODE = 'GMS'.freeze
+      MANUAL_AMBER_SMS_ACTION_CODE = 'AMS'.freeze
+
       # Codes for letters as follows:
       LETTER_1_IN_ARREARS_FH = 'LF1'.freeze
       LETTER_2_IN_ARREARS_FH = 'LF2'.freeze

--- a/spec/lib/hackney/notification/manual_action_code_spec.rb
+++ b/spec/lib/hackney/notification/manual_action_code_spec.rb
@@ -6,28 +6,33 @@ describe Hackney::Notification::ManualActionCode do
   describe '#get_by_sms_template_name' do
     let(:subject) { described_class.get_by_sms_template_name(template_name: template_name) }
 
-    context 'When name starts with Green' do
+    context 'when name starts with Green' do
       let(:template_name) { 'Green arrears reminder' }
-      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_GREEN_SMS_ACTION_CODE) }
+
+      it { is_expected.to eq(Hackney::Tenancy::ActionCodes::MANUAL_GREEN_SMS_ACTION_CODE) }
     end
 
-    context 'When name starts with Amber' do
+    context 'when name starts with Amber' do
       let(:template_name) { 'Amber arrears reminder' }
-      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_AMBER_SMS_ACTION_CODE) }
+
+      it { is_expected.to eq(Hackney::Tenancy::ActionCodes::MANUAL_AMBER_SMS_ACTION_CODE) }
     end
 
-    context 'When name starts with with an unknown word' do
+    context 'when name starts with with an unknown word' do
       let(:template_name) { 'Arrears reminder' }
-      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
 
-      context 'With Green in the name' do
+      it { is_expected.to eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+
+      context 'with Green in the name' do
         let(:template_name) { 'Arrears Green reminder' }
-        it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+
+        it { is_expected.to eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
       end
 
-      context 'With Amber in the name' do
+      context 'with Amber in the name' do
         let(:template_name) { 'Arrears Amber reminder' }
-        it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+
+        it { is_expected.to eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
       end
     end
   end

--- a/spec/lib/hackney/notification/manual_action_code_spec.rb
+++ b/spec/lib/hackney/notification/manual_action_code_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Hackney::Notification::ManualActionCode do
+  let(:template_name) { '' }
+
+  describe '#get_by_sms_template_name' do
+    let(:subject) { described_class.get_by_sms_template_name(template_name: template_name) }
+
+    context 'When name starts with Green' do
+      let(:template_name) { 'Green arrears reminder' }
+      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_GREEN_SMS_ACTION_CODE) }
+    end
+
+    context 'When name starts with Amber' do
+      let(:template_name) { 'Amber arrears reminder' }
+      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_AMBER_SMS_ACTION_CODE) }
+    end
+
+    context 'When name starts with with an unknown word' do
+      let(:template_name) { 'Arrears reminder' }
+      it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+
+      context 'With Green in the name' do
+        let(:template_name) { 'Arrears Green reminder' }
+        it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+      end
+
+      context 'With Amber in the name' do
+        let(:template_name) { 'Arrears Amber reminder' }
+        it { should eq(Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Originally I planned to do this using template IDs, however as there are multiple templates that can be sent, I've opted for a looser approach that will work so long as the current structure is sent.

A fallback happens to send the previous Manual SMS action code (which is `GMS`) when the template name can't be identified.