### PR TITLE
Call the add_action_diary not the gateway itself

### DIFF
--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -125,7 +125,7 @@ module Hackney
       def add_action_diary_and_sync_case
         UseCases::AddActionDiaryAndSyncCase.new(
           sync_case_priority: sync_case_priority,
-          action_diary_gateway: action_diary_gateway
+          add_action_diary: add_action_diary
         )
       end
 

--- a/lib/use_cases/add_action_diary_and_sync_case.rb
+++ b/lib/use_cases/add_action_diary_and_sync_case.rb
@@ -1,12 +1,12 @@
 module UseCases
   class AddActionDiaryAndSyncCase
-    def initialize(sync_case_priority:, action_diary_gateway:)
+    def initialize(sync_case_priority:, add_action_diary:)
       @sync_case_priority = sync_case_priority
-      @action_diary_gateway = action_diary_gateway
+      @add_action_diary = add_action_diary
     end
 
     def execute(tenancy_ref:, action_code:, comment:, username:)
-      @action_diary_gateway.create_entry(
+      @add_action_diary.execute(
         tenancy_ref: tenancy_ref,
         action_code: action_code,
         comment: comment,

--- a/spec/use_cases/add_action_diary_and_sync_case_spec.rb
+++ b/spec/use_cases/add_action_diary_and_sync_case_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe UseCases::AddActionDiaryAndSyncCase do
   let(:add_action_diary_and_sync_case) {
     described_class.new(sync_case_priority: sync_case_priority,
-                        action_diary_gateway: action_diary_gateway)
+                        add_action_diary: add_action_diary)
   }
 
   let(:sync_case_priority) { spy }
-  let(:action_diary_gateway) { spy }
+  let(:add_action_diary) { spy }
 
   let(:username) { Faker::Name.name }
   let(:tenancy_ref) { Faker::Lorem.characters(8) }
@@ -24,7 +24,7 @@ describe UseCases::AddActionDiaryAndSyncCase do
       )
       allow(add_action_diary_and_sync_case).to receive(:execute)
       expect(sync_case_priority).to have_received(:execute)
-      expect(action_diary_gateway).to have_received(:create_entry)
+      expect(add_action_diary).to have_received(:execute)
     end
   end
 end


### PR DESCRIPTION
Originally called the `action_diary_gateway` which was incorrect as the `add_action_diary` usecase had an added stepped which was missed out in #250 

This PR fixes that issue