### PR TITLE
Lba balance bug

### DIFF
--- a/app/models/hackney/service_charge/letter/before_action.rb
+++ b/app/models/hackney/service_charge/letter/before_action.rb
@@ -3,7 +3,7 @@ module Hackney
     class Letter
       class BeforeAction < Hackney::ServiceCharge::Letter
         TEMPLATE_PATHS = [
-          'lib/hackney/pdf/templates/letter_before_action.erb'
+          'lib/hackney/pdf/templates/leasehold/letter_before_action.erb'
         ].freeze
         MANDATORY_FIELDS = %i[original_lease_date date_of_current_purchase_assignment].freeze
 

--- a/app/models/hackney/service_charge/letter/before_action.rb
+++ b/app/models/hackney/service_charge/letter/before_action.rb
@@ -5,7 +5,7 @@ module Hackney
         TEMPLATE_PATHS = [
           'lib/hackney/pdf/templates/leasehold/letter_before_action.erb'
         ].freeze
-        MANDATORY_FIELDS = %i[original_lease_date date_of_current_purchase_assignment].freeze
+        MANDATORY_FIELDS = %i[original_lease_date date_of_current_purchase_assignment lba_balance].freeze
 
         def initialize(params)
           super(params)
@@ -29,7 +29,11 @@ module Hackney
         private
 
         def calculate_lba_balance(arrears_balance, money_judgement)
-          return 0 if arrears_balance.nil? || money_judgement.nil?
+          if arrears_balance.nil?
+            arrears_balance = 0
+          elsif money_judgement.nil?
+            money_judgement = 0
+          end
 
           BigDecimal(arrears_balance.to_s) - BigDecimal(money_judgement.to_s)
         end

--- a/app/models/hackney/service_charge/letter/before_action.rb
+++ b/app/models/hackney/service_charge/letter/before_action.rb
@@ -5,10 +5,11 @@ module Hackney
         TEMPLATE_PATHS = [
           'lib/hackney/pdf/templates/leasehold/letter_before_action.erb'
         ].freeze
-        MANDATORY_FIELDS = %i[original_lease_date date_of_current_purchase_assignment lba_balance].freeze
+        MANDATORY_FIELDS = %i[original_lease_date date_of_current_purchase_assignment money_judgement].freeze
 
         def initialize(params)
           super(params)
+          
           validated_params = validate_mandatory_fields(MANDATORY_FIELDS, params)
 
           @lba_expiry_date = validated_params[:lba_expiry_date]
@@ -20,6 +21,7 @@ module Hackney
                                           validated_params[:money_judgement]
                                         ))
           @tenure_type = validated_params[:tenure_type]
+          validate_lba_balance_exists?
         end
 
         def freehold?
@@ -29,12 +31,11 @@ module Hackney
         private
 
         def calculate_lba_balance(arrears_balance, money_judgement)
-          if arrears_balance.nil?
-            arrears_balance = 0
-          elsif money_judgement.nil?
-            money_judgement = 0
+          if arrears_balance.nil?	
+            arrears_balance = 0	
+          elsif money_judgement.nil?	
+            money_judgement = 0	
           end
-
           BigDecimal(arrears_balance.to_s) - BigDecimal(money_judgement.to_s)
         end
 
@@ -42,6 +43,10 @@ module Hackney
           return nil if date.nil?
 
           date.strftime('%d %B %Y')
+        end
+
+        def validate_lba_balance_exists?
+          @errors.cocncat(name: @lba_balance.to_s, message: 'missing mandatory field') if @lba_balance.nil?
         end
       end
     end

--- a/app/models/hackney/service_charge/letter/before_action.rb
+++ b/app/models/hackney/service_charge/letter/before_action.rb
@@ -9,7 +9,7 @@ module Hackney
 
         def initialize(params)
           super(params)
-          
+
           validated_params = validate_mandatory_fields(MANDATORY_FIELDS, params)
 
           @lba_expiry_date = validated_params[:lba_expiry_date]
