### PR TITLE
Allow automation of letters 1 and 2 to write to the action diary

### DIFF
--- a/app/jobs/hackney/income/jobs/save_and_send_letter_job.rb
+++ b/app/jobs/hackney/income/jobs/save_and_send_letter_job.rb
@@ -7,7 +7,7 @@ module Hackney
 
         after_perform do
           Rails.logger.info 'after_perform enqueuing send letter to gov notify'
-          Hackney::Income::Jobs::SendLetterToGovNotifyJob.perform_now(document_id: @document_id)
+          Hackney::Income::Jobs::SendLetterToGovNotifyJob.perform_now(document_id: @document_id, tenancy_ref: nil)
         end
 
         def perform(letter_html:, bucket_name:, filename:, document_id:)

--- a/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
+++ b/app/jobs/hackney/income/jobs/send_letter_to_gov_notify_job.rb
@@ -4,9 +4,8 @@ module Hackney
       class SendLetterToGovNotifyJob < ApplicationJob
         HACKNEY_BUCKET_DOCS = Rails.application.config_for('cloud_storage')['bucket_docs']
 
-        def perform(document_id:)
+        def perform(document_id:, tenancy_ref:)
           Rails.logger.info "JOB: Performing SendLetterToGovNotifyJob on document_id: #{document_id}"
-
           document = Hackney::Cloud::Document.find(document_id)
 
           letter_pdf = pdf_file_from_s3(document.filename)
@@ -15,6 +14,7 @@ module Hackney
           letter_response =
             income_use_case_factory.send_precompiled_letter.execute(
               username: document.username,
+              tenancy_ref: tenancy_ref,
               payment_ref: metadata[:payment_ref],
               template_id: metadata.dig(:template, :id),
               unique_reference: document.uuid,

--- a/lib/hackney/notification/send_manual_precompiled_letter.rb
+++ b/lib/hackney/notification/send_manual_precompiled_letter.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Notification
     class SendManualPrecompiledLetter < BaseManualGateway
-      def execute(username: nil, payment_ref: nil, template_id:, unique_reference:, letter_pdf:)
+      def execute(username: nil, payment_ref: nil, tenancy_ref:, template_id:, unique_reference:, letter_pdf:)
         send_letter_response =
           notification_gateway.send_precompiled_letter(
             unique_reference: unique_reference,
@@ -11,7 +11,11 @@ module Hackney
         # FIXME: this must be in a background job => UH is unreliable
         # TODO: create job to accept exact same args as add_action_diary_usecase
 
-        tenancy_ref = leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref)
+        if template_id.include? 'income'
+          tenancy_ref = tenancy_ref
+        else
+          tenancy_ref = leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref)
+        end
 
         ad_code = action_code(template_id: template_id)
         Rails.logger.info "writing action diary code #{ad_code} from template_id: #{template_id} for Letter '#{unique_reference}'"

--- a/lib/hackney/notification/send_manual_precompiled_letter.rb
+++ b/lib/hackney/notification/send_manual_precompiled_letter.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Notification
     class SendManualPrecompiledLetter < BaseManualGateway
-      def execute(username: nil, payment_ref: nil, tenancy_ref:, template_id:, unique_reference:, letter_pdf:)
+      def execute(username: nil, payment_ref: nil, template_id:, unique_reference:, letter_pdf:, tenancy_ref: nil)
         send_letter_response =
           notification_gateway.send_precompiled_letter(
             unique_reference: unique_reference,
@@ -11,11 +11,7 @@ module Hackney
         # FIXME: this must be in a background job => UH is unreliable
         # TODO: create job to accept exact same args as add_action_diary_usecase
 
-        if template_id.include? 'income'
-          tenancy_ref = tenancy_ref
-        else
-          tenancy_ref = leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref)
-        end
+        tenancy_ref = leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref) if tenancy_ref.nil?
 
         ad_code = action_code(template_id: template_id)
         Rails.logger.info "writing action diary code #{ad_code} from template_id: #{template_id} for Letter '#{unique_reference}'"

--- a/lib/hackney/notification/send_manual_precompiled_letter.rb
+++ b/lib/hackney/notification/send_manual_precompiled_letter.rb
@@ -11,7 +11,7 @@ module Hackney
         # FIXME: this must be in a background job => UH is unreliable
         # TODO: create job to accept exact same args as add_action_diary_usecase
 
-        tenancy_ref = leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref) if tenancy_ref.nil?
+        tenancy_ref ||= leasehold_gateway.get_tenancy_ref(payment_ref: payment_ref).dig(:tenancy_ref)
 
         ad_code = action_code(template_id: template_id)
         Rails.logger.info "writing action diary code #{ad_code} from template_id: #{template_id} for Letter '#{unique_reference}'"

--- a/lib/use_cases/automate_sending_letters.rb
+++ b/lib/use_cases/automate_sending_letters.rb
@@ -28,7 +28,7 @@ module UseCases
         template_id: letter_name,
         user: generate_income_collection_user
       )
