### PR TITLE
to prevent unnecessary automated communications from being sent pause…

### DIFF
--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -17,7 +17,7 @@ module Hackney
           weightings: priorities.fetch(:weightings)
         )
 
-        @automate_sending_letters.execute(case_priority: case_priority)
+        @automate_sending_letters.execute(case_priority: case_priority) unless case_priority.paused?
 
         nil
       end


### PR DESCRIPTION
When a case is paused, it should be removed from the automation. Any automated letters should not be sent to a paused case.

https://hackney.atlassian.net/browse/MA-241?atlOrigin=eyJpIjoiZTNlODNiYmY1Yjc1NDE0MGJiZTIwMWJiMTNhNWEzMjMiLCJwIjoiaiJ9