### PR TITLE
add support for multi-household properties

### DIFF
--- a/lib/hackney/income/universal_housing_leasehold_gateway.rb
+++ b/lib/hackney/income/universal_housing_leasehold_gateway.rb
@@ -15,7 +15,7 @@ module Hackney
               .where(u_saff_rentacc: payment_ref)
               .exclude(Sequel.trim(Sequel.qualify(:tenagree, :prop_ref)) => '')
               .join(rent, prop_ref: :prop_ref)
-              .join(household, prop_ref: :prop_ref)
+              .join(household, house_ref: Sequel.qualify(:tenagree, :house_ref))
               .first
 
         raise TenancyNotFoundError unless res.present?
@@ -25,7 +25,7 @@ module Hackney
         property_res = property.first(prop_ref: prop_ref) || {}
         corr_address = get_correspondence_address(
           corr_postcode: res[:corr_postcode],
-          prop_postcode: res[:post_code],
+          prop_postcode: property_res[:post_code],
           household_res: res,
           property_res: property_res
         )

--- a/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_leasehold_gateway_spec.rb
@@ -66,7 +66,6 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
 
     context 'when payment_ref exists' do
       let(:set_household_postcode) { household_postcode }
-      let(:set_property_postcode) { property_postcode }
       let(:create_property) { true }
 
       before do
@@ -75,15 +74,13 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
         create_uh_rent(sc_leasedate: sc_leasedate, prop_ref: prop_ref)
         create_uh_househ(house_ref: house_ref, prop_ref: prop_ref, house_desc: lessee_full_name,
                          corr_preamble: corr_preamble, corr_desig: corr_desig,
-                         corr_postcode: set_household_postcode, post_code: set_property_postcode)
+                         corr_postcode: set_household_postcode)
         create_uh_property(prop_address.merge(property_ref: prop_ref)) if create_property
         create_uh_postcode(household_address)
         create_uh_postcode(property_address)
       end
 
       context 'when corr_postcode' do
-        let(:set_property_postcode) { ' ' }
-
         it 'get the prop_ref' do
           result = gateway.get_leasehold_info(payment_ref: payment_ref)
 
@@ -102,7 +99,6 @@ describe Hackney::Income::UniversalHousingLeaseholdGateway, universal: true do
 
       context 'when both correspondence postcode and property address do NOT exist' do
         let(:set_household_postcode) { ' ' }
-        let(:set_property_postcode) { ' ' }
         let(:create_property) { false }
 
         it 'get the prop_ref' do


### PR DESCRIPTION
We need to look for the correspondence address based on the household reference.
We also need to use the property postcode as a base, instead of the household postcode