### PR TITLE
Add query to set default filter for worktray

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -9,7 +9,8 @@ class MyCasesController < ApplicationController
       filters: {
         is_paused: my_cases_params[:is_paused],
         classification: my_cases_params[:recommended_actions],
-        patch: my_cases_params[:patch]
+        patch: my_cases_params[:patch],
+        full_patch: my_cases_params[:full_patch]
       }
     )
 
@@ -18,11 +19,12 @@ class MyCasesController < ApplicationController
 
   def my_cases_params
     params.require(REQUIRED_INDEX_PARAMS)
-    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused patch recommended_actions])
+    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused patch recommended_actions full_patch])
 
     allowed_params[:user_id] = allowed_params[:user_id].to_i
 
     allowed_params[:is_paused] = ActiveModel::Type::Boolean.new.cast(allowed_params[:is_paused])
+    allowed_params[:full_patch] = ActiveModel::Type::Boolean.new.cast(allowed_params[:full_patch])
 
     allowed_params[:page_number] = min_1(allowed_params[:page_number].to_i)
     allowed_params[:number_per_page] = min_1(allowed_params[:number_per_page].to_i)

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -90,9 +90,9 @@ module Hackney
       end
 
       def only_show_immediate_actions?(filters)
-        tabs_that_display_all_actions = [filters[:is_paused], filters[:full_patch]]
+        filters_that_return_all_actions = [filters[:is_paused], filters[:full_patch]]
 
-        tabs_that_display_all_actions.all? { |filter| filter == false || filter.nil? }
+        filters_that_return_all_actions.all? { |filter| filter == false || filter.nil? }
       end
 
       def by_balance

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -66,11 +66,6 @@ module Hackney
 
       private
 
-      # filters: {
-      #   is_paused: nil,
-      #   classification: nil,
-      #   patch: nil
-      # }
       def tenancies_filtered_for(user_id, filters)
         query = GatewayModel.where('
           assigned_user_id = ? AND
@@ -78,9 +73,9 @@ module Hackney
 
         query = query.where('patch_code = ?', filters[:patch]) if filters[:patch]
 
-        if filters[:classification]
+        if filters[:classification].present?
           query = query.where(classification: filters[:classification])
-        elsif !filters[:is_paused]
+        elsif only_show_immediate_actions?(filters)
           query = query.where.not(classification: :no_action).or(query.where(classification: nil))
         end
 
@@ -92,6 +87,12 @@ module Hackney
           query = query.not_paused
         end
         query
+      end
+
+      def only_show_immediate_actions?(filters)
+        tabs_that_display_all_actions = [filters[:is_paused], filters[:full_patch]]
+
+        tabs_that_display_all_actions.all? { |filter| filter == false || filter.nil? }
       end
 
       def by_balance

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -77,7 +77,12 @@ module Hackney
           balance > ?', user_id, 0)
 
         query = query.where('patch_code = ?', filters[:patch]) if filters[:patch]
-        query = query.where(classification: filters[:classification]) if filters[:classification]
+
+        if filters[:classification]
+          query = query.where(classification: filters[:classification])
+        elsif !filters[:is_paused]
+          query = query.where.not(classification: :no_action).or(query.where(classification: nil))
+        end
 
         return query if filters[:is_paused].nil?
 

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -24,7 +24,8 @@ describe MyCasesController do
           .with(user_id: user_id, page_number: 1, number_per_page: 1, filters: {
             is_paused: nil,
             classification: nil,
-            patch: nil
+            patch: nil,
+            full_patch: nil
           })
 
         get :index, params: { user_id: user_id, page_number: 0, number_per_page: 0 }
@@ -51,7 +52,8 @@ describe MyCasesController do
           .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, filters: {
             is_paused: nil,
             classification: nil,
-            patch: nil
+            patch: nil,
+            full_patch: nil
           })
           .and_return(cases: [], number_per_page: 1)
 
@@ -84,7 +86,8 @@ describe MyCasesController do
           .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, filters: {
             is_paused: false,
             classification: nil,
-            patch: nil
+            patch: nil,
+            full_patch: nil
           })
           .and_return(expected_result)
 
@@ -104,7 +107,8 @@ describe MyCasesController do
           .with(user_id: user_id, page_number: page_number, number_per_page: number_per_page, filters: {
             is_paused: nil,
             classification: nil,
-            patch: patch
+            patch: patch,
+            full_patch: nil
           })
           .and_return(expected_result)
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -397,7 +397,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with is_paused set false' do
         let(:is_paused) { false }
 
-        it 'shows the number pages of of paused cases' do
+        it 'shows the number pages of paused cases' do
           expect(subject).to eq(expected_num_pages(num_active_cases, num_pages))
         end
       end
@@ -405,15 +405,21 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with is_paused set true' do
         let(:is_paused) { true }
 
-        it 'shows the number pages of of paused cases' do
+        it 'shows the number pages of paused cases' do
           expect(subject).to eq(expected_num_pages(num_paused_cases, num_pages))
