### PR TITLE
Use preamble and design from property address when no correspondence address is set

### DIFF
--- a/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
@@ -163,8 +163,8 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
 
   def expected_correspondence_address_when_property
     {
-      correspondence_address1: corr_preamble,
-      correspondence_address2: corr_desig + ' ' + property_address[:aline1],
+      correspondence_address1: prop_preamble,
+      correspondence_address2: prop_desig + ' ' + property_address[:aline1],
       correspondence_address3: property_address[:aline2],
       correspondence_address4: property_address[:aline3],
       correspondence_address5: property_address[:aline4],

--- a/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
@@ -6,29 +6,43 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
   let(:payment_ref) { Random.rand(100).to_s }
   let(:tenancy_ref) { Random.rand(100).to_s }
   let(:house_ref) { Random.rand(100).to_s }
-  let(:corr_preamble) { '23' }
   let(:cur_bal) { Random.rand(100) }
-  let(:corr_desig) { 'Some street' }
-  let(:address) {
+  let(:corr_preamble) { Faker::Address.secondary_address }
+  let(:corr_desig) { Random.rand(100).to_s }
+  let(:household_postcode) { Faker::Address.postcode }
+  let(:household_address) {
     {
       aline1: Faker::Address.street_name,
-      aline2: 'Address line 2',
-      aline3: 'Address line 3',
-      aline4: 'Address line 4',
-      post_code: 'E8 1DY'
+      aline2: Faker::Address.community,
+      aline3: Faker::Address.city,
+      aline4: Faker::Address.country,
+      post_code: household_postcode
+    }
+  }
+  let(:property_postcode) { Faker::Address.postcode }
+  let(:prop_preamble) { Faker::Address.secondary_address }
+  let(:prop_desig) { Random.rand(100).to_s }
+  let(:property_address) {
+    {
+      aline1: Faker::Address.street_name,
+      aline2: Faker::Address.community,
+      aline3: Faker::Address.city,
+      aline4: Faker::Address.country,
+      post_code: property_postcode
     }
   }
 
   let(:prop_address) {
     {
       address1: Faker::Address.street_name,
-      post_code: Faker::Address.postcode
+      post_code: property_postcode,
+      post_preamble: prop_preamble,
+      post_desig: prop_desig
     }
   }
 
   let(:lessee_full_name) { 'Mr John Doe Smith' }
 
-  let(:prop_post_code) { Faker::Address.postcode }
   let(:prop_ref) { Random.rand(100).to_s }
   let(:sc_leasedate) { Faker::Date.forward(10) }
   let(:commencement_of_tenancy) { Faker::Date.backward(10) }
@@ -51,23 +65,24 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
     end
 
     context 'when payment_ref exists' do
+      let(:set_household_postcode) { household_postcode }
+      let(:set_property_postcode) { property_postcode }
+      let(:create_property) { true }
+
       before do
         create_uh_tenancy_agreement(tenancy_ref: tenancy_ref, current_balance: cur_bal, u_saff_rentacc: payment_ref,
                                     house_ref: house_ref, prop_ref: prop_ref, cot: commencement_of_tenancy)
         create_uh_rent(sc_leasedate: sc_leasedate, prop_ref: prop_ref)
         create_uh_househ(house_ref: house_ref, prop_ref: prop_ref, house_desc: lessee_full_name,
                          corr_preamble: corr_preamble, corr_desig: corr_desig,
-                         corr_postcode: correspondence_postcode, post_code: property_postcode)
+                         corr_postcode: set_household_postcode, post_code: set_property_postcode)
+        create_uh_property(prop_address.merge(property_ref: prop_ref)) if create_property
+        create_uh_postcode(household_address)
+        create_uh_postcode(property_address)
       end
 
       context 'when corr_postcode' do
-        let(:correspondence_postcode) { address[:post_code] }
-        let(:property_postcode) { ' ' }
-
-        before do
-          create_uh_postcode(address)
-          create_uh_property(prop_address.merge(property_ref: prop_ref))
-        end
+        let(:set_property_postcode) { ' ' }
 
         it 'get the prop_ref' do
           result = gateway.get_leasehold_info(payment_ref: payment_ref)
@@ -80,14 +95,15 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
             lessee_full_name: lessee_full_name,
             lessee_short_name: lessee_full_name,
             date_of_current_purchase_assignment: commencement_of_tenancy
-          }.merge(expected_correspondence_address)
+          }.merge(expected_correspondence_address_when_household)
            .merge(expected_property_address))
         end
       end
 
       context 'when both correspondence postcode and property address do NOT exist' do
