### PR TITLE
Allow patch code env list to take whitespaces

### DIFF
--- a/lib/use_cases/case_ready_for_automation.rb
+++ b/lib/use_cases/case_ready_for_automation.rb
@@ -7,7 +7,7 @@ module UseCases
     private
 
     def patch_codes_allowed_for_automation
-      patch_codes_allowed_for_automation_env.to_s.split(',')
+      patch_codes_allowed_for_automation_env.to_s.split(',').map(&:squish)
     end
 
     def patch_codes_allowed_for_automation_env

--- a/spec/use_cases/case_ready_for_automation_spec.rb
+++ b/spec/use_cases/case_ready_for_automation_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe UseCases::CaseReadyForAutomation do
   let(:use_case) { described_class.new }
 
-  let(:patch_code_1) { 'ABC' }
-  let(:patch_code_not_in_automation_list) { 'BAA' }
+  let(:patch_code_1) { 'W02' }
+  let(:patch_code_not_in_automation_list) { 'W03' }
 
   before do
     allow(use_case).to receive(:patch_codes_allowed_for_automation_env).and_return(patch_codes_env)
@@ -27,7 +27,7 @@ describe UseCases::CaseReadyForAutomation do
   end
 
   context 'when the patch code automation env is defined' do
-    let(:patch_codes_env) { 'ABC,DEF,GHI' }
+    let(:patch_codes_env) { 'W02,W04,W06' }
 
     it 'returns true if the patch code exists in the env' do
       expect(use_case.execute(patch_code: patch_code_1)).to eq(true)
@@ -35,6 +35,14 @@ describe UseCases::CaseReadyForAutomation do
 
     it 'returns false if the patch code does not exist in the env' do
       expect(use_case.execute(patch_code: patch_code_not_in_automation_list)).to eq(false)
+    end
+  end
+
+  context 'when the patch code env varibale has spacing' do
+    let(:patch_codes_env) { 'W02, W04, W06' }
+
+    it 'returns true if the patch code exists in the env' do
+      expect(use_case.execute(patch_code: patch_code_1)).to eq(true)
     end
   end
 end


### PR DESCRIPTION
### WHAT
Allow the patch code list env variable to accept white spaces

### WHY
To reduce fragility of the env variable 