### PR TITLE
Swap from individuals to teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-*       @cob16 @alexdesi @mrosel @elena-vi
+*       @LBHackney-IT/Madetech


### PR DESCRIPTION
**What**

Moves away from named individuals to use the `Madetech` (sic) team within the Hackney org (`LBHackney-IT`).

**Why**

This will stop unnecessary code churn when people join and leave the project. 

**Concerns**

Would recommend pruning the list of users in the `Madetech` team or perhaps creating a new team called `ManageArrears`?