### PR TITLE
Fetch evictdate field from tenagree table

### DIFF
--- a/db/migrate/20191106142526_add_eviction_date_to_criteria.rb
+++ b/db/migrate/20191106142526_add_eviction_date_to_criteria.rb
@@ -1,0 +1,5 @@
+class AddEvictionDateToCriteria < ActiveRecord::Migration[5.2]
+  def change
+    add_column :case_priorities, :eviction_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_145325) do
+ActiveRecord::Schema.define(version: 2019_11_06_142526) do
 
   create_table "case_priorities", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2019_10_22_145325) do
     t.string "patch_code"
     t.datetime "courtdate"
     t.string "court_outcome"
+    t.datetime "eviction_date"
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
     t.index ["case_id"], name: "index_case_priorities_on_case_id"
     t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -45,7 +45,8 @@ module Hackney
               classification: classification_usecase.execute,
               patch_code: criteria.patch_code,
               courtdate: criteria.courtdate,
-              court_outcome: criteria.court_outcome
+              court_outcome: criteria.court_outcome,
+              eviction_date: criteria.eviction_date
             )
           end
         rescue ActiveRecord::RecordNotUnique
@@ -137,7 +138,8 @@ module Hackney
           patch_code: model.patch_code,
           classification: model.classification,
           courtdate: model.courtdate,
-          court_outcome: model.court_outcome
+          court_outcome: model.court_outcome,
+          eviction_date: model.eviction_date
         }
       end
     end

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -35,6 +35,9 @@ module Hackney
             DECLARE @CourtOutcome VARCHAR(3) = (
               SELECT u_court_outcome FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
             )
+            DECLARE @EvictionDate SMALLDATETIME = (
+              SELECT evictdate FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
+            )
 
             DECLARE @WeeklyRent NUMERIC(9, 2) = (
               SELECT rent FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
@@ -106,6 +109,7 @@ module Hackney
               @NospExpiryDate as nosp_expiry_date,
               @Courtdate as courtdate,
               @CourtOutcome as court_outcome,
+              @EvictionDate as eviction_date,
               @Payment1Value as payment_1_value,
               @Payment1Date as payment_1_date,
               @Payment2Value as payment_2_value,
@@ -160,6 +164,10 @@ module Hackney
 
         def court_outcome
           attributes[:court_outcome]
+        end
+
+        def eviction_date
+          attributes[:eviction_date]
         end
 
         def days_in_arrears

--- a/lib/hackney/income/view_my_cases.rb
+++ b/lib/hackney/income/view_my_cases.rb
@@ -76,10 +76,9 @@ module Hackney
           broken_court_order: assigned_tenancy.fetch(:broken_court_order),
           nosp_served: assigned_tenancy.fetch(:nosp_served),
           active_nosp: assigned_tenancy.fetch(:active_nosp),
-
           courtdate: assigned_tenancy.fetch(:courtdate),
           court_outcome: assigned_tenancy.fetch(:court_outcome),
-
+          eviction_date: assigned_tenancy.fetch(:eviction_date),
           classification: assigned_tenancy.fetch(:classification)
         }
       end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -78,7 +78,8 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_nosp: attributes.fetch(:criteria).active_nosp?,
           patch_code: attributes.fetch(:criteria).patch_code,
           courtdate: attributes.fetch(:criteria).courtdate,
-          court_outcome: attributes.fetch(:criteria).court_outcome
+          court_outcome: attributes.fetch(:criteria).court_outcome,
+          eviction_date: attributes.fetch(:criteria).eviction_date
         )
       end
 
@@ -160,7 +161,8 @@ describe Hackney::Income::StoredTenanciesGateway do
           active_nosp: attributes.fetch(:criteria).active_nosp?,
           patch_code: attributes.fetch(:criteria).patch_code,
           courtdate: attributes.fetch(:criteria).courtdate,
-          court_outcome: attributes.fetch(:criteria).court_outcome
+          court_outcome: attributes.fetch(:criteria).court_outcome,
+          eviction_date: attributes.fetch(:criteria).eviction_date
         )
       end
 
@@ -714,7 +716,8 @@ describe Hackney::Income::StoredTenanciesGateway do
       active_nosp: attributes.fetch(:criteria).active_nosp?,
       patch_code: attributes.fetch(:criteria).patch_code,
       courtdate: attributes.fetch(:criteria).courtdate,
