### PR TITLE
Convert default (1900s) eviction date to 'nil'

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -167,6 +167,8 @@ module Hackney
         end
 
         def eviction_date
+          return nil if date_not_valid?(attributes[:eviction_date])
+
           attributes[:eviction_date]
         end
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -75,6 +75,20 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
     it 'returns an eviction date' do
       expect(subject).to eq(eviction_date.to_date)
     end
+
+    context 'when UH returns no nosp expiry date (1900-01-01 00:00:00 +0000)' do
+      before do
+        truncate_uh_tables
+        create_uh_tenancy_agreement(
+          tenancy_ref: tenancy_ref,
+          current_balance: current_balance
+        )
+      end
+
+      it 'returns nil' do
+        expect(subject).to eq(nil)
+      end
+    end
   end
 
   describe '#nosp_served_date' do


### PR DESCRIPTION
Similarly to court date and nosp dates, we get back a default-looking date (1st Jan 1900) if the field is missing in UH. This may be the fault of the tenancy API, or it may be the fault of MSSQL Server - either way, it's not desirable behaviour for us (as it confuses users and makes our classification logic harder).

In the future, it would be good to have this filtering in a single component rather than spread across multiple fields, but this PR should fix some significant issues with filtering, so I am happy to delay that cleanup.