### PR TITLE
Commence a sync when adding a new action to a case

### DIFF
--- a/app/controllers/action_diary_controller.rb
+++ b/app/controllers/action_diary_controller.rb
@@ -13,6 +13,11 @@ class ActionDiaryController < ApplicationController
       render(json: { status: 'error', code: 422, message: e.message }, status: :unprocessable_entity)
       return
     end
+
+    income_use_case_factory.sync_case_priority.execute(
+      tenancy_ref: action_diary_params.fetch(:tenancy_ref)
+    )
+
     head(:no_content)
   end
 

--- a/app/controllers/action_diary_controller.rb
+++ b/app/controllers/action_diary_controller.rb
@@ -3,7 +3,7 @@ class ActionDiaryController < ApplicationController
 
   def create
     begin
-      income_use_case_factory.add_action_diary.execute(
+      income_use_case_factory.add_action_diary_and_sync_case.execute(
         tenancy_ref: action_diary_params.fetch(:tenancy_ref),
         action_code: action_diary_params.fetch(:action_code),
         comment: action_diary_params.fetch(:comment),
@@ -13,10 +13,6 @@ class ActionDiaryController < ApplicationController
       render(json: { status: 'error', code: 422, message: e.message }, status: :unprocessable_entity)
       return
     end
-
-    income_use_case_factory.sync_case_priority.execute(
-      tenancy_ref: action_diary_params.fetch(:tenancy_ref)
-    )
 
     head(:no_content)
   end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -122,6 +122,14 @@ module Hackney
         )
       end
 
+      def add_action_diary_and_sync_case
+        UseCases::AddActionDiaryAndSyncCase.new(
+          prioritisation_gateway: prioritisation_gateway,
+          sync_case_priority: sync_case_priority,
+          action_diary_gateway: action_diary_gateway
+        )
+      end
+
       def sync_case_priority
         ActiveSupport::Deprecation.warn(
           "SyncCasePriorityJob is deprecated - use external scheduler via 'rake income:sync:enqueue'"

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -124,7 +124,6 @@ module Hackney
 
       def add_action_diary_and_sync_case
         UseCases::AddActionDiaryAndSyncCase.new(
-          prioritisation_gateway: prioritisation_gateway,
           sync_case_priority: sync_case_priority,
           action_diary_gateway: action_diary_gateway
         )

--- a/lib/use_cases/add_action_diary_and_sync_case.rb
+++ b/lib/use_cases/add_action_diary_and_sync_case.rb
@@ -1,7 +1,6 @@
 module UseCases
   class AddActionDiaryAndSyncCase
-    def initialize(prioritisation_gateway:, sync_case_priority:, action_diary_gateway:)
-      @prioritisation_gateway = prioritisation_gateway
+    def initialize(sync_case_priority:, action_diary_gateway:)
       @sync_case_priority = sync_case_priority
       @action_diary_gateway = action_diary_gateway
     end

--- a/lib/use_cases/add_action_diary_and_sync_case.rb
+++ b/lib/use_cases/add_action_diary_and_sync_case.rb
@@ -1,4 +1,3 @@
-require 'active_support'
 module UseCases
   class AddActionDiaryAndSyncCase
     def initialize(prioritisation_gateway:, sync_case_priority:, action_diary_gateway:)

--- a/lib/use_cases/add_action_diary_and_sync_case.rb
+++ b/lib/use_cases/add_action_diary_and_sync_case.rb
@@ -1,0 +1,21 @@
+require 'active_support'
+module UseCases
+  class AddActionDiaryAndSyncCase
+    def initialize(prioritisation_gateway:, sync_case_priority:, action_diary_gateway:)
+      @prioritisation_gateway = prioritisation_gateway
+      @sync_case_priority = sync_case_priority
+      @action_diary_gateway = action_diary_gateway
+    end
+
+    def execute(tenancy_ref:, action_code:, comment:, username:)
+      @action_diary_gateway.create_entry(
+        tenancy_ref: tenancy_ref,
+        action_code: action_code,
+        comment: comment,
+        username: username
+      )
+
+      @sync_case_priority.execute(tenancy_ref: tenancy_ref)
+    end
+  end
+end

--- a/spec/controllers/action_diary_controller_spec.rb
+++ b/spec/controllers/action_diary_controller_spec.rb
@@ -6,15 +6,21 @@ describe ActionDiaryController, type: :controller do
       username: Faker::Name.name,
       tenancy_ref: Faker::Lorem.characters(8),
       action_code: Faker::Internet.slug,
-      comment: Faker::Lorem.paragraph
+      comment: 'George was here'
     }
   end
 
   let(:use_case_double) { double(Hackney::Tenancy::AddActionDiaryEntry) }
+  let(:sync_case_priority_double) { double(Hackney::Income::SyncCasePriority) }
 
   before do
     stub_const('Hackney::Tenancy::AddActionDiaryEntry', use_case_double)
     allow(use_case_double).to receive(:new).and_return(use_case_double)
+    allow(use_case_double).to receive(:execute)
+
+    stub_const('Hackney::Income::SyncCasePriority', sync_case_priority_double)
+    allow(sync_case_priority_double).to receive(:new).and_return(sync_case_priority_double)
+    allow(sync_case_priority_double).to receive(:execute)
   end
 
   it 'is accessible' do
@@ -22,7 +28,7 @@ describe ActionDiaryController, type: :controller do
   end
 
   context 'when receiving valid params' do
-    it 'passes the correct params to the use case' do
+    it 'passes the correct params to the add action diary entry use case' do
       expect(use_case_double).to receive(:execute)
         .with(action_diary_params)
         .and_return(nil)
@@ -35,6 +41,17 @@ describe ActionDiaryController, type: :controller do
       expect(use_case_double).to receive(:execute).and_return(nil).once
       patch :create, params: action_diary_params
       expect(response.status).to eq(204)
+    end
+  end
+
+  context 'when receiving valid params to the sync case priority use case' do
+    it 'passes the correct params to the use case' do
+      expect(sync_case_priority_double).to receive(:execute)
+        .with(tenancy_ref: action_diary_params[:tenancy_ref])
+        .and_return(nil)
+        .once
+
+      patch :create, params: action_diary_params
     end
   end
 

--- a/spec/controllers/action_diary_controller_spec.rb
+++ b/spec/controllers/action_diary_controller_spec.rb
@@ -6,20 +6,18 @@ describe ActionDiaryController, type: :controller do
       username: Faker::Name.name,
       tenancy_ref: Faker::Lorem.characters(8),
       action_code: Faker::Internet.slug,
-      comment: 'George was here'
+      comment: Faker::Lorem.paragraph
     }
   end
 
