### PR TITLE
Do not store User ID in metadata for Document

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -17,7 +17,8 @@ class LettersController < ApplicationController
   def send_letter
     income_use_case_factory.send_letter.execute(
       uuid: params.fetch(:uuid),
-      user_id: params.fetch(:user_id)
+      username: params.fetch(:username),
+      email: params.fetch(:email)
     )
   end
 end

--- a/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
+++ b/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
@@ -14,7 +14,7 @@ module Hackney
 
           letter_response =
             income_use_case_factory.send_precompiled_letter.execute(
-              username: Hackney::Income::Models::User.find_by(id: metadata[:user_id])&.name,
+              username: document.username,
               payment_ref: metadata[:payment_ref],
               template_id: metadata.dig(:template, :id),
               unique_reference: document.uuid,

--- a/db/migrate/20191101093146_add_columns_to_documents.rb
+++ b/db/migrate/20191101093146_add_columns_to_documents.rb
@@ -1,0 +1,18 @@
+class AddColumnsToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :username, :string
+    add_column :documents, :email, :string
+
+    Hackney::Cloud::Document.find_each do |document|
+      next if document.metedata.blank?
+
+      metadata = JSON.parse(document.metedata)
+
+      user = Hackney::Income::Models::User.find_by(id: metadata['user_id'])
+
+      next if user.blank?
+
+      document.update!(username: user.name, email: user.email)
+    end
+  end
+end

--- a/db/migrate/20191101093146_add_columns_to_documents.rb
+++ b/db/migrate/20191101093146_add_columns_to_documents.rb
@@ -4,9 +4,9 @@ class AddColumnsToDocuments < ActiveRecord::Migration[5.2]
     add_column :documents, :email, :string
 
     Hackney::Cloud::Document.find_each do |document|
-      next if document.metedata.blank?
+      next if document.metadata.blank?
 
-      metadata = JSON.parse(document.metedata)
+      metadata = JSON.parse(document.metadata)
 
       user = Hackney::Income::Models::User.find_by(id: metadata['user_id'])
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_145325) do
+ActiveRecord::Schema.define(version: 2019_11_01_093146) do
 
   create_table "case_priorities", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -48,8 +48,8 @@ ActiveRecord::Schema.define(version: 2019_10_22_145325) do
     t.decimal "weekly_rent", precision: 10, scale: 2
     t.string "last_communication_action"
     t.datetime "last_communication_date"
-    t.integer "classification"
     t.string "patch_code"
