### PR TITLE
Backdated action diary requests

### DIFF
--- a/app/jobs/hackney/income/jobs/add_action_diary_entry_job.rb
+++ b/app/jobs/hackney/income/jobs/add_action_diary_entry_job.rb
@@ -8,13 +8,13 @@ module Hackney
           0
         end
 
-        def perform(tenancy_ref:, action_code:, comment:)
+        def perform(tenancy_ref:, action_code:, comment:, user_id: nil)
           Rails.logger.info("Starting AddActionDiaryEntryJob for tenancy_ref #{tenancy_ref} and action code #{action_code}")
           income_use_case_factory.add_action_diary.execute(
             tenancy_ref: tenancy_ref,
             action_code: action_code,
             comment: comment,
-            user_id: nil
+            user_id: user_id
           )
         end
       end

--- a/lib/hackney/tenancy/add_action_diary_entry.rb
+++ b/lib/hackney/tenancy/add_action_diary_entry.rb
@@ -8,14 +8,15 @@ module Hackney
         @users_gateway = users_gateway
       end
 
-      def execute(tenancy_ref:, action_code:, comment:, user_id: nil)
+      def execute(tenancy_ref:, action_code:, comment:, user_id: nil, date: nil)
         # if user_id look up
         username = user_id.nil? ? nil : @users_gateway.find_user(id: user_id)&.name
+        date = date.nil? ? DateTime.now : date
 
         raise ArgumentError, 'user_id supplied does not exist' if !user_id.nil? && username.nil?
 
         Rails.logger.info("Adding action diary comment to #{tenancy_ref} with username '#{username}'")
-        @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: username)
+        @action_diary_gateway.create_entry(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: username, date: date)
       end
     end
   end

--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -19,13 +19,14 @@ module Hackney
           }
         end
 
-        def create_entry(tenancy_ref:, action_code:, comment:, username: nil)
+        def create_entry(tenancy_ref:, action_code:, comment:, date:, username: nil)
           body = {
-            tenancyAgreementRef: tenancy_ref,
-            actionCode: action_code,
-            comment: comment
+            TenancyAgreementRef: tenancy_ref,
+            ActionCode: action_code,
+            Comment: comment,
+            CreatedDate: date.iso8601
           }
