### PR TITLE
Use Web Archive to download FreeTDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # 50 MB stack needed in sync worker thread
 ENV RUBY_THREAD_VM_STACK_SIZE=50000000
 
-RUN wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.27.tar.gz && \
+RUN wget https://web.archive.org/web/20191028054637/http://www.freetds.org/files/stable/freetds-1.00.27.tar.gz && \
   tar -xzf freetds-1.00.27.tar.gz && \
   cd freetds-1.00.27 && \
   ./configure --prefix=/usr/local --with-tdsver=7.3 && \


### PR DESCRIPTION
freetds.org website and ftp server went down. This is a workaround to 
ensure we can still develop and run our CI/CD pipeline.