### PR TITLE
Add weekly balance  and latest communication action and date to sync

### DIFF
--- a/db/migrate/20190930143533_add_rent_to_case_priority.rb
+++ b/db/migrate/20190930143533_add_rent_to_case_priority.rb
@@ -1,0 +1,5 @@
+class AddRentToCasePriority < ActiveRecord::Migration[5.2]
+  def change
+    add_column :case_priorities, :weekly_rent, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/migrate/20191001160154_add_last_communication_action.rb
+++ b/db/migrate/20191001160154_add_last_communication_action.rb
@@ -1,0 +1,5 @@
+class AddLastCommunicationAction < ActiveRecord::Migration[5.2]
+  def change
+    add_column :case_priorities, :last_communication_action, :string, default: nil
+  end
+end

--- a/db/migrate/20191001160536_add_last_communication_date.rb
+++ b/db/migrate/20191001160536_add_last_communication_date.rb
@@ -1,6 +1,5 @@
 class AddLastCommunicationDate < ActiveRecord::Migration[5.2]
   def change
     add_column :case_priorities, :last_communication_date, :datetime
-
   end
 end

--- a/db/migrate/20191001160536_add_last_communication_date.rb
+++ b/db/migrate/20191001160536_add_last_communication_date.rb
@@ -1,0 +1,6 @@
+class AddLastCommunicationDate < ActiveRecord::Migration[5.2]
+  def change
+    add_column :case_priorities, :last_communication_date, :datetime
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_143533) do
+ActiveRecord::Schema.define(version: 2019_10_01_160536) do
 
   create_table "case_priorities", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 2019_09_30_143533) do
     t.datetime "nosp_served_date"
     t.datetime "nosp_expiry_date"
     t.decimal "weekly_rent", precision: 10, scale: 2
+    t.string "last_communication_action"
+    t.datetime "last_communication_date"
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
     t.index ["case_id"], name: "index_case_priorities_on_case_id"
     t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_102411) do
+ActiveRecord::Schema.define(version: 2019_09_30_143533) do
 
   create_table "case_priorities", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_102411) do
     t.integer "case_id"
     t.datetime "nosp_served_date"
     t.datetime "nosp_expiry_date"
+    t.decimal "weekly_rent", precision: 10, scale: 2
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
     t.index ["case_id"], name: "index_case_priorities_on_case_id"
     t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -37,7 +37,8 @@ module Hackney
               nosp_served: criteria.nosp_served?,
               nosp_served_date: criteria.nosp_served_date,
               nosp_expiry_date: criteria.nosp_expiry_date,
-
+              last_communication_action: criteria.last_communication_action,
+              last_communication_date: criteria.last_communication_date,
               active_nosp: criteria.active_nosp?
             )
           end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -26,6 +26,7 @@ module Hackney
               active_nosp_contribution: score_calculator.active_nosp,
 
               balance: criteria.balance,
+              weekly_rent: criteria.weekly_rent,
               days_in_arrears: criteria.days_in_arrears,
               days_since_last_payment: criteria.days_since_last_payment,
               payment_amount_delta: criteria.payment_amount_delta,

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -147,13 +147,13 @@ module Hackney
         end
 
         def last_communication_action
-          return nil if attributes.fetch(:last_communication_action).nil?
-          attributes.fetch(:last_communication_action)
+          return nil if attributes[:last_communication_action].nil?
+          attributes[:last_communication_action]
         end
 
         def last_communication_date
-          return nil if attributes.fetch(:last_communication_date).nil?
-          attributes.fetch(:last_communication_date)
+          return nil if attributes[:last_communication_date].nil?
+          attributes[:last_communication_date]
         end
 
         def active_agreement?

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -39,19 +39,19 @@ module Hackney
             DECLARE @BreachedAgreementsCount INT = (SELECT COUNT(tag_ref) FROM [dbo].[arag] WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND arag_status = @BreachedArrearsAgreementStatus)
             DECLARE @NospsInLastYear INT = (SELECT COUNT(tag_ref) FROM araction WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND action_code = @NospActionDiaryCode AND action_date >= CONVERT(date, DATEADD(year, -1, GETDATE())))
             DECLARE @NospsInLastMonth INT = (SELECT COUNT(tag_ref) FROM araction WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND action_code = @NospActionDiaryCode AND action_date >= CONVERT(date, DATEADD(month, -1, GETDATE())))