-          body[:username] = username unless username.nil?
+          body[:Username] = username unless username.nil?
           responce = self.class.post('/api/v2/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
 
           unless responce.success?

--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -21,12 +21,12 @@ module Hackney
 
         def create_entry(tenancy_ref:, action_code:, comment:, date:, username: nil)
           body = {
-            TenancyAgreementRef: tenancy_ref,
-            ActionCode: action_code,
-            Comment: comment,
-            CreatedDate: date.iso8601
+            tenancyAgreementRef: tenancy_ref,
+            actionCode: action_code,
+            comment: comment,
+            createdDate: date.iso8601
           }
-          body[:Username] = username unless username.nil?
+          body[:username] = username unless username.nil?
           responce = self.class.post('/api/v2/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
 
           unless responce.success?

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -9,17 +9,30 @@ describe Hackney::Tenancy::AddActionDiaryEntry do
   let(:tenancy_ref) { Faker::Lorem.characters(8) }
   let(:action_code) { Faker::Internet.slug }
   let(:comment) { Faker::Lorem.paragraph }
+  let(:date) { Faker::Date.backward }
 
   context 'when the system wants to add an action diary message' do
     subject { usecase.execute(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment) }
 
     it 'calls the action_diary_gateway' do
+      allow(DateTime).to receive(:now).and_return(date)
+
       expect(action_diary_gateway).to receive(:create_entry)
-        .with(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: nil)
+        .with(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: nil, date: date)
         .once
 
       subject
     end
+  end
+
+  it 'optional date can be supplied that is passed to the gateway' do
+    given_date = Faker::Date.backward
+
+    expect(action_diary_gateway).to receive(:create_entry)
+      .with(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: nil, date: given_date)
+      .once
+
+    usecase.execute(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, date: given_date)
   end
 
   context 'when a user wants to add an action diary message' do
@@ -28,10 +41,11 @@ describe Hackney::Tenancy::AddActionDiaryEntry do
     let(:user) { OpenStruct.new(name: Faker::Name.name, id: Faker::Number.number(3).to_i) }
 
     it 'calls the action_diary_gateway' do
+      allow(DateTime).to receive(:now).and_return(date)
       expect(users_gateway).to receive(:find_user).with(id: user.id).and_return(user).once
 
       expect(action_diary_gateway).to receive(:create_entry)
-        .with(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: user.name)
+        .with(tenancy_ref: tenancy_ref, action_code: action_code, comment: comment, username: user.name, date: date)
         .once
 
       subject

--- a/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
@@ -9,6 +9,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
   let(:username) { Faker::Name.name }
   let(:action_code) { Faker::Internet.slug }
   let(:comment) { Faker::Lorem.paragraph }
+  let(:date) { Faker::Time.backward }
 
   let(:required_headers) do
     {
@@ -27,36 +28,42 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
       gateway.create_entry(
         tenancy_ref: tenancy_ref,
         action_code: action_code,
-        comment: comment
+        comment: comment,
+        date: date
       )
 
       assert_requested(
         :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: required_headers,
         body: {
-          tenancyAgreementRef: tenancy_ref,
-          actionCode: action_code,
-          comment: comment
-        }.to_json,
+          TenancyAgreementRef: tenancy_ref,
+          ActionCode: action_code,
+          Comment: comment,
+          CreatedDate: date
+        },
         times: 1
       )
     end
 
     it 'creates a entry with user user if username supplied' do
-      gateway.create_entry(tenancy_ref: tenancy_ref,
-                           action_code: action_code,
-                           comment: comment,
-                           username: username)
+      gateway.create_entry(
+        tenancy_ref: tenancy_ref,
+        action_code: action_code,
+        comment: comment,
+        username: username,
+        date: date
+      )
 
       assert_requested(
         :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: required_headers,
         body: {
-          tenancyAgreementRef: tenancy_ref,
-          actionCode: action_code,
-          comment: comment,
-          username: username
-        }.to_json,
+          TenancyAgreementRef: tenancy_ref,
+          ActionCode: action_code,
+          Comment: comment,
+          Username: username,
+          CreatedDate: date
+        },
         times: 1
       )
     end
@@ -73,6 +80,7 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
           tenancy_ref: tenancy_ref,
           action_code: action_code,
           comment: comment,
+          date: date,
           username: username
         )
       }.to raise_error(

--- a/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
@@ -36,10 +36,10 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
         :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: required_headers,
         body: {
-          TenancyAgreementRef: tenancy_ref,
-          ActionCode: action_code,
-          Comment: comment,
-          CreatedDate: date
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: action_code,
+          comment: comment,
+          createdDate: date
         },
         times: 1
       )
@@ -58,11 +58,11 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
         :post, host + '/api/v2/tenancies/arrears-action-diary',
         headers: required_headers,
         body: {
-          TenancyAgreementRef: tenancy_ref,
-          ActionCode: action_code,
-          Comment: comment,
-          Username: username,
-          CreatedDate: date
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: action_code,
+          comment: comment,
+          username: username,
+          createdDate: date
         },
         times: 1
       )


### PR DESCRIPTION
### What is the change:
- add a new field (date) to the action diary gateway/use case.

### Reason for this change:
- Action diary events can be backfilled when fixing errors (current priority)
- This is the groundwork for a longer-term fix of making add to action diary a background process.
	
	The first step is to be able to add an entry using a given time. 
	(This will then allow the task to be able to run in the background without delaying the time of the action diary event)
	
### related work
- gateway doc https://g6bw0g0ojk.execute-api.eu-west-2.amazonaws.com/production/tenancy/swagger/index.html?urls.primaryName=TenancyAPI%20v2
-  https://github.com/LBHackney-IT/LBHTenancyAPI/pull/113