### PR TITLE
Ma 248 letter saving bug

### DIFF
--- a/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
+++ b/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
@@ -22,6 +22,7 @@ module Hackney
             )
 
           document.ext_message_id = letter_response.message_id
+          document.status = :queued
           document.save!
         end
 

--- a/app/models/hackney/cloud/document.rb
+++ b/app/models/hackney/cloud/document.rb
@@ -4,7 +4,7 @@ module Hackney
       # the end status maps to https://docs.notifications.service.gov.uk/java.html#status-letter
       # Accepted    GOV.UK Notify has sent the letter to the provider to be printed.
       # Received    The provider has printed and dispatched the letter.
-      enum status: { uploading: 0, uploaded: 1, received: 2, accepted: 3, 'validation-failed' => 4, downloaded: 5 }
+      enum status: { uploading: 0, uploaded: 1, received: 2, accepted: 3, 'validation-failed' => 4, downloaded: 5, queued: 6 }
 
       def failed?
         status == 'validation-failed'

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -46,7 +46,7 @@ module Hackney
         if payment_ref.present?
           document_model.where("JSON_EXTRACT(metadata, '$.payment_ref') = ?", payment_ref).order(created_at: :DESC)
         else
-          document_model.all.order(created_at: :DESC)
+          document_model.where.not(status: :uploaded).order(created_at: :DESC)
         end
       end
 

--- a/spec/hackney/income/jobs/send_letter_to_gov_notify_job_spec.rb
+++ b/spec/hackney/income/jobs/send_letter_to_gov_notify_job_spec.rb
@@ -5,6 +5,7 @@ describe Hackney::Income::Jobs::SendLetterToGovNotifyJob do
     Hackney::Cloud::Document.create(
       filename: 'test_file.txt',
       extension: '.txt',
+      status: 'uploaded',
       uuid: SecureRandom.uuid,
       mime_type: 'application/pdf',
       metadata: {
@@ -24,5 +25,10 @@ describe Hackney::Income::Jobs::SendLetterToGovNotifyJob do
   it 'updates with message id' do
     doc = Hackney::Cloud::Document.find(document_id)
     expect { described_class.perform_now(document_id: document_id) }.to change { doc.reload.ext_message_id }.from(nil).to(message_receipt.message_id)
+  end
+
+  it 'updates with letter status' do
+    doc = Hackney::Cloud::Document.find(document_id)
+    expect { described_class.perform_now(document_id: document_id) }.to change { doc.reload.status }.from('uploaded').to('queued')
   end
 end

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -13,10 +13,15 @@ describe Hackney::Cloud::Storage, type: :model do
   end
 
   describe 'retrieve all document' do
-    it 'retrieves all documents' do
-      expect(Hackney::Cloud::Document).to receive(:all).and_return(Hackney::Cloud::Document.none)
+    let!(:uploading) { create(:document, status: :uploading) }
+    let!(:uploaded) { create(:document, status: :uploaded) }
+    let!(:received) { create(:document, status: :received) }
+    let!(:accepted) { create(:document, status: :accepted) }
+    let!(:downloaded) { create(:document, status: :downloaded) }
+    let!(:queued) { create(:document, status: :queued) }
 
-      storage.all_documents
+    it 'retrieves all documents without uploading' do
+      expect(storage.all_documents).not_to include(uploaded)
     end
 
     context 'when payment_ref param is used' do

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -13,12 +13,15 @@ describe Hackney::Cloud::Storage, type: :model do
   end
 
   describe 'retrieve all document' do
-    let(:uploading) { create(:document, status: :uploading) }
-    let(:uploaded) { create(:document, status: :uploaded) }
-    let(:received) { create(:document, status: :received) }
-    let(:accepted) { create(:document, status: :accepted) }
-    let(:downloaded) { create(:document, status: :downloaded) }
-    let(:queued) { create(:document, status: :queued) }
+    let!(:uploaded) { create(:document, status: :uploaded) }
+
+    before do
+      create(:document, status: :uploading)
+      create(:document, status: :received)
+      create(:document, status: :accepted)
+      create(:document, status: :downloaded)
+      create(:document, status: :queued)
+    end
 
     it 'retrieves all documents without uploading' do
       expect(storage.all_documents).not_to include(uploaded)

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -23,7 +23,7 @@ describe Hackney::Cloud::Storage, type: :model do
       create(:document, status: :queued)
     end
 
-    it 'retrieves all documents without uploading' do
+    it 'retrieves all documents except for the one marked as "uploaded"' do
       expect(storage.all_documents).not_to include(uploaded)
     end
 

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -13,12 +13,12 @@ describe Hackney::Cloud::Storage, type: :model do
   end
 
   describe 'retrieve all document' do
-    let!(:uploading) { create(:document, status: :uploading) }
-    let!(:uploaded) { create(:document, status: :uploaded) }
-    let!(:received) { create(:document, status: :received) }
-    let!(:accepted) { create(:document, status: :accepted) }
-    let!(:downloaded) { create(:document, status: :downloaded) }
-    let!(:queued) { create(:document, status: :queued) }
+    let(:uploading) { create(:document, status: :uploading) }
+    let(:uploaded) { create(:document, status: :uploaded) }
+    let(:received) { create(:document, status: :received) }
+    let(:accepted) { create(:document, status: :accepted) }
+    let(:downloaded) { create(:document, status: :downloaded) }
+    let(:queued) { create(:document, status: :queued) }
 
     it 'retrieves all documents without uploading' do
       expect(storage.all_documents).not_to include(uploaded)

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/apply_for_court_date_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/apply_for_court_date_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Apply for Court Date Rule', type: :feature do
-  court_warning_letter_code = 'IC4'.freeze
+  court_warning_letter_code = Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
 
   apply_for_court_date_condition_matrix = [
     {

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_nosp_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_nosp_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'Send NOSP Rule', type: :feature do
-  pre_nosp_warning_letter = 'IC3'.freeze
-
   send_nosp_condition_matrix = [
     {
       outcome: :no_action,
@@ -13,7 +11,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -26,7 +24,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -39,7 +37,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: 1.month.from_now,
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -52,7 +50,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
-      last_communication_action: 'ZR2', # Stage 02 Complete / Letter 2 Sent
+      last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
       eviction_date: nil,
       courtdate: ''
     },
@@ -65,7 +63,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 5.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -78,7 +76,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: 2.weeks.ago,
       courtdate: ''
     },
@@ -91,7 +89,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: 1.week.from_now,
       courtdate: ''
     },
@@ -104,7 +102,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: 2.weeks.from_now
     },
@@ -117,7 +115,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -130,7 +128,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 7.months.ago.to_date,
-      last_communication_action: 'ZR2', # Stage 02 Complete / Letter 2 Sent
+      last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
       eviction_date: nil,
       courtdate: ''
     },
@@ -143,7 +141,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: true,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -156,7 +154,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: ''
     },