-        
+
             DECLARE @LastCommunicationAction VARCHAR(60) = (
-              SELECT TOP 1 action_code 
+              SELECT TOP 1 action_code
               FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
-              AND action_code IN (SELECT communication_types FROM @CommunicationTypes) 
+              AND action_code IN (SELECT communication_types FROM @CommunicationTypes)
               ORDER BY action_date DESC
             )
             DECLARE @LastCommunicationDate SMALLDATETIME = (
-              SELECT TOP 1 action_date 
+              SELECT TOP 1 action_date
               FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
-              AND action_code IN (SELECT communication_types FROM @CommunicationTypes) 
+              AND action_code IN (SELECT communication_types FROM @CommunicationTypes)
               ORDER BY action_date DESC
             )
 

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -119,7 +119,6 @@ module Hackney
         end
 
         def days_in_arrears
-          byebug
           day_difference(Date.today, attributes.fetch(:arrears_start_date))
         end
 

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -28,6 +28,10 @@ module Hackney
               SELECT u_notice_expiry FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
             )
 
+            DECLARE @WeeklyRent NUMERIC(9, 2) = (
+              SELECT rent FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
+            )
+
 
             DECLARE @RemainingTransactions INT = (SELECT COUNT(tag_ref) FROM [dbo].[rtrans] WITH (NOLOCK) WHERE tag_ref = @TenancyRef)
             DECLARE @ActiveAgreementsCount INT = (SELECT COUNT(tag_ref) FROM [dbo].[arag] WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND arag_status = @ActiveArrearsAgreementStatus)
@@ -61,6 +65,7 @@ module Hackney
 
             SELECT
               @CurrentBalance as current_balance,
+              @WeeklyRent as weekly_rent,
               @LastPaymentDate as last_payment_date,
               @ArrearsStartDate as arrears_start_date,
               @ActiveAgreementsCount as active_agreements_count,
@@ -97,6 +102,10 @@ module Hackney
           attributes.fetch(:current_balance).to_f
         end
 
+        def weekly_rent
+          attributes.fetch(:weekly_rent).to_f
+        end
+
         def nosp_served_date
           return if attributes[:nosp_served_date].nil?
 
@@ -110,6 +119,7 @@ module Hackney
         end
 
         def days_in_arrears
+          byebug
           day_difference(Date.today, attributes.fetch(:arrears_start_date))
         end
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -66,6 +66,7 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_nosp_contribution: score_calculator.active_nosp,
 
           balance: attributes.fetch(:criteria).balance,
+          weekly_rent: attributes.fetch(:criteria).weekly_rent,
           days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
           days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
           payment_amount_delta: attributes.fetch(:criteria).payment_amount_delta,

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -131,23 +131,25 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     end
   end
 
-  describe '#last_communciation_type' do
+  describe '#last_communciation_action' do
     subject { criteria.last_communication_action }
 
     context 'when the tenant has not been contacted' do
       it { is_expected.to be_nil }
     end
 
-    context 'can return action code for the latest communication action' do
+    context 'when in communication with the tenant' do
       before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
         create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.today - 2.days)
       }
 
-      it { is_expected.to eq('MML') }
+      it 'return the latest communication code' do
+        expect(subject).to eq('MML')
+      end
     end
 
-    context 'does not return action code if it is not a communication action code' do
+    context 'when an action code is not a communication action code' do
       before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'RBA', date: Date.today)
       }
@@ -163,13 +165,15 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
       it { is_expected.to be_nil }
     end
 
-    context 'can return action date for the latest communication action' do
+    context 'when in communication with the tenant' do
       before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.yesterday)
         create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
       }
 
-      it { is_expected.to eq(Date.today) }
+      it 'return the latest communication code' do
+        expect(subject).to eq(Date.today)
+      end
     end
   end
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -131,6 +131,21 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     end
   end
 
+  describe '#last_communciation_type' do
+    subject { criteria.last_communciation_type }
+
+    context 'when the tenant has not been contacted' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when has been sent an' do
+      #before { create_uh_transaction(tenancy_ref: tenancy_ref, type: 'RPY', date: Date.today - 2.days) }
+
+      it { is_expected.to eq("Maysa") }
+    end
+
+  end
+
   describe '#active_agreement?' do
     subject { criteria.active_agreement? }
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -56,6 +56,7 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
 
     context 'when the tenancy is not in arrears' do
       let(:current_balance) { -50.00 }
+
       it { is_expected.to be_zero }
     end
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -171,7 +171,7 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
         create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
       }
 
-      it 'return the latest communication code' do
+      it 'return the latest communication date' do
         expect(subject).to eq(Date.today)
       end
     end

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -27,6 +27,14 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     end
   end
 
+  describe '#weekly_rent' do
+    subject { criteria.weekly_rent }
+
+    it 'returns the weekly rent of a tenancy' do
+      expect(subject).to eq(5)
+    end
+  end
+
   describe '#nosp_served_date' do
     subject { criteria.nosp_served_date }
 