@@ -21,7 +21,7 @@ module Hackney
                                           validated_params[:money_judgement]
                                         ))
           @tenure_type = validated_params[:tenure_type]
-          validate_lba_balance_exists?
+          validate_lba_exists(@lba_balance)
         end
 
         def freehold?
@@ -31,10 +31,10 @@ module Hackney
         private
 
         def calculate_lba_balance(arrears_balance, money_judgement)
-          if arrears_balance.nil?	
-            arrears_balance = 0	
-          elsif money_judgement.nil?	
-            money_judgement = 0	
+          if arrears_balance.nil?
+            arrears_balance = 0
+          elsif money_judgement.nil?
+            money_judgement = 0
           end
           BigDecimal(arrears_balance.to_s) - BigDecimal(money_judgement.to_s)
         end
@@ -45,8 +45,8 @@ module Hackney
           date.strftime('%d %B %Y')
         end
 
-        def validate_lba_balance_exists?
-          @errors.cocncat(name: @lba_balance.to_s, message: 'missing mandatory field') if @lba_balance.nil?
+        def validate_lba_exists(lba_balance)
+          @errors.cocncat(name: lba_balance.to_s, message: 'missing mandatory field') if lba_balance.nil?
         end
       end
     end

--- a/app/models/hackney/service_charge/letter/letter_two.rb
+++ b/app/models/hackney/service_charge/letter/letter_two.rb
@@ -3,9 +3,9 @@ module Hackney
     class Letter
       class LetterTwo < Hackney::ServiceCharge::Letter
         TEMPLATE_PATHS = [
-          'lib/hackney/pdf/templates/letter_2_in_arrears_FH.erb',
-          'lib/hackney/pdf/templates/letter_2_in_arrears_LH.erb',
-          'lib/hackney/pdf/templates/letter_2_in_arrears_SO.erb'
+          'lib/hackney/pdf/templates/leasehold/letter_2_in_arrears_FH.erb',
+          'lib/hackney/pdf/templates/leasehold/letter_2_in_arrears_LH.erb',
+          'lib/hackney/pdf/templates/leasehold/letter_2_in_arrears_SO.erb'
         ].freeze
 
         MANDATORY_FIELDS = %i[arrears_letter_1_date].freeze

--- a/spec/lib/hackney/pdf/get_templates_for_user_spec.rb
+++ b/spec/lib/hackney/pdf/get_templates_for_user_spec.rb
@@ -29,8 +29,8 @@ describe Hackney::PDF::GetTemplatesForUser do
     let(:income_path) { Hackney::PDF::GetTemplatesForUser::INCOME_COLLECTION_TEMPLATE_DIRECTORY_PATH }
 
     it 'checks the leasehold template path exists' do
-     expect(Pathname.new(leasehold_path)).to exist
-  end
+      expect(Pathname.new(leasehold_path)).to exist
+    end
 
     it 'checks the income template path exists' do
       expect(Pathname.new(income_path)).to exist

--- a/spec/lib/hackney/pdf/get_templates_for_user_spec.rb
+++ b/spec/lib/hackney/pdf/get_templates_for_user_spec.rb
@@ -24,6 +24,19 @@ describe Hackney::PDF::GetTemplatesForUser do
     end
   }
 
+  context 'when getting the template directory paths for the user' do
+    let(:leasehold_path) { Hackney::PDF::GetTemplatesForUser::LEASEHOLD_SERVICES_TEMPLATE_DIRECTORY_PATH }
+    let(:income_path) { Hackney::PDF::GetTemplatesForUser::INCOME_COLLECTION_TEMPLATE_DIRECTORY_PATH }
+
+    it 'checks the leasehold template path exists' do
+     expect(Pathname.new(leasehold_path)).to exist
+  end
+
+    it 'checks the income template path exists' do
+      expect(Pathname.new(income_path)).to exist
+    end
+  end
+
   context 'when user is in the leasehold services group' do
     let(:user_groups) { ['leasehold-group'] }
 