-  let(:use_case_double) { double(Hackney::Tenancy::AddActionDiaryEntry) }
+  let(:add_action_diary_entry_double) { double(Hackney::Tenancy::AddActionDiaryEntry) }
   let(:sync_case_priority_double) { double(Hackney::Income::SyncCasePriority) }
 
   before do
-    stub_const('Hackney::Tenancy::AddActionDiaryEntry', use_case_double)
-    allow(use_case_double).to receive(:new).and_return(use_case_double)
-    allow(use_case_double).to receive(:execute)
+    allow(Hackney::Tenancy::AddActionDiaryEntry).to receive(:new).and_return(add_action_diary_entry_double)
+    allow(add_action_diary_entry_double).to receive(:execute)
 
-    stub_const('Hackney::Income::SyncCasePriority', sync_case_priority_double)
-    allow(sync_case_priority_double).to receive(:new).and_return(sync_case_priority_double)
+    allow(Hackney::Income::SyncCasePriority).to receive(:new).and_return(sync_case_priority_double)
     allow(sync_case_priority_double).to receive(:execute)
   end
 
@@ -29,7 +27,7 @@ describe ActionDiaryController, type: :controller do
 
   context 'when receiving valid params' do
     it 'passes the correct params to the add action diary entry use case' do
-      expect(use_case_double).to receive(:execute)
+      expect(add_action_diary_entry_double).to receive(:execute)
         .with(action_diary_params)
         .and_return(nil)
         .once
@@ -38,7 +36,7 @@ describe ActionDiaryController, type: :controller do
     end
 
     it 'returns a 200 response' do
-      expect(use_case_double).to receive(:execute).and_return(nil).once
+      expect(add_action_diary_entry_double).to receive(:execute).and_return(nil).once
       patch :create, params: action_diary_params
       expect(response.status).to eq(204)
     end
@@ -51,13 +49,13 @@ describe ActionDiaryController, type: :controller do
         .and_return(nil)
         .once
 
-      patch :create, params: action_diary_params
+      post :create, params: action_diary_params
     end
   end
 
   context 'when receiving a username that does not exist' do
     it 'returns a 422 error' do
-      expect(use_case_double).to receive(:execute)
+      expect(add_action_diary_entry_double).to receive(:execute)
         .and_raise(ArgumentError.new('username supplied does not exist'))
         .once
 

--- a/spec/controllers/action_diary_controller_spec.rb
+++ b/spec/controllers/action_diary_controller_spec.rb
@@ -10,15 +10,11 @@ describe ActionDiaryController, type: :controller do
     }
   end
 
-  let(:add_action_diary_entry_double) { double(Hackney::Tenancy::AddActionDiaryEntry) }
-  let(:sync_case_priority_double) { double(Hackney::Income::SyncCasePriority) }
+  let(:add_action_diary_entry_sync_case_double) { double(UseCases::AddActionDiaryAndSyncCase) }
 
   before do