@@ -48,7 +56,6 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
 
     context 'when the tenancy is not in arrears' do
       let(:current_balance) { -50.00 }
-
       it { is_expected.to be_zero }
     end
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -139,20 +139,20 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     end
 
     context 'can return action code for the latest communication action' do
-      before { 
+      before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
-        create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.today-2.days)
-       }
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.today - 2.days)
+      }
 
-      it { is_expected.to eq("MML") }
+      it { is_expected.to eq('MML') }
     end
 
     context 'does not return action code if it is not a communication action code' do
-      before { 
+      before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'RBA', date: Date.today)
-       }
+      }
 
-      it { is_expected.to be_nil}
+      it { is_expected.to be_nil }
     end
   end
 
@@ -164,10 +164,10 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     end
 
     context 'can return action date for the latest communication action' do
-      before { 
+      before {
         create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.yesterday)
         create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
-       }
+      }
 
       it { is_expected.to eq(Date.today) }
     end

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -132,18 +132,45 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
   end
 
   describe '#last_communciation_type' do
-    subject { criteria.last_communciation_type }
+    subject { criteria.last_communication_action }
 
     context 'when the tenant has not been contacted' do
       it { is_expected.to be_nil }
     end
 
-    context 'when has been sent an' do
-      #before { create_uh_transaction(tenancy_ref: tenancy_ref, type: 'RPY', date: Date.today - 2.days) }
+    context 'can return action code for the latest communication action' do
+      before { 
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.today-2.days)
+       }
 
-      it { is_expected.to eq("Maysa") }
+      it { is_expected.to eq("MML") }
     end
 
+    context 'does not return action code if it is not a communication action code' do
+      before { 
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'RBA', date: Date.today)
+       }
+
+      it { is_expected.to be_nil}
+    end
+  end
+
+  describe '#last_communciation_date' do
+    subject { criteria.last_communication_date }
+
+    context 'when the tenant has not been contacted' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'can return action date for the latest communication action' do
+      before { 
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'S0A', date: Date.yesterday)
+        create_uh_action(tenancy_ref: tenancy_ref, code: 'MML', date: Date.today)
+       }
+
+      it { is_expected.to eq(Date.today) }
+    end
   end
 
   describe '#active_agreement?' do

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -12,6 +12,10 @@ module Stubs
       @balance || 100.00
     end
 
+    def weekly_rent
+      5.0
+    end
+
     def nosp_served_date
       '2019-12-13 12:43:10'.to_date
     end

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -12,6 +12,14 @@ module Stubs
       @balance || 100.00
     end
 
+    def last_communication_action
+      @last_communication_action
+    end
+
+    def last_communication_date
+      @last_communication_date
+    end
+
     def weekly_rent
       5.0
     end

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -12,13 +12,9 @@ module Stubs
       @balance || 100.00
     end
 
-    def last_communication_action
-      @last_communication_action
-    end
+    attr_reader :last_communication_action
 
-    def last_communication_date
-      @last_communication_date
-    end
+    attr_reader :last_communication_date
 
     def weekly_rent
       5.0

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -1,10 +1,11 @@
 module UniversalHousingHelper
   # rubocop:disable Metrics/ParameterLists
-  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, prop_ref: '', terminated: false, cot: '',
+  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, rent: 5.0 ,prop_ref: '', terminated: false, cot: '',
                                   tenure_type: 'SEC', high_action: '111', u_saff_rentacc: '', house_ref: '')
     Hackney::UniversalHousing::Client.connection[:tenagree].insert(
       tag_ref: tenancy_ref,
       cur_bal: current_balance,
+      rent: rent,
       prop_ref: prop_ref,
       terminated: terminated ? 1 : 0,
       tenure: tenure_type,

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -1,6 +1,6 @@
 module UniversalHousingHelper
   # rubocop:disable Metrics/ParameterLists
-  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, rent: 5.0 ,prop_ref: '', terminated: false, cot: '',
+  def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, rent: 5.0, prop_ref: '', terminated: false, cot: '',
                                   tenure_type: 'SEC', high_action: '111', u_saff_rentacc: '', house_ref: '')
     Hackney::UniversalHousing::Client.connection[:tenagree].insert(
       tag_ref: tenancy_ref,


### PR DESCRIPTION
**What?**
-  Extracted weekly rent for tenancy from UH

- Saved this on income-collection db

- Extracted last_communication_action (code) from the araction table is UH

- Extracted last_communication_date from the araction table is UH

**Why?**

- To do weekly sync and calculate priority score

- Save last_communication_action and last_communication_date to income-api ab