-      @send_letter_to_gov_notify.perform_later(document_id: generate_letter[:document_id])
+      @send_letter_to_gov_notify.perform_later(document_id: generate_letter[:document_id], tenancy_ref: case_priority.tenancy_ref)
 
       true
     end

--- a/spec/hackney/income/jobs/send_letter_to_gov_notify_job_spec.rb
+++ b/spec/hackney/income/jobs/send_letter_to_gov_notify_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::Jobs::SendLetterToGovNotifyJob do
+  let(:tenancy_ref) { '12345' }
+
   let(:document_id) do
     Hackney::Cloud::Document.create(
       filename: 'test_file.txt',
@@ -24,11 +26,18 @@ describe Hackney::Income::Jobs::SendLetterToGovNotifyJob do
 
   it 'updates with message id' do
     doc = Hackney::Cloud::Document.find(document_id)
-    expect { described_class.perform_now(document_id: document_id) }.to change { doc.reload.ext_message_id }.from(nil).to(message_receipt.message_id)
+    expect {
+      described_class.perform_now(
+        document_id: document_id,
+        tenancy_ref: tenancy_ref
+      )
+    } .to change { doc.reload.ext_message_id }.from(nil).to(
+      message_receipt.message_id
+    )
   end
 
   it 'updates with letter status' do
     doc = Hackney::Cloud::Document.find(document_id)
-    expect { described_class.perform_now(document_id: document_id) }.to change { doc.reload.status }.from('uploaded').to('queued')
+    expect { described_class.perform_now(document_id: document_id, tenancy_ref: tenancy_ref) }.to change { doc.reload.status }.from('uploaded').to('queued')
   end
 end

--- a/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
+++ b/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
@@ -15,17 +15,16 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
 
   let(:test_file) { File.open('spec/test_files/test_pdf.pdf', 'rb') }
   let(:unique_reference) { SecureRandom.uuid }
-  let(:payment_ref) { 'payment_ref' }
-  let(:tenancy_ref) { '12234' }
 
   before do
     allow(add_action_diary_usecase).to receive(:execute)
   end
 
-  context 'when sending an automated income collection letter' do
+  context 'when sending an income collection letter' do
+    let(:tenancy_ref) { Faker::Number.number(6) }
     let(:subject) do
       send_precompiled_letter.execute(
-        payment_ref: payment_ref,
+        payment_ref: nil,
         tenancy_ref: tenancy_ref,
         template_id: 'income collection letter',
         unique_reference: unique_reference,
@@ -33,50 +32,31 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
       )
     end
 
-    it 'will not call the leasehold_gatway' do
+    it 'will send the letter by without calling the leasehold gateway using a tenancy_ref' do
       expect_any_instance_of(leasehold_gateway).not_to receive(:get_tenancy_ref)
     end
   end
 
-  context 'when sending an letters manually' do
-    let(:template_id) { 'Letter 1 in arrears FH' }
-
+  context 'when sending a leasehold letter' do
+    let(:payment_ref) { Faker::Number.number(6) }
     let(:subject) do
       send_precompiled_letter.execute(
-        unique_reference: unique_reference,
-        letter_pdf: test_file,
         payment_ref: payment_ref,
         tenancy_ref: nil,
-        template_id: template_id
+        template_id: 'Letter 1 in arrears FH',
+        unique_reference: unique_reference,
+        letter_pdf: test_file
       )
     end
 
     before {
-      expect_any_instance_of(leasehold_gateway).to receive(:get_tenancy_ref).and_return(tenancy_ref: 12_321)
+      allow_any_instance_of(leasehold_gateway).to receive(:get_tenancy_ref).and_return(tenancy_ref: Faker::Number.number(6))
     }
 
-    it { expect(subject).to be_a Hackney::Notification::Domain::NotificationReceipt }
-    it { expect(subject.body).to include(unique_reference) }
-
-    context 'when templates write into action diary they should have action codes associated with them' do
-      [
-        'letter 1 in arrears FH', 'letter 1 in arrears LH',
-        'letter 1 in arrears SO', 'letter 2 in arrears FH',
-        'letter 2 in arrears LH', 'letter 2 in arrears SO',
-        'income collection letter 1', 'income collection letter 2'
-      ].each do |template|
-        it {
-          expect {
-            send_precompiled_letter.execute(
-              unique_reference: unique_reference,
-              letter_pdf: test_file,
-              payment_ref: payment_ref,
-              tenancy_ref: nil,
-              template_id: template
-            )
-          } .not_to raise_error
-        }
-      end
+    it 'will send the letter by calling the leasehold gateway using a payment_ref' do
+      expect_any_instance_of(leasehold_gateway).to receive(:get_tenancy_ref).with(payment_ref: payment_ref)
+      expect(subject).to be_a Hackney::Notification::Domain::NotificationReceipt
+      expect(subject.body).to include(unique_reference)
     end
   end
 end

--- a/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
+++ b/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
@@ -4,6 +4,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
   let(:notification_gateway) { Hackney::Income::StubNotificationsGateway.new }
   let(:add_action_diary_usecase) { instance_double(Hackney::Tenancy::AddActionDiaryEntry) }
   let(:leasehold_gateway) { Hackney::Income::UniversalHousingLeaseholdGateway }
+
   let(:send_precompiled_letter) do
     described_class.new(
       notification_gateway: notification_gateway,
@@ -14,26 +15,45 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
 
   let(:test_file) { File.open('spec/test_files/test_pdf.pdf', 'rb') }
   let(:unique_reference) { SecureRandom.uuid }
-  let(:template_id) { 'Letter 1 in arrears FH' }
   let(:payment_ref) { 'payment_ref' }
+  let(:tenancy_ref) { '12234' }
 
   before do
     allow(add_action_diary_usecase).to receive(:execute)
   end
 
+  context 'when sending an automated income collection letter' do
+    let(:subject) do
+      send_precompiled_letter.execute(
+        payment_ref: nil,
+        tenancy_ref: tenancy_ref,
+        template_id: 'income collection letter',
+        unique_reference: unique_reference,
+        letter_pdf: test_file
+      )
+    end
+
+    it 'will not call the leasehold_gatway' do
+      expect_any_instance_of(leasehold_gateway).not_to receive(:get_tenancy_ref)
+    end
+  end
+
   context 'when sending an letters manually' do
-    before {
-      expect_any_instance_of(leasehold_gateway).to receive(:get_tenancy_ref).and_return(tenancy_ref: 12_321)
-    }
+    let(:template_id) { 'Letter 1 in arrears FH' }
 
     let(:subject) do
       send_precompiled_letter.execute(
         unique_reference: unique_reference,
         letter_pdf: test_file,
         payment_ref: payment_ref,
+        tenancy_ref: tenancy_ref,
         template_id: template_id
       )
     end
+
+    before {
+      expect_any_instance_of(leasehold_gateway).to receive(:get_tenancy_ref).and_return(tenancy_ref: 12_321)
+    }
 
     it { expect(subject).to be_a Hackney::Notification::Domain::NotificationReceipt }
     it { expect(subject.body).to include(unique_reference) }
@@ -42,8 +62,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
       [
         'letter 1 in arrears FH', 'letter 1 in arrears LH',
         'letter 1 in arrears SO', 'letter 2 in arrears FH',
-        'letter 2 in arrears LH', 'letter 2 in arrears SO',
-        'income collection letter 1', 'income collection letter 2'
+        'letter 2 in arrears LH', 'letter 2 in arrears SO'
       ].each do |template|
         it {
           expect {
@@ -51,6 +70,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
               unique_reference: unique_reference,
               letter_pdf: test_file,
               payment_ref: payment_ref,
+              tenancy_ref: tenancy_ref,
               template_id: template
             )
           } .not_to raise_error

--- a/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
+++ b/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
@@ -26,7 +26,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
       send_precompiled_letter.execute(
         payment_ref: nil,
         tenancy_ref: tenancy_ref,
-        template_id: 'income collection letter',
+        template_id: 'income_collection_letter_1',
         unique_reference: unique_reference,
         letter_pdf: test_file
       )
@@ -43,7 +43,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
       send_precompiled_letter.execute(
         payment_ref: payment_ref,
         tenancy_ref: nil,
-        template_id: 'Letter 1 in arrears FH',
+        template_id: 'letter_1_in_arrears_FH',
         unique_reference: unique_reference,
         letter_pdf: test_file
       )

--- a/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
+++ b/spec/lib/hackney/notification/send_manual_precompiled_letter_spec.rb
@@ -25,7 +25,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
   context 'when sending an automated income collection letter' do
     let(:subject) do
       send_precompiled_letter.execute(
-        payment_ref: nil,
+        payment_ref: payment_ref,
         tenancy_ref: tenancy_ref,
         template_id: 'income collection letter',
         unique_reference: unique_reference,
@@ -46,7 +46,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
         unique_reference: unique_reference,
         letter_pdf: test_file,
         payment_ref: payment_ref,
-        tenancy_ref: tenancy_ref,
+        tenancy_ref: nil,
         template_id: template_id
       )
     end
@@ -62,7 +62,8 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
       [
         'letter 1 in arrears FH', 'letter 1 in arrears LH',
         'letter 1 in arrears SO', 'letter 2 in arrears FH',
-        'letter 2 in arrears LH', 'letter 2 in arrears SO'
+        'letter 2 in arrears LH', 'letter 2 in arrears SO',
+        'income collection letter 1', 'income collection letter 2'
       ].each do |template|
         it {
           expect {
@@ -70,7 +71,7 @@ describe Hackney::Notification::SendManualPrecompiledLetter do
               unique_reference: unique_reference,
               letter_pdf: test_file,
               payment_ref: payment_ref,
-              tenancy_ref: tenancy_ref,
+              tenancy_ref: nil,
               template_id: template
             )
           } .not_to raise_error


### PR DESCRIPTION
### WHAT
Pass the tenancy_ref through in the flow of automation

### WHY
So it can write to the action diary once automation has sent letters 1 or 2