### PR TITLE
return patch code in api

### DIFF
--- a/lib/hackney/income/view_cases.rb
+++ b/lib/hackney/income/view_cases.rb
@@ -77,7 +77,8 @@ module Hackney
           courtdate: assigned_tenancy.fetch(:courtdate),
           court_outcome: assigned_tenancy.fetch(:court_outcome),
           eviction_date: assigned_tenancy.fetch(:eviction_date),
-          classification: assigned_tenancy.fetch(:classification)
+          classification: assigned_tenancy.fetch(:classification),
+          patch_code: assigned_tenancy.fetch(:patch_code)
         }
       end
     end

--- a/spec/lib/hackney/income/view_cases_spec.rb
+++ b/spec/lib/hackney/income/view_cases_spec.rb
@@ -120,7 +120,8 @@ describe Hackney::Income::ViewCases do
                                            court_outcome: tenancy_priority_factors.fetch(:court_outcome),
                                            eviction_date: tenancy_priority_factors.fetch(:eviction_date),
 
-                                           classification: tenancy_priority_factors.fetch(:classification)
+                                           classification: tenancy_priority_factors.fetch(:classification),
+                                           patch_code: tenancy_priority_factors.fetch(:patch_code)
                                          ))
       end
 
@@ -251,7 +252,7 @@ describe Hackney::Income::ViewCases do
       courtdate: Date.today - 5,
       court_outcome: Faker::Lorem.word,
       eviction_date: Date.today + 1.month,
-
+      patch_code: Faker::Lorem.characters(3),
       classification: 'no_action'
     }
   end


### PR DESCRIPTION
patch codes where not returned when fetching all case priorities, this needs to be returned so that useful reports could be generated on the front end