+    t.integer "classification"
     t.datetime "courtdate"
     t.string "court_outcome"
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
@@ -89,6 +89,8 @@ ActiveRecord::Schema.define(version: 2019_10_22_145325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ext_message_id"
+    t.string "username"
+    t.string "email"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -12,8 +12,6 @@ module Hackney
       def save(letter_html:, uuid:, filename:, metadata:)
         extension = File.extname(filename)
 
-        user = Hackney::Income::Models::User.find_by(id: metadata[:user_id])
-
         new_doc = document_model.create(
           filename: filename,
           uuid: uuid,
@@ -21,8 +19,8 @@ module Hackney
           mime_type: Rack::Mime.mime_type(extension),
           status: UPLOADING_CLOUD_STATUS,
           metadata: metadata.to_json,
-          email: user&.email,
-          username: user&.name
+          email: metadata[:email],
+          username: metadata[:username]
         )
 
         if new_doc.errors.empty?

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -12,13 +12,17 @@ module Hackney
       def save(letter_html:, uuid:, filename:, metadata:)
         extension = File.extname(filename)
 
+        user = Hackney::Income::Models::User.find_by(id: metadata[:user_id])
+
         new_doc = document_model.create(
           filename: filename,
           uuid: uuid,
           extension: extension,
           mime_type: Rack::Mime.mime_type(extension),
           status: UPLOADING_CLOUD_STATUS,
-          metadata: metadata.to_json
+          metadata: metadata.to_json,
+          email: user&.email,
+          username: user&.name
         )
 
         if new_doc.errors.empty?

--- a/lib/hackney/income/process_letter.rb
+++ b/lib/hackney/income/process_letter.rb
@@ -5,7 +5,7 @@ module Hackney
         @cloud_storage = cloud_storage
       end
 
-      def execute(uuid:, user_id:)
+      def execute(uuid:, username:, email:)
         cached_letter_object = pop_from_cache(uuid)
 
         letter_html = cached_letter_object[:preview]
@@ -15,7 +15,8 @@ module Hackney
           filename: "#{uuid}.pdf",
           uuid: uuid,
           metadata: {
-            user_id: user_id,
+            username: username,
+            email: email,
             payment_ref: cached_letter_object[:case][:payment_ref],
             template: cached_letter_object[:template]
           }

--- a/lib/hackney/letter/all_documents_use_case.rb
+++ b/lib/hackney/letter/all_documents_use_case.rb
@@ -8,20 +8,12 @@ module Hackney
       def execute(payment_ref: nil)
         @cloud_storage.all_documents(payment_ref: payment_ref)
                       .each do |doc|
-          next unless doc.metadata
-          metadata = JSON.parse(doc.metadata).deep_symbolize_keys
-          if metadata[:user_id]
-            metadata[:user_name] = user_name(metadata[:user_id])
-            doc.metadata = metadata.to_json
-          end
+          metadata = JSON.parse(doc.metadata).deep_symbolize_keys if doc.metadata
+          metadata ||= {}
+          metadata[:username] = doc.username
+
+          doc.metadata = metadata.to_json
         end
-      end
-
-      private
-
-      def user_name(user_id)
-        user = Hackney::Income::Models::User.find_by(id: user_id)
-        user ? user.name : nil
       end
     end
   end

--- a/spec/controllers/letters_controller_spec.rb
+++ b/spec/controllers/letters_controller_spec.rb
@@ -28,7 +28,8 @@ describe LettersController, type: :controller do
 
   describe '#send_letter' do
     context 'when user "accepts" the preview' do
-      let(:user_id) { Faker::Number.number }
+      let(:username) { Faker::Name.name }
+      let(:email) { Faker::Internet.email }
       let(:uuid) { SecureRandom.uuid }
 
       before do
@@ -36,16 +37,16 @@ describe LettersController, type: :controller do
       end
 
       it 'calls succefully' do
-        post :send_letter, params: { uuid: uuid, user_id: user_id }
+        post :send_letter, params: { uuid: uuid, username: username, email: email }
 
         expect(response).to be_successful
       end
 
       it 'calls the usecase' do
         expect_any_instance_of(Hackney::Income::ProcessLetter)
-          .to receive(:execute).with(uuid: uuid, user_id: user_id)
+          .to receive(:execute).with(uuid: uuid, username: username, email: email)
 
-        post :send_letter, params: { uuid: uuid, user_id: user_id }
+        post :send_letter, params: { uuid: uuid, username: username, email: email }
       end
     end
   end

--- a/spec/lib/hackney/income/process_letter_spec.rb
+++ b/spec/lib/hackney/income/process_letter_spec.rb
@@ -4,7 +4,8 @@ describe Hackney::Income::ProcessLetter do
   let(:cloud_storage) { instance_double(Hackney::Cloud::Storage) }
 
   let(:subject) { described_class.new(cloud_storage: cloud_storage) }
-  let(:user_id) { Faker::Number.number }
+  let(:username) { Faker::Name.name }
+  let(:email) { Faker::Internet.email }
   let(:html) { "<h1>#{Faker::RickAndMorty.quote}</h1>" }
   let(:uuid) { SecureRandom.uuid }
 
@@ -41,12 +42,13 @@ describe Hackney::Income::ProcessLetter do
       letter_html: html,
       filename: "#{uuid}.pdf",
       metadata: {
-        user_id: user_id,
+        username: username,
+        email: email,
         payment_ref: cache_obj[:case][:payment_ref],
         template: cache_obj[:template]
       }
     )
 
-    subject.execute(uuid: uuid, user_id: user_id)
+    subject.execute(uuid: uuid, username: username, email: email)
   end
 end

--- a/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
+++ b/spec/lib/hackney/tenancy/add_action_diary_entry_spec.rb
@@ -37,7 +37,7 @@ describe Hackney::Tenancy::AddActionDiaryEntry do
   context 'when a user wants to add an action diary message' do
     subject { usecase.execute(username: username, tenancy_ref: tenancy_ref, action_code: action_code, comment: comment) }
 
-    let(:user) { OpenStruct.new(name: Faker::Name.name, id: Faker::Number.number(3).to_i) }
+    let(:username) { Faker::Name.name }
 
     it 'calls the action_diary_gateway' do
       allow(DateTime).to receive(:now).and_return(date)


### PR DESCRIPTION
### Why

- So we can remove any reference to the User Model in a later change.

### What 

- Denormalise the User's Name and Email onto the Document Model. 

### Blockers

- Should wait for the large refactor (https://github.com/LBHackney-IT/lbh-income-api/pull/233) to be finished before merging this in.
- This change needs to be merged before https://github.com/LBHackney-IT/lbh-income-api/pull/235