+        end
+
+        it 'shows the number pages of paused cases with one no_action classification' do
+          create(:case_priority, assigned_user_id: user.id, balance: 40, is_paused_until: Faker::Date.forward(1), classification: :no_action)
+
+          expect(subject).to eq(expected_num_pages(num_paused_cases + 1, num_pages))
         end
       end
 
       context 'with is_paused not set' do
         let(:is_paused) { nil }
 
-        it 'shows the number pages of of paused cases' do
+        it 'shows the number pages of paused cases' do
           expect(subject).to eq(expected_num_pages((num_paused_cases + num_active_cases), num_pages))
         end
       end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -423,7 +423,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with is_paused not set' do
         let(:is_paused) { nil }
 
-        it 'shows the number pages of paused cases' do
+        it 'shows the number of pages of paused cases' do
           expect(subject).to eq(expected_num_pages((num_paused_cases + num_active_cases), num_pages))
         end
       end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -397,7 +397,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with is_paused set false' do
         let(:is_paused) { false }
 
-        it 'shows the number pages of paused cases' do
+        it 'shows the number of pages of paused cases' do
           expect(subject).to eq(expected_num_pages(num_active_cases, num_pages))
         end
       end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -409,10 +409,14 @@ describe Hackney::Income::StoredTenanciesGateway do
           expect(subject).to eq(expected_num_pages(num_paused_cases, num_pages))
         end
 
-        it 'shows the number pages of paused cases with one no_action classification' do
-          create(:case_priority, assigned_user_id: user.id, balance: 40, is_paused_until: Faker::Date.forward(1), classification: :no_action)
+        context 'with one no_action classification case' do
+          before do
+            create(:case_priority, assigned_user_id: user.id, balance: 40, is_paused_until: Faker::Date.forward(1), classification: :no_action)
+          end
 
-          expect(subject).to eq(expected_num_pages(num_paused_cases + 1, num_pages))
+          it 'shows the number pages of paused cases with one no_action classification' do
+            expect(subject).to eq(expected_num_pages(num_paused_cases + 1, num_pages))
+          end
         end
       end
 
@@ -465,7 +469,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with no filter by classification' do
         let(:classification) { nil }
 
-        it 'does not return :no_action tenancies' do
+        it 'only returns tenancies with warning letters as next action' do
           expect(subject.count).to eq(cases_with_warning_letter_action)
         end
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -279,7 +279,7 @@ describe Hackney::Income::StoredTenanciesGateway do
     let(:user) { create(:user) }
     let(:other_user) { create(:user) }
 
-    context 'with thr user having ten tenancies in arrears and ten not in arrears' do
+    context 'with the user having ten tenancies in arrears and ten not in arrears' do
       before do
         create_list(:case_priority, 10, assigned_user_id: user.id, balance: 1)
         create_list(:case_priority, 10, assigned_user_id: user.id, balance: -1)
@@ -456,8 +456,8 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with no filter by classification' do
         let(:classification) { nil }
 
-        it 'returns all tenancies' do
-          expect(subject.count).to eq(cases_with_no_action + cases_with_warning_letter_action)
+        it 'does not return :no_action tenancies' do
+          expect(subject.count).to eq(cases_with_warning_letter_action)
         end
       end
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -414,7 +414,7 @@ describe Hackney::Income::StoredTenanciesGateway do
             create(:case_priority, assigned_user_id: user.id, balance: 40, is_paused_until: Faker::Date.forward(1), classification: :no_action)
           end
 
-          it 'shows the number pages of paused cases with one no_action classification' do
+          it 'shows the number of pages of paused cases with one no_action classification' do
             expect(subject).to eq(expected_num_pages(num_paused_cases + 1, num_pages))
           end
         end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -454,16 +454,27 @@ describe Hackney::Income::StoredTenanciesGateway do
           page_number: 1,
           number_per_page: 50,
           filters: {
-            classification: classification
+            classification: classification,
+            full_patch: full_patch
           }
         )
       end
+
+      let(:full_patch) { false }
 
       context 'with no filter by classification' do
         let(:classification) { nil }
 
         it 'does not return :no_action tenancies' do
           expect(subject.count).to eq(cases_with_warning_letter_action)
+        end
+
+        context 'when the full_patch filter is set' do
+          let(:full_patch) { true }
+
+          it 'contains all cases' do
+            expect(subject.count).to eq(cases_with_no_action + cases_with_warning_letter_action)
+          end
         end
       end
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -405,7 +405,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'with is_paused set true' do
         let(:is_paused) { true }
 
-        it 'shows the number pages of paused cases' do
+        it 'shows the number of pages of paused cases' do
           expect(subject).to eq(expected_num_pages(num_paused_cases, num_pages))
         end
 


### PR DESCRIPTION
### WHAT: 
Added a query to filter the default view of the work tray
### WHY: 
So not to show no_action in the immediate action tab