### PR TITLE
make the dummy gov notify gateway able to give the expected name

### DIFF
--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -7,7 +7,7 @@ describe MessagesController, type: :controller do
     {
       user_id: Faker::Number.number(2),
       tenancy_ref: "#{Faker::Number.number(8)}/#{Faker::Number.number(2)}",
-      template_id: Faker::HitchhikersGuideToTheGalaxy.planet,
+      template_id: Hackney::Notification::GovNotifyGateway::EXAMPLE_TEMPLATES.sample[:id],
       phone_number: Faker::PhoneNumber.phone_number,
       reference: Faker::HitchhikersGuideToTheGalaxy.starship,
       variables: {

--- a/spec/support/stubs/dummy_gov_notify_gateway.rb
+++ b/spec/support/stubs/dummy_gov_notify_gateway.rb
@@ -6,7 +6,9 @@ module Hackney
 
       def initialize(sms_sender_id:, api_key:, send_live_communications:, test_phone_number:, test_email_address:, test_physical_address: nil); end
 
-      def get_template_name(id); end
+      def get_template_name(template_id)
+        get_templates&.find { |template_item| template_item[:id] == template_id }&.fetch(:name) || template_id
+      end
 
       def send_text_message(phone_number:, template_id:, reference:, variables:)
         Hackney::Notification::Domain::NotificationReceipt.new(body: 'DummyGovNotifyGateway body')
@@ -20,7 +22,7 @@ module Hackney
         Hackney::Notification::Domain::NotificationReceipt.new(body: 'DummyGovNotifyGateway body')
       end
 
-      def get_templates(type:)
+      def get_templates(type: nil)
         EXAMPLE_TEMPLATES
       end
     end


### PR DESCRIPTION
This allows the dummy to give the name associated with the ID from the stub json.