### PR TITLE
worktray to be filtered by patch

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -6,7 +6,8 @@ class MyCasesController < ApplicationController
       user_id: my_cases_params[:user_id],
       page_number: my_cases_params[:page_number],
       number_per_page: my_cases_params[:number_per_page],
-      is_paused: my_cases_params[:is_paused]
+      is_paused: my_cases_params[:is_paused],
+      classification: my_cases_params[:recommended_actions]
     )
 
     render json: response
@@ -14,7 +15,7 @@ class MyCasesController < ApplicationController
 
   def my_cases_params
     params.require(REQUIRED_INDEX_PARAMS)
-    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + [:is_paused])
+    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused recommended_actions])
 
     allowed_params[:user_id] = allowed_params[:user_id].to_i
 

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -52,24 +52,24 @@ module Hackney
         end
       end
 
-      def get_tenancies_for_user(user_id:, page_number: nil, number_per_page: nil, is_paused: nil)
-        query = tenancy_filtered_by_paused_state_for(user_id, is_paused)
+      def get_tenancies_for_user(user_id:, page_number: nil, number_per_page: nil, is_paused: nil, classification: nil)
+        query = tenancy_filtered_by_paused_state_for(user_id, is_paused, classification)
 
         query = query.offset((page_number - 1) * number_per_page).limit(number_per_page) if page_number.present? && number_per_page.present?
 
         query.order(by_balance).map(&method(:build_tenancy_list_item))
       end
 
-      def number_of_pages_for_user(user_id:, number_per_page:, is_paused: nil)
-        (tenancy_filtered_by_paused_state_for(user_id, is_paused).count.to_f / number_per_page).ceil
+      def number_of_pages_for_user(user_id:, number_per_page:, is_paused: nil, classification: nil)
+        (tenancy_filtered_by_paused_state_for(user_id, is_paused, classification).count.to_f / number_per_page).ceil
       end
 
       private
 
-      def tenancy_filtered_by_paused_state_for(user_id, is_paused)
-        query = GatewayModel.where('
-          assigned_user_id = ? AND
-          balance > ?', user_id, 0)
+      def tenancy_filtered_by_paused_state_for(user_id, is_paused, classification)
+        query = GatewayModel.where('assigned_user_id = ? AND balance > ?', user_id, 0)
+
+        query = query.where(classification: classification) if classification
 
         return query if is_paused.nil?
 

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -66,11 +66,11 @@ module Hackney
 
       private
 
-# filters: {
-#   is_paused: nil,
-#   classification: nil,
-#   patch: nil
-# }
+      # filters: {
+      #   is_paused: nil,
+      #   classification: nil,
+      #   patch: nil
+      # }
       def tenancies_filtered_for(user_id, filters)
         query = GatewayModel.where('
           assigned_user_id = ? AND

--- a/lib/hackney/income/view_my_cases.rb
+++ b/lib/hackney/income/view_my_cases.rb
@@ -8,11 +8,12 @@ module Hackney
         @stored_tenancies_gateway = stored_tenancies_gateway
       end
 
-      def execute(user_id:, page_number:, number_per_page:, is_paused: nil)
+      def execute(user_id:, page_number:, number_per_page:, is_paused: nil, classification: nil)
         number_of_pages_for_user = @stored_tenancies_gateway.number_of_pages_for_user(
           user_id: user_id,
           number_per_page: number_per_page,
-          is_paused: is_paused
+          is_paused: is_paused,
+          classification: classification
         )
         return Response.new([], 0) if number_of_pages_for_user.zero?
 
@@ -20,7 +21,8 @@ module Hackney
           user_id: user_id,
           page_number: page_number,
           number_per_page: number_per_page,
-          is_paused: is_paused
+          is_paused: is_paused,
+          classification: classification
         )
 
         assigned_tenancy_refs = assigned_tenancies.map { |t| t.fetch(:tenancy_ref) }

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -21,7 +21,7 @@ describe MyCasesController do
       it 'min of 1 should be used' do
         allow(view_my_cases_instance)
           .to receive(:execute)
-          .with(user_id: user_id, page_number: 1, number_per_page: 1, is_paused: nil)
+          .with(user_id: user_id, page_number: 1, number_per_page: 1, is_paused: nil, classification: nil)
 
         get :index, params: { user_id: user_id, page_number: 0, number_per_page: 0 }
       end
@@ -43,7 +43,7 @@ describe MyCasesController do
       it 'calls the view my cases use case with the given user_id, page_number and number_per_page' do
         allow(view_my_cases_instance)
           .to receive(:execute)
-          .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: nil)
+          .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: nil, classification: nil)
           .and_return(cases: [], number_per_page: 1)
 
         get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
@@ -72,7 +72,7 @@ describe MyCasesController do
 
         allow(view_my_cases_instance)
           .to receive(:execute)
-          .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: false)
+          .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: false, classification: nil)
           .and_return(expected_result)
 
         get :index, params: { user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: false }

--- a/spec/lib/hackney/income/view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/view_my_cases_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Hackney::Income::ViewMyCases do
-  subject { view_my_cases.execute(user_id: user_id, page_number: page_number, number_per_page: number_per_page) }
+  subject { view_my_cases.execute(user_id: user_id, page_number: page_number, number_per_page: number_per_page, classification: nil) }
 
   let(:user_id) { Faker::Number.number(2).to_i }
   let(:page_number) { Faker::Number.number(2).to_i }
@@ -158,7 +158,8 @@ describe Hackney::Income::ViewMyCases do
       expect(stored_tenancies_gateway).to receive(:number_of_pages_for_user).with(
         user_id: user_id,
         number_per_page: number_per_page,
-        is_paused: nil
+        is_paused: nil,
+        classification: nil
       ).and_call_original
       subject
     end

--- a/spec/lib/hackney/income/view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/view_my_cases_spec.rb
@@ -132,14 +132,16 @@ describe Hackney::Income::ViewMyCases do
       end
 
       context 'when filtering out paused cases' do
-        subject { view_my_cases.execute(
-          user_id: user_id,
-          page_number: page_number,
-          number_per_page: number_per_page,
-          filters: {
-            is_paused: true
-          }
-        ) }
+        subject {
+          view_my_cases.execute(
+            user_id: user_id,
+            page_number: page_number,
+            number_per_page: number_per_page,
+            filters: {
+              is_paused: true
+            }
+          )
+        }
 
         it 'returns only paused cases' do
           expect(stored_tenancies_gateway)

--- a/spec/support/stubs/stored_tenancy_gateway_stub.rb
+++ b/spec/support/stubs/stored_tenancy_gateway_stub.rb
@@ -5,11 +5,11 @@ module Hackney
         @stored_tenancies_attributes = stored_tenancies_attributes
       end
 
-      def get_tenancies_for_user(user_id:, page_number:, number_per_page:, is_paused: nil)
+      def get_tenancies_for_user(user_id:, page_number:, number_per_page:, is_paused: nil, classification: nil)
         @stored_tenancies_attributes.values
       end
 
-      def number_of_pages_for_user(user_id:, number_per_page:, is_paused: nil)
+      def number_of_pages_for_user(user_id:, number_per_page:, is_paused: nil, classification: nil)
         @stored_tenancies_attributes.keys.count
       end
     end


### PR DESCRIPTION
Now we are able to call 
GET `/api/v1/my-cases/?patch=W01` and get a worktray that is filtered by patch. 

The front end implementation of this is here https://github.com/LBHackney-IT/LBH-IncomeCollection/pull/215

https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=MA&modal=detail&selectedIssue=MA-183