### PR TITLE
adjusting last communications codes

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -28,8 +28,8 @@ module Hackney
 
         def send_letter_one?
           valid_actions = [
-            Hackney::Tenancy::ActionCodes::GREEN_SMS_SENT_AUTO,
-            Hackney::Tenancy::ActionCodes::GREEN_SMS_SENT_MANUAL
+            Hackney::Tenancy::ActionCodes::AUTOMATED_SMS_ACTION_CODE,
+            Hackney::Tenancy::ActionCodes::MANUAL_SMS_ACTION_CODE
           ]
 
           @criteria.last_communication_action.in?(valid_actions) &&
@@ -41,8 +41,7 @@ module Hackney
 
         def send_letter_two?
           valid_actions = [
-            Hackney::Tenancy::ActionCodes::LETTER_1_IN_ARREARS_AUTO,
-            Hackney::Tenancy::ActionCodes::LETTER_1_IN_ARREARS_MANUAL
+            Hackney::Tenancy::ActionCodes::LETTER_1_IN_ARREARS_SENT
           ]
 
           @criteria.last_communication_action.in?(valid_actions) &&
@@ -55,8 +54,7 @@ module Hackney
 
         def send_warning_letter?
           valid_actions = [
-            Hackney::Tenancy::ActionCodes::LETTER_2_IN_ARREARS_AUTO,
-            Hackney::Tenancy::ActionCodes::LETTER_2_IN_ARREARS_MANUAL
+            Hackney::Tenancy::ActionCodes::LETTER_2_IN_ARREARS_SENT
           ]
 
           @criteria.last_communication_action.in?(valid_actions) &&
@@ -68,8 +66,7 @@ module Hackney
 
         def send_nosp?
           valid_actions = [
-            Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_AUTO,
-            Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_MANUAL
+            Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT
           ]
           @criteria.last_communication_action.in?(valid_actions) &&
             @criteria.balance >= arrear_accumulation_by_number_weeks(4) &&

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -11,7 +11,7 @@ module Hackney
             DECLARE @PaymentTypes table(payment_type varchar(3))
             INSERT INTO @PaymentTypes VALUES ('RBA'), ('RBP'), ('RBR'), ('RCI'), ('RCO'), ('RCP'), ('RDD'), ('RDN'), ('RDP'), ('RDR'), ('RDS'), ('RDT'), ('REF'), ('RHA'), ('RHB'), ('RIT'), ('RML'), ('RPD'), ('RPO'), ('RPY'), ('RQP'), ('RRC'), ('RRP'), ('RSO'), ('RTM'), ('RUC'), ('RWA')
             DECLARE @CommunicationTypes table(communication_types varchar(60))
-            INSERT INTO @CommunicationTypes VALUES ('C'), ('MML'), ('S0A'), ('REF'), ('ZW1'), ('ZW2'), ('ZW3'), ('MW1'), ('MW2'), ('MW3'), ('LF1'), ('LF2'), ('LL1'), ('LL2'), ('LS1'), ('LS2'), ('SMS'), ('GAT'), ('GAE'), ('GME'), ('GMS'), ('AMS')
+            INSERT INTO @CommunicationTypes VALUES ('C'), ('MML'), ('S0A'), ('REF'), ('ZW1'), ('ZW2'), ('ZW3'), ('MW1'), ('MW2'), ('MW3'), ('LF1'), ('LF2'), ('LL1'), ('LL2'), ('LS1'), ('LS2'), ('SMS'), ('GAT'), ('GAE'), ('GME'), ('GMS'), ('AMS'), ('ZR1'), ('ZR2')
 
             DECLARE @CurrentBalance NUMERIC(9, 2) = (SELECT cur_bal FROM [dbo].[tenagree] WITH (NOLOCK) WHERE tag_ref = @TenancyRef)
             DECLARE @LastPaymentDate SMALLDATETIME = (

--- a/lib/hackney/tenancy/action_codes.rb
+++ b/lib/hackney/tenancy/action_codes.rb
@@ -18,17 +18,11 @@ module Hackney
       LETTER_1_IN_ARREARS_SO = 'LS1'.freeze
       LETTER_2_IN_ARREARS_SO = 'LS2'.freeze
 
-      GREEN_SMS_SENT_AUTO = 'GAT'.freeze
-      GREEN_SMS_SENT_MANUAL = 'GMS'.freeze
+      LETTER_1_IN_ARREARS_SENT = 'ZR1'.freeze
 
-      LETTER_1_IN_ARREARS_AUTO = 'IC1'.freeze
-      LETTER_1_IN_ARREARS_MANUAL = 'IM1'.freeze
+      LETTER_2_IN_ARREARS_SENT = 'ZR2'.freeze
 
-      LETTER_2_IN_ARREARS_AUTO = 'IC2'.freeze
-      LETTER_2_IN_ARREARS_MANUAL = 'IM2'.freeze
-
-      PRE_NOSP_WARNING_LETTER_AUTO = 'IC3'.freeze
-      PRE_NOSP_WARNING_LETTER_MANUAL = 'IM3'.freeze
+      PRE_NOSP_WARNING_LETTER_SENT = 'not yet defined in UH'.freeze
     end
   end
 end

--- a/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
@@ -110,8 +110,7 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
 
     context 'when the arrears are greater than or equal to one weeks rent and less than 3 week rent' do
       last_communication_actions = {
-        letter_one_in_arrears_auto: 'IC1',
-        letter_one_in_arrears_manual: 'IM1'
+        letter_one_in_arrears_auto: 'ZR1'
       }
       last_communication_actions.each do |key, last_communication_action|
         it "can classify to send letter two when the tenant has arreas of 1 week with a last communication action of #{key}" do
@@ -143,8 +142,7 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
 
     context 'when the arrears are greater than or equal to three weeks rent and less than 4 week rent' do
       last_communication_actions = {
-        letter_two_in_arrears_auto: 'IC2',
-        letter_two_in_arrears_manual: 'IM2'
+        letter_two_in_arrears: 'ZR2'
       }
       last_communication_actions.each do |key, last_communication_action|
         it "can classify to send a warning letter when the tenant has missed three weeks rent with a last communication action of #{key}" do
@@ -167,8 +165,7 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
 
     context 'when the arrears are greater than or equal 4 week rent' do
       last_communication_actions = {
-        pre_nosp_warning_letter_auto: 'IC3',
-        pre_nosp_warning_letter_manual: 'IM3'
+        pre_nosp_warning_letter: 'not yet defined in UH' # this is a placeholder code defined in lib/hackney/tenancy/action_codes.rb
       }
       last_communication_actions.each do |key, last_communication_action|
         it "can classify to send a NOSP when the tenant has missed 4 weeks worth of rent with a last communication action of #{key}" do


### PR DESCRIPTION
We had implemented the classification rules without confirming which codes we should be checking. Now Elaine has provided accurate action diary codes that we should track. 

Please note that we still don't have a code for nosp warning letter - this still needs to be set up in UH