### PR TITLE
Add manual sync task

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -93,3 +93,4 @@ module Hackney
     end
   end
 end
+# docker exec -ti c180331b6de6 mysql --user=incomeapi --password incomeapi

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -93,4 +93,3 @@ module Hackney
     end
   end
 end
-# docker exec -ti c180331b6de6 mysql --user=incomeapi --password incomeapi

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -152,6 +152,13 @@ module Hackney
         )
       end
 
+      def uh_tenancies_gateway
+        Hackney::Income::UniversalHousingTenanciesGateway.new(
+          restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
+          patches: ENV.fetch('PERMITTED_PATCHES', '').split(',')
+        )
+      end
+
       private
 
       def cloud_storage
@@ -185,13 +192,6 @@ module Hackney
 
       def stored_tenancies_gateway
         Hackney::Income::StoredTenanciesGateway.new
-      end
-
-      def uh_tenancies_gateway
-        Hackney::Income::UniversalHousingTenanciesGateway.new(
-          restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
-          patches: ENV.fetch('PERMITTED_PATCHES', '').split(',')
-        )
       end
 
       def tenancy_api_gateway

--- a/lib/tasks/income/sync.rake
+++ b/lib/tasks/income/sync.rake
@@ -9,21 +9,13 @@ namespace :income do
 
     desc 'manually runs the sync'
     task :manual_sync do
-
       use_case_factory = Hackney::Income::UseCaseFactory.new
 
       tenancy_refs = use_case_factory.uh_tenancies_gateway.tenancies_in_arrears
 
-      # byebug
-      tenancy_ref =  "22aa04834d8"
-      use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
-
       tenancy_refs.each do |tenancy_ref|
-        p tenancy_ref
         use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
-        p :saved
       end
-
     end
   end
 end

--- a/lib/tasks/income/sync.rake
+++ b/lib/tasks/income/sync.rake
@@ -6,5 +6,24 @@ namespace :income do
       use_case_factory = Hackney::Income::UseCaseFactory.new
       use_case_factory.schedule_sync_cases.execute
     end
+
+    desc 'manually runs the sync'
+    task :manual_sync do
+
+      use_case_factory = Hackney::Income::UseCaseFactory.new
+
+      tenancy_refs = use_case_factory.uh_tenancies_gateway.tenancies_in_arrears
+
+      # byebug
+      tenancy_ref =  "22aa04834d8"
+      use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
+
+      tenancy_refs.each do |tenancy_ref|
+        p tenancy_ref
+        use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
+        p :saved
+      end
+
+    end
   end
 end


### PR DESCRIPTION
### What

- Add a Rake task that will sync tenancies inline

### Why

- Sometimes we want to manually run a sync. This gives us a nice interface via Rake rather than loading a Rails Console. 