### PR TITLE
Increase width of lessee address box

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,4 @@ For more: [AWS Client Side encryption] https://docs.aws.amazon.com/AmazonS3/late
 [mt-ca]: https://github.com/madetech/clean-architecture
 [made-tech]: https://madetech.com/
 [rubocop]: https://github.com/rubocop-hq/rubocop
+

--- a/README.md
+++ b/README.md
@@ -149,4 +149,3 @@ For more: [AWS Client Side encryption] https://docs.aws.amazon.com/AmazonS3/late
 [mt-ca]: https://github.com/madetech/clean-architecture
 [made-tech]: https://madetech.com/
 [rubocop]: https://github.com/rubocop-hq/rubocop
-

--- a/lib/hackney/pdf/templates/pdf_styles.css
+++ b/lib/hackney/pdf/templates/pdf_styles.css
@@ -16,7 +16,7 @@
 }
 
 .lessee_address {
-  width: 95mm;
+  width: 120mm;
   margin-top: 0;
   margin-bottom: 112.32pt;
   margin-left: 30pt;

--- a/lib/hackney/pdf/templates/pdf_styles.css
+++ b/lib/hackney/pdf/templates/pdf_styles.css
@@ -16,9 +16,9 @@
 }
 
 .lessee_address {
-  width: 120mm;
-  margin-top: 0;
-  margin-bottom: 112.32pt;
+  width: 117mm;
+  margin-top: -3mm;
+  margin-bottom: 120pt;
   margin-left: 30pt;
 }
 


### PR DESCRIPTION
**What**

a) Very long Lessee full name is causing the letter to fail validation by Gov Notify. Have increased the max-width for this line. 
b) Reclaim some of the whitespace at the top of the envelope window box.

**Why**

a) Resolves validation issues
b) allows additional wrapping of up to two lines, at the cost of Lessee and Sender address blocks no longer being aligned.
