### PR TITLE
add a task to generate failed message reports

### DIFF
--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -150,6 +150,12 @@ module Hackney
         )
       end
 
+      def get_failed_sms_messages
+        Hackney::Notification::GetFailedSMSMessages.new(
+          notification_gateway: notifications_gateway
+        )
+      end
+
       private
 
       def cloud_storage

--- a/lib/hackney/notification/get_failed_sms_messages.rb
+++ b/lib/hackney/notification/get_failed_sms_messages.rb
@@ -1,0 +1,23 @@
+module Hackney
+  module Notification
+    class GetFailedSMSMessages
+      def initialize(notification_gateway:)
+        @notification_gateway = notification_gateway
+      end
+
+      def execute()
+        notification_gateway.get_messages(type: 'sms', status: 'failed').map do |message|
+          {
+            id: message.id,
+            reference: message.reference,
+            phone_number: message.phone_number
+          }
+        end
+      end
+
+      private
+
+      attr_reader :notification_gateway
+    end
+  end
+end

--- a/lib/hackney/notification/get_failed_sms_messages.rb
+++ b/lib/hackney/notification/get_failed_sms_messages.rb
@@ -5,7 +5,7 @@ module Hackney
         @notification_gateway = notification_gateway
       end
 
-      def execute()
+      def execute
         notification_gateway.get_messages(type: 'sms', status: 'failed').map do |message|
           {
             id: message.id,

--- a/lib/hackney/notification/gov_notify_gateway.rb
+++ b/lib/hackney/notification/gov_notify_gateway.rb
@@ -63,8 +63,8 @@ module Hackney
       def get_messages(type: nil, status: nil)
         Enumerator.new do |enum|
           last_id = nil
-          while collection = fetch_messages(type: type, status: status, older_than: last_id).collection.presence
-            for response in collection
+          while (collection = fetch_messages(type: type, status: status, older_than: last_id).collection.presence)
+            collection.each do |response|
               last_id = response.id
               enum.yield response
             end

--- a/lib/hackney/notification/gov_notify_gateway.rb
+++ b/lib/hackney/notification/gov_notify_gateway.rb
@@ -60,6 +60,18 @@ module Hackney
         end
       end
 
+      def get_messages(type: nil, status: nil)
+        Enumerator.new do |enum|
+          last_id = nil
+          while collection = fetch_messages(type: type, status: status, older_than: last_id).collection.presence
+            for response in collection
+              last_id = response.id
+              enum.yield response
+            end
+          end
+        end
+      end
+
       private
 
       def client
@@ -85,6 +97,14 @@ module Hackney
       def pre_release_email(email)
         return email if @send_live_communications
         @test_email_address
+      end
+
+      def fetch_messages(type: nil, status: nil, older_than: nil)
+        client.get_notifications({
+          template_type: type,
+          status: status,
+          older_than: older_than
+        }.compact)
       end
     end
   end

--- a/lib/hackney/notification/gov_notify_gateway.rb
+++ b/lib/hackney/notification/gov_notify_gateway.rb
@@ -61,15 +61,13 @@ module Hackney
       end
 
       def get_messages(type: nil, status: nil)
-        Enumerator.new do |enum|
-          last_id = nil
-          while (collection = fetch_messages(type: type, status: status, older_than: last_id).collection.presence)
-            collection.each do |response|
-              last_id = response.id
-              enum.yield response
-            end
-          end
+        messages = []
+        last_id = nil
+        while (collection = fetch_messages(type: type, status: status, older_than: last_id).collection.presence)
+          last_id = collection.last.id
+          messages += collection
         end
+        messages
       end
 
       private

--- a/lib/tasks/bau/failed_messages_report.rake
+++ b/lib/tasks/bau/failed_messages_report.rake
@@ -2,10 +2,10 @@ require 'cgi'
 
 namespace :bau do
   desc 'generate report of tenancy references that did not receive an SMS'
-  task :failed_messages_report, [:tenancies_uri] do |t, args|
+  task :failed_messages_report, [:tenancies_uri] do |_t, args|
     tenancies_uri = args.tenancies_uri || '/tenancies'
-    tenancy_ref_regex = "\\d+/\\d+"
-    uuid_regex = "[\\da-f\\-]{32,36}"
+    tenancy_ref_regex = '\\d+/\\d+'
+    uuid_regex = '[\\da-f\\-]{32,36}'
     matches = [
       # SendGreenInArrearsMsgJob-#{case_priority.tenancy_ref}-#{SecureRandom.uuid}
       Regexp.new("^\\S+-(#{tenancy_ref_regex})-#{uuid_regex}$"),

--- a/lib/tasks/bau/failed_messages_report.rake
+++ b/lib/tasks/bau/failed_messages_report.rake
@@ -1,0 +1,25 @@
+require 'cgi'
+
+namespace :bau do
+  desc 'generate report of tenancy references that did not receive an SMS'
+  task :failed_messages_report, [:tenancies_uri] do |t, args|
+    tenancies_uri = args.tenancies_uri || '/tenancies'
+    tenancy_ref_regex = "\\d+/\\d+"
+    uuid_regex = "[\\da-f\\-]{32,36}"
+    matches = [
+      # SendGreenInArrearsMsgJob-#{case_priority.tenancy_ref}-#{SecureRandom.uuid}
+      Regexp.new("^\\S+-(#{tenancy_ref_regex})-#{uuid_regex}$"),
+      # manual_#{tenancy.ref}
+      Regexp.new("^\\S+_(#{tenancy_ref_regex})$")
+    ]
+
+    use_cases = Hackney::Income::UseCaseFactory.new
+    use_cases.get_failed_sms_messages.execute.each do |message|
+      reference = message[:reference]
+      tenancy_refs = matches.map { |r| r.match(reference)&.values_at(1) }.flatten.compact
+      tenancy_ref = tenancy_refs.first || reference
+
+      puts "#{message[:phone_number]} -- #{tenancies_uri}/#{CGI.escape(tenancy_ref)}"
+    end
+  end
+end

--- a/lib/tasks/bau/reassign_case.rake
+++ b/lib/tasks/bau/reassign_case.rake
@@ -1,7 +1,7 @@
 namespace :bau do
   desc 'reassign case to user'
-  task :reassign_case, [:tenancy_ref, :user_id] do
+  task :reassign_case, [:tenancy_ref, :user_id] do |t, args|
     user_assignment_gateway = Hackney::Income::SqlTenancyCaseGateway.new
-    user_assignment_gateway.assign_user(tenancy_ref: tenancy_ref, user_id: user_id)
+    user_assignment_gateway.assign_user(tenancy_ref: args.tenancy_ref, user_id: args.user_id)
   end
 end

--- a/lib/tasks/bau/reassign_case.rake
+++ b/lib/tasks/bau/reassign_case.rake
@@ -1,6 +1,6 @@
 namespace :bau do
   desc 'reassign case to user'
-  task :reassign_case, [:tenancy_ref, :user_id] do |t, args|
+  task :reassign_case, [:tenancy_ref, :user_id] do |_t, args|
     user_assignment_gateway = Hackney::Income::SqlTenancyCaseGateway.new
     user_assignment_gateway.assign_user(tenancy_ref: args.tenancy_ref, user_id: args.user_id)
   end


### PR DESCRIPTION
This changes the manual process that depends on PaperTrail to directly use govnotify.

The current working logic is:
- Tenancy refs are always in the SMS Message ref
- Extract it out for known patterns
- dump the full SMS reference if it doesn't match a known pattern
- output the phone number and (optionally) the URL to the tenancy on the website.