### PR TITLE
Do not filter worktray by User

### DIFF
--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -67,9 +67,7 @@ module Hackney
       private
 
       def tenancies_filtered_for(user_id, filters)
-        query = GatewayModel.where('
-          assigned_user_id = ? AND
-          balance > ?', user_id, 0)
+        query = GatewayModel.where('balance > ?', 0)
 
         query = query.where('patch_code = ?', filters[:patch]) if filters[:patch]
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -267,8 +267,8 @@ describe Hackney::Income::StoredTenanciesGateway do
         create(:case_priority, assigned_user_id: other_user.id, balance: 1)
       end
 
-      it 'returns only the user\'s tenancies' do
-        expect(subject.count).to eq(2)
+      it 'returns all the tenancies' do
+        expect(subject.count).to eq(3)
       end
     end
   end
@@ -323,7 +323,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       context 'when the number per page is three' do
         let(:number_per_page) { 3 }
 
-        it { is_expected.to eq(2) }
+        it { is_expected.to eq(4) }
       end
     end
   end


### PR DESCRIPTION
### Why

- As a User, I want to see all cases in a Patch.
- As a User, I am not assigned cases on Priority but by Patch

### What

- Remove filtering by User on the Worktray

### Notes
- Todo: Remove assigning Cases to Users in the Sync