### PR TITLE
Order by upcoming court date

### DIFF
--- a/app/controllers/my_cases_controller.rb
+++ b/app/controllers/my_cases_controller.rb
@@ -10,7 +10,8 @@ class MyCasesController < ApplicationController
         is_paused: my_cases_params[:is_paused],
         classification: my_cases_params[:recommended_actions],
         patch: my_cases_params[:patch],
-        full_patch: my_cases_params[:full_patch]
+        full_patch: my_cases_params[:full_patch],
+        upcoming_court_dates: my_cases_params[:upcoming_court_dates]
       }
     )
 
@@ -19,12 +20,13 @@ class MyCasesController < ApplicationController
 
   def my_cases_params
     params.require(REQUIRED_INDEX_PARAMS)
-    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused patch recommended_actions full_patch])
+    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused patch recommended_actions full_patch upcoming_court_dates])
 
     allowed_params[:user_id] = allowed_params[:user_id].to_i
 
     allowed_params[:is_paused] = ActiveModel::Type::Boolean.new.cast(allowed_params[:is_paused])
     allowed_params[:full_patch] = ActiveModel::Type::Boolean.new.cast(allowed_params[:full_patch])
+    allowed_params[:upcoming_court_dates] = ActiveModel::Type::Boolean.new.cast(allowed_params[:upcoming_court_dates])
 
     allowed_params[:page_number] = min_1(allowed_params[:page_number].to_i)
     allowed_params[:number_per_page] = min_1(allowed_params[:number_per_page].to_i)

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -59,7 +59,11 @@ module Hackney
 
         query = query.offset((page_number - 1) * number_per_page).limit(number_per_page) if page_number.present? && number_per_page.present?
 
-        query.order(by_balance).map(&method(:build_tenancy_list_item))
+        if filters[:upcoming_court_dates].present?
+          query.order([:courtdate])
+        else
+          query.order(by_balance).map(&method(:build_tenancy_list_item))
+        end
       end
 
       def number_of_pages_for_user(user_id:, number_per_page:, filters: {})

--- a/spec/controllers/my_cases_controller_spec.rb
+++ b/spec/controllers/my_cases_controller_spec.rb
@@ -25,7 +25,8 @@ describe MyCasesController do
             is_paused: nil,
             classification: nil,
             patch: nil,
-            full_patch: nil
+            full_patch: nil,
+            upcoming_court_dates: nil
           })
 
         get :index, params: { user_id: user_id, page_number: 0, number_per_page: 0 }
@@ -53,7 +54,8 @@ describe MyCasesController do
             is_paused: nil,
             classification: nil,
             patch: nil,
-            full_patch: nil
+            full_patch: nil,
+            upcoming_court_dates: nil
           })
           .and_return(cases: [], number_per_page: 1)
 
@@ -87,7 +89,8 @@ describe MyCasesController do
             is_paused: false,
             classification: nil,
             patch: nil,
-            full_patch: nil
+            full_patch: nil,
+            upcoming_court_dates: nil
           })
           .and_return(expected_result)
 
@@ -108,7 +111,8 @@ describe MyCasesController do
             is_paused: nil,
             classification: nil,
             patch: patch,
-            full_patch: nil
+            full_patch: nil,
+            upcoming_court_dates: nil
           })
           .and_return(expected_result)
 

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -437,9 +437,8 @@ describe Hackney::Income::StoredTenanciesGateway do
   context 'when there are tenancies with an upcoming courtdate' do
     let(:user) { create(:user) }
 
-    let!(:case_1) {create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 20) }
-    let!(:case_2) { create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 1) }
-    let!(:case_3) {create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 16) }
+    let!(:case_1) { create(:case_priority, assigned_user_id: user.id, balance: 60, courtdate: Date.today + 20) }
+    let!(:case_2) { create(:case_priority, assigned_user_id: user.id, balance: 50, courtdate: Date.today + 1) }
 
     context 'when we call get_tenancies_for_user' do
       subject do