-    allow(Hackney::Tenancy::AddActionDiaryEntry).to receive(:new).and_return(add_action_diary_entry_double)
-    allow(add_action_diary_entry_double).to receive(:execute)
-
-    allow(Hackney::Income::SyncCasePriority).to receive(:new).and_return(sync_case_priority_double)
-    allow(sync_case_priority_double).to receive(:execute)
+    allow(UseCases::AddActionDiaryAndSyncCase).to receive(:new).and_return(add_action_diary_entry_sync_case_double)
+    allow(add_action_diary_entry_sync_case_double).to receive(:execute)
   end
 
   it 'is accessible' do
@@ -27,16 +23,16 @@ describe ActionDiaryController, type: :controller do
 
   context 'when receiving valid params' do
     it 'passes the correct params to the add action diary entry use case' do
-      expect(add_action_diary_entry_double).to receive(:execute)
+      expect(add_action_diary_entry_sync_case_double).to receive(:execute)
         .with(action_diary_params)
         .and_return(nil)
         .once
 
-      patch :create, params: action_diary_params
+      post :create, params: action_diary_params
     end
 
     it 'returns a 200 response' do
-      expect(add_action_diary_entry_double).to receive(:execute).and_return(nil).once
+      expect(add_action_diary_entry_sync_case_double).to receive(:execute).and_return(nil).once
       patch :create, params: action_diary_params
       expect(response.status).to eq(204)
     end
@@ -44,8 +40,8 @@ describe ActionDiaryController, type: :controller do
 
   context 'when receiving valid params to the sync case priority use case' do
     it 'passes the correct params to the use case' do
-      expect(sync_case_priority_double).to receive(:execute)
-        .with(tenancy_ref: action_diary_params[:tenancy_ref])
+      expect(add_action_diary_entry_sync_case_double).to receive(:execute)
+        .with(action_diary_params)
         .and_return(nil)
         .once
 
@@ -55,11 +51,11 @@ describe ActionDiaryController, type: :controller do
 
   context 'when receiving a username that does not exist' do
     it 'returns a 422 error' do
-      expect(add_action_diary_entry_double).to receive(:execute)
+      expect(add_action_diary_entry_sync_case_double).to receive(:execute)
         .and_raise(ArgumentError.new('username supplied does not exist'))
         .once
 
-      patch :create, params: action_diary_params
+      post :create, params: action_diary_params
 
       expect(response.status).to eq(422)
       json = JSON.parse(response.body, symbolize_names: true)

--- a/spec/use_cases/add_action_diary_and_sync_case_spec.rb
+++ b/spec/use_cases/add_action_diary_and_sync_case_spec.rb
@@ -2,12 +2,10 @@ require 'rails_helper'
 
 describe UseCases::AddActionDiaryAndSyncCase do
   let(:add_action_diary_and_sync_case) {
-    described_class.new(prioritisation_gateway: prioritisation_gateway,
-                        sync_case_priority: sync_case_priority,
+    described_class.new(sync_case_priority: sync_case_priority,
                         action_diary_gateway: action_diary_gateway)
   }
 
-  let(:prioritisation_gateway) { spy }
   let(:sync_case_priority) { spy }
   let(:action_diary_gateway) { spy }
 

--- a/spec/use_cases/add_action_diary_and_sync_case_spec.rb
+++ b/spec/use_cases/add_action_diary_and_sync_case_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe UseCases::AddActionDiaryAndSyncCase do
+  let(:add_action_diary_and_sync_case) {
+    described_class.new(prioritisation_gateway: prioritisation_gateway,
+                        sync_case_priority: sync_case_priority,
+                        action_diary_gateway: action_diary_gateway)
+  }
+
+  let(:prioritisation_gateway) { spy }
+  let(:sync_case_priority) { spy }
+  let(:action_diary_gateway) { spy }
+
+  let(:username) { Faker::Name.name }
+  let(:tenancy_ref) { Faker::Lorem.characters(8) }
+  let(:action_code) { Faker::Internet.slug }
+  let(:comment) { Faker::Lorem.paragraph }
+
+  context 'when adding to the action diary and syncing a case' do
+    it 'will call the add_action_diary and sync_case_priority usecase with the correct data' do
+      add_action_diary_and_sync_case.execute(
+        tenancy_ref: tenancy_ref,
+        action_code: action_code,
+        comment: comment,
+        username: username
+      )
+      allow(add_action_diary_and_sync_case).to receive(:execute)
+      expect(sync_case_priority).to have_received(:execute)
+      expect(action_diary_gateway).to have_received(:create_entry)
+    end
+  end
+end


### PR DESCRIPTION
### WHAT
Added logic to commence a sync when a new action is added to a case

### WHY
So we can have the most up to date data with regards to cases, instead of having to wait for the nightly sync