### PR TITLE
Revert "fix checking state when document is accepted"

### DIFF
--- a/lib/hackney/notification/enqueue_request_all_precompiled_letter_states.rb
+++ b/lib/hackney/notification/enqueue_request_all_precompiled_letter_states.rb
@@ -12,7 +12,7 @@ module Hackney
         self.document_store = document_store
         self.documents =
           document_store.where('updated_at >= ?', Time.now - 7.days)
-                        .where.not(status: %i[nil validation-failed received])
+                        .where.not(status: %i[nil validation-failed accepted])
       end
 
       def execute

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -52,8 +52,8 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }
-      it { expect(subject.documents).to include(accepted) }
-      it { expect(subject.documents).not_to include(received) }
+      it { expect(subject.documents).to include(received) }
+      it { expect(subject.documents).not_to include(accepted) }
       it { expect(subject.documents).not_to include(failed) }
 
       it 'all statuses should be checked' do


### PR DESCRIPTION
This needs a bit more work, and it's blocking a deploy to production

Reverts LBHackney-IT/lbh-income-api#182