--- a/spec/models/hackney/service_charge/letter/before_action_spec.rb
+++ b/spec/models/hackney/service_charge/letter/before_action_spec.rb
@@ -21,6 +21,16 @@ describe Hackney::ServiceCharge::Letter::BeforeAction do
   let(:tenure_type) { nil }
   let(:original_lease_date) { nil }
 
+  context 'when the letter is being generated' do
+    it 'checks that the template file exists' do
+      files = Hackney::ServiceCharge::Letter::BeforeAction::TEMPLATE_PATHS
+
+      files.each do |file|
+        expect(Pathname.new(file)).to exist
+      end
+    end
+  end
+
   context 'when a money judgement and charging order exists' do
     let(:letter) { described_class.new(letter_params) }
 

--- a/spec/models/hackney/service_charge/letter/letter_two_spec.rb
+++ b/spec/models/hackney/service_charge/letter/letter_two_spec.rb
@@ -14,6 +14,16 @@ describe Hackney::ServiceCharge::Letter::LetterTwo do
     }
   }
 
+  context 'when the letter is being generated' do
+    it 'checks that the template file exists' do
+      files = Hackney::ServiceCharge::Letter::LetterTwo::TEMPLATE_PATHS
+
+      files.each do |file|
+        expect(Pathname.new(file)).to exist
+      end
+    end
+  end
+
   describe 'fetch letter 1 date' do
     let(:letter) { described_class.new(letter_params) }
 

--- a/spec/models/hackney/service_charge/letter_spec.rb
+++ b/spec/models/hackney/service_charge/letter_spec.rb
@@ -96,7 +96,7 @@ describe Hackney::ServiceCharge::Letter do
         letter_params: letter_params,
         template_path: Hackney::ServiceCharge::Letter::BeforeAction::TEMPLATE_PATHS.sample
       )
-      expected_balance =  format('%.2f',letter_params[:total_collectable_arrears_balance].to_f-letter_params[:money_judgement].to_f)
+      expected_balance = format('%.2f', letter_params[:total_collectable_arrears_balance].to_f - letter_params[:money_judgement].to_f)
       expect(letter.lba_balance).to eq(expected_balance.to_s)
     end
   end

--- a/spec/models/hackney/service_charge/letter_spec.rb
+++ b/spec/models/hackney/service_charge/letter_spec.rb
@@ -87,8 +87,18 @@ describe Hackney::ServiceCharge::Letter do
 
       expect(letter.errors).to eq [
         { message: 'missing mandatory field', name: 'original_lease_date' },
-        { message: 'missing mandatory field', name: 'date_of_current_purchase_assignment' }
+        { message: 'missing mandatory field', name: 'date_of_current_purchase_assignment' },
+        { message: 'missing mandatory field', name: 'lba_balance' }
       ]
+    end
+
+    it 'returns the correct lba balance' do
+      letter = described_class.build(
+        letter_params: letter_params,
+        template_path: Hackney::ServiceCharge::Letter::BeforeAction::TEMPLATE_PATHS.sample
+      )
+      expected_balance =  format('%.2f',letter_params[:total_collectable_arrears_balance].to_f-letter_params[:money_judgement].to_f)
+      expect(letter.lba_balance).to eq(expected_balance.to_s)
     end
   end
 

--- a/spec/models/hackney/service_charge/letter_spec.rb
+++ b/spec/models/hackney/service_charge/letter_spec.rb
@@ -87,8 +87,7 @@ describe Hackney::ServiceCharge::Letter do
 
       expect(letter.errors).to eq [
         { message: 'missing mandatory field', name: 'original_lease_date' },
-        { message: 'missing mandatory field', name: 'date_of_current_purchase_assignment' },
-        { message: 'missing mandatory field', name: 'lba_balance' }
+        { message: 'missing mandatory field', name: 'date_of_current_purchase_assignment' }
       ]
     end
 


### PR DESCRIPTION
**WHAT**

- Updated template paths for the LBA and letter 2, this is yet to be tested

- Update `lba_balance` calculation method

**WHY**

- LBA balance was not showing up as the directories of the templates has been updated so the correct letter class wasn't not picked up in the switch case