@@ -169,7 +167,7 @@ describe 'Send NOSP Rule', type: :feature do
       is_paused_until: nil,
       active_agreement: false,
       last_communication_date: 8.days.ago.to_date,
-      last_communication_action: pre_nosp_warning_letter,
+      last_communication_action: Hackney::Tenancy::ActionCodes::PRE_NOSP_WARNING_LETTER_SENT,
       eviction_date: nil,
       courtdate: 2.months.ago
     }

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -50,7 +50,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:accepted) { create(:document, status: :accepted) }
       let!(:failed) { create(:document, status: 'validation-failed') }
       let!(:downloaded) { create(:document, status: :downloaded) }
-      let(:queued) { create(:document, status: :queued) }
+      let!(:queued) { create(:document, status: :queued) }
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -50,6 +50,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:accepted) { create(:document, status: :accepted) }
       let!(:failed) { create(:document, status: 'validation-failed') }
       let!(:downloaded) { create(:document, status: :downloaded) }
+      let(:queued) { create(:document, status: :queued) }
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -50,7 +50,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:accepted) { create(:document, status: :accepted) }
       let!(:failed) { create(:document, status: 'validation-failed') }
       let!(:downloaded) { create(:document, status: :downloaded) }
-      let!(:queued) { create(:document, status: :queued) } # rubocop:disable RSpec/LetSetup
+      let!(:queued) { create(:document, status: :queued) }
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }
@@ -58,6 +58,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       it { expect(subject.documents).not_to include(received) }
       it { expect(subject.documents).not_to include(failed) }
       it { expect(subject.documents).to include(downloaded) }
+      it { expect(subject.documents).to include(queued) }
 
       it 'all statuses should be checked' do
         document_store.statuses.each do |status|

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -50,7 +50,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:accepted) { create(:document, status: :accepted) }
       let!(:failed) { create(:document, status: 'validation-failed') }
       let!(:downloaded) { create(:document, status: :downloaded) }
-      let!(:queued) { create(:document, status: :queued) }
+      let!(:queued) { create(:document, status: :queued) } # rubocop:disable RSpec/LetSetup
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }


### PR DESCRIPTION
Introduced a new state of `queued` to show that a letter has been queued up for sending to gov notify also users don't like seeing previews that were uploaded in the all documents page, so I've filtered them out. 