-      court_outcome: attributes.fetch(:criteria).court_outcome
+      court_outcome: attributes.fetch(:criteria).court_outcome,
+      eviction_date: attributes.fetch(:criteria).eviction_date
     }
   end
 end

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -15,6 +15,8 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
 
   let(:court_outcome) { nil }
 
+  let(:eviction_date) { '2007-09-20 10:30:00' }
+
   let(:current_balance) { Faker::Number.decimal.to_f }
 
   before {
@@ -24,7 +26,8 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
       nosp_notice_served_date: nosp_notice_served_date,
       nosp_notice_expiry_date: nosp_notice_expiry_date,
       courtdate: courtdate,
-      court_outcome: court_outcome
+      court_outcome: court_outcome,
+      eviction_date: eviction_date
     )
   }
 
@@ -63,6 +66,14 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
 
     it 'returns a court_outcome' do
       expect(subject).to eq(court_outcome)
+    end
+  end
+
+  describe '#eviction_date' do
+    subject { criteria.eviction_date }
+
+    it 'returns an eviction date' do
+      expect(subject).to eq(eviction_date.to_date)
     end
   end
 

--- a/spec/lib/hackney/income/view_my_cases_spec.rb
+++ b/spec/lib/hackney/income/view_my_cases_spec.rb
@@ -129,6 +129,7 @@ describe Hackney::Income::ViewMyCases do
 
                                            courtdate: tenancy_priority_factors.fetch(:courtdate),
                                            court_outcome: tenancy_priority_factors.fetch(:court_outcome),
+                                           eviction_date: tenancy_priority_factors.fetch(:eviction_date),
 
                                            classification: tenancy_priority_factors.fetch(:classification)
                                          ))
@@ -267,6 +268,7 @@ describe Hackney::Income::ViewMyCases do
 
       courtdate: Date.today - 5,
       court_outcome: Faker::Lorem.word,
+      eviction_date: Date.today + 1.month,
 
       classification: 'no_action'
     }

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -4,7 +4,7 @@ module Stubs
                 :number_of_broken_agreements,
                 :payment_date_delta, :payment_amount_delta,
                 :active_agreement, :active_nosp, :nosp_served_date,
-                :nosp_expiry_date, :patch_code, :courtdate
+                :nosp_expiry_date, :patch_code, :courtdate, :eviction_date
 
     attr_accessor :days_since_last_payment, :last_communication_date, :paused, :nosp_served,
                   :last_communication_action, :court_outcome
@@ -27,6 +27,10 @@ module Stubs
 
     def courtdate
       '2005-12-13 12:43:10'.to_date
+    end
+
+    def eviction_date
+      '2007-09-20 10:30:00'.to_date
     end
 
     def patch_code

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -3,7 +3,8 @@ module UniversalHousingHelper
   def create_uh_tenancy_agreement(tenancy_ref:, current_balance: 0.0, rent: 5.0, prop_ref: '', terminated: false, cot: '',
                                   tenure_type: 'SEC', high_action: '111', u_saff_rentacc: '', house_ref: '',
                                   nosp_notice_served_date: '1900-01-01 00:00:00 +0000', nosp_notice_expiry_date: '1900-01-01 00:00:00 +0000',
-                                  money_judgement: 0.0, charging_order: 0.0, bal_dispute: 0.0, courtdate: '1900-01-01 00:00:00 +0000', court_outcome: nil)
+                                  money_judgement: 0.0, charging_order: 0.0, bal_dispute: 0.0, courtdate: '1900-01-01 00:00:00 +0000',
+                                  court_outcome: nil, eviction_date: '1900-01-01 00:00:00 +0000')
     Hackney::UniversalHousing::Client.connection[:tenagree].insert(
       tag_ref: tenancy_ref,
       cur_bal: current_balance,
@@ -37,6 +38,7 @@ module UniversalHousingHelper
       u_notice_expiry: nosp_notice_expiry_date.to_date,
       courtdate: courtdate.to_date,
       u_court_outcome: court_outcome,
+      evictdate: eviction_date.to_date,
       intro_date: DateTime.now,
       intro_ext_date: DateTime.now,
       u_saff_rentacc: u_saff_rentacc,


### PR DESCRIPTION
### Why
* The evictdate field is required to notify the user of upcoming eviction dates for tenancies.

### What
* Synced across tenagree.evictdate field from UH
* Added test