-        let(:correspondence_postcode) { '' }
-        let(:property_postcode) { ' ' }
+        let(:set_household_postcode) { ' ' }
+        let(:set_property_postcode) { ' ' }
+        let(:create_property) { false }
 
         it 'get the prop_ref' do
           result = gateway.get_leasehold_info(payment_ref: payment_ref)
@@ -113,12 +129,7 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
       end
 
       context 'when both corr_postcode is empty AND property_postcode are present' do
-        let(:correspondence_postcode) { '' }
-        let(:property_postcode) { address[:post_code] }
-
-        before do
-          create_uh_postcode(address)
-        end
+        let(:set_household_postcode) { ' ' }
 
         it 'uses the property post_code as correspondence address' do
           result = gateway.get_leasehold_info(payment_ref: payment_ref)
@@ -130,22 +141,34 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
             original_lease_date: sc_leasedate,
             lessee_full_name: lessee_full_name,
             lessee_short_name: lessee_full_name,
-            date_of_current_purchase_assignment: commencement_of_tenancy,
-            property_address: ', '
-          }.merge(expected_correspondence_address))
+            date_of_current_purchase_assignment: commencement_of_tenancy
+          }.merge(expected_correspondence_address_when_property)
+           .merge(expected_property_address))
         end
       end
     end
   end
 
-  def expected_correspondence_address
+  def expected_correspondence_address_when_household
     {
       correspondence_address1: corr_preamble,
-      correspondence_address2: corr_desig + ' ' + address[:aline1],
-      correspondence_address3: address[:aline2],
-      correspondence_address4: address[:aline3],
-      correspondence_address5: address[:aline4],
-      correspondence_postcode: address[:post_code],
+      correspondence_address2: corr_desig + ' ' + household_address[:aline1],
+      correspondence_address3: household_address[:aline2],
+      correspondence_address4: household_address[:aline3],
+      correspondence_address5: household_address[:aline4],
+      correspondence_postcode: household_address[:post_code],
+      international: false
+    }
+  end
+
+  def expected_correspondence_address_when_property
+    {
+      correspondence_address1: corr_preamble,
+      correspondence_address2: corr_desig + ' ' + property_address[:aline1],
+      correspondence_address3: property_address[:aline2],
+      correspondence_address4: property_address[:aline3],
+      correspondence_address5: property_address[:aline4],
+      correspondence_postcode: property_address[:post_code],
       international: false
     }
   end

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -93,7 +93,7 @@ module UniversalHousingHelper
     )
   end
 
-  def create_uh_property(property_ref:, patch_code: '', post_preamble: '', address1: '', post_code: '')
+  def create_uh_property(property_ref:, patch_code: '', post_preamble: '', address1: '', post_code: '', post_desig: '')
     Hackney::UniversalHousing::Client.connection[:property].insert(
       prop_ref: property_ref,
       arr_patch: patch_code,
@@ -117,7 +117,8 @@ module UniversalHousingHelper
       dtstamp: DateTime.now,
       post_preamble: post_preamble,
       address1: address1,
-      post_code: post_code
+      post_code: post_code,
+      post_desig: post_desig
     )
   end
 


### PR DESCRIPTION
This includes a refactor to make our tests actually prove we're choosing between the household and property addresses correctly.

For actual behaviour changes, look at the individual commits