@@ -448,13 +447,14 @@ describe Hackney::Income::StoredTenanciesGateway do
           page_number: 1,
           number_per_page: 50,
           filters: {
-            upcoming_court_dates: true,
+            upcoming_court_dates: true
           }
         )
       end
 
       it 'returns all tenancies ordered by court date' do
         expect(subject.first).to eq(case_2)
+        expect(subject.last).to eq(case_1)
       end
     end
   end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -437,8 +437,18 @@ describe Hackney::Income::StoredTenanciesGateway do
   context 'when there are tenancies with an upcoming courtdate' do
     let(:user) { create(:user) }
 
-    let!(:case_1) { create(:case_priority, assigned_user_id: user.id, balance: 60, courtdate: Date.today + 20) }
-    let!(:case_2) { create(:case_priority, assigned_user_id: user.id, balance: 50, courtdate: Date.today + 1) }
+    let(:cases_with_courtdate_in_future) { 5 }
+    let(:cases_with_courtdate_in_past) { 5 }
+
+    before do
+      cases_with_courtdate_in_future.times do
+        create(:case_priority, assigned_user_id: user.id, balance: 40, classification: nil, courtdate: Date.today + 20)
+      end
+
+      cases_with_courtdate_in_past.times do
+        create(:case_priority, assigned_user_id: user.id, balance: 40, classification: nil, courtdate: Date.today - 20)
+      end
+    end
 
     context 'when we call get_tenancies_for_user' do
       subject do
@@ -452,9 +462,8 @@ describe Hackney::Income::StoredTenanciesGateway do
         )
       end
 
-      it 'returns all tenancies ordered by court date' do
-        expect(subject.first).to eq(case_2)
-        expect(subject.last).to eq(case_1)
+      it 'returns only tenancies with an upcoming courtdate' do
+        expect(subject.count).to eq(cases_with_courtdate_in_future)
       end
     end
   end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -437,61 +437,24 @@ describe Hackney::Income::StoredTenanciesGateway do
   context 'when there are tenancies with an upcoming courtdate' do
     let(:user) { create(:user) }
 
-    let(:cases_with_courtdate_within_a_week) { 5 }
-    let(:cases_with_courtdate_outside_a_week) { 5 }
-
-    before do
-      cases_with_courtdate_within_a_week.times do
-        create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 5)
-      end
-
-      cases_with_courtdate_outside_a_week.times do
-        create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 29)
-      end
-    end
+    let!(:case_1) {create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 20) }
+    let!(:case_2) { create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 1) }
+    let!(:case_3) {create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 16) }
 
     context 'when we call get_tenancies_for_user' do
       subject do
         gateway.get_tenancies_for_user(
           user_id: user.id,
           page_number: 1,
-          number_per_page: 50
+          number_per_page: 50,
+          filters: {
+            upcoming_court_dates: true,
+          }
         )
       end
 
-      it 'returns all tenancies' do
-        expect(subject.count).to eq(cases_with_courtdate_within_a_week + cases_with_courtdate_outside_a_week)
-      end
-    end
-  end
-
-  context 'when there are tenancies with an upcoming courtdate' do
-    let(:user) { create(:user) }
-
-    let(:cases_with_courtdate_within_a_week) { 5 }
-    let(:cases_with_courtdate_outside_a_week) { 5 }
-
-    before do
-      cases_with_courtdate_within_a_week.times do
-        create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 5)
-      end
-
-      cases_with_courtdate_outside_a_week.times do
-        create(:case_priority, assigned_user_id: user.id, balance: 40, courtdate: Date.today + 29)
-      end
-    end
-
-    context 'when we call get_tenancies_for_user' do
-      subject do
-        gateway.get_tenancies_for_user(
-          user_id: user.id,
-          page_number: 1,
-          number_per_page: 50
-        )
-      end
-
-      it 'returns all tenancies' do
-        expect(subject.count).to eq(cases_with_courtdate_within_a_week + cases_with_courtdate_outside_a_week)
+      it 'returns all tenancies ordered by court date' do
+        expect(subject.first).to eq(case_2)
       end
     end
   end


### PR DESCRIPTION
### WHAT
Order cases with upcoming court dates

### WHY
So the frontend can receive the cases in order of earliest upcoming court dates