### PR TITLE
Refactor (and fix) nosp/sms classification logic

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -64,12 +64,13 @@ module Hackney
         end
 
         def send_sms?
-          @criteria.last_communication_action.nil? &&
-            @criteria.balance >= 5 &&
-            @criteria.nosp_served? == false &&
-            last_communication_between_three_months_one_week? &&
-            @case_priority.paused? == false &&
-            @criteria.active_agreement? == false
+          return false if @criteria.last_communication_action.present?
+          return false if @criteria.nosp_served?
+          return false unless last_communication_between_three_months_one_week?
+          return false if @case_priority.paused?
+          return false if @criteria.active_agreement?
+
+          @criteria.balance >= 5
         end
 
         def send_letter_one?
@@ -92,6 +93,8 @@ module Hackney
         end
 
         def send_letter_two?
+          return false if @criteria.active_agreement?
+
           valid_actions = [
             Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1
           ]
@@ -104,8 +107,9 @@ module Hackney
         end
 
         def send_nosp?
-          return false if @criteria.active_agreement?
           return false if @case_priority.paused?
+          return false if @criteria.active_agreement?
+          return false if @criteria.nosp_served?
 
           valid_actions = [
             Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
@@ -113,15 +117,14 @@ module Hackney
           ]
 
           if @criteria.nosp_expiry_date.present?
-            can_send_nosp = @criteria.nosp_expiry_date < Time.zone.now
+            return false if @criteria.nosp_expiry_date >= Time.zone.now
           else
-            can_send_nosp = @criteria.last_communication_action.in?(valid_actions) &&
-                            last_communication_between_three_months_one_week?
+            return false unless @criteria.last_communication_action.in?(valid_actions)
+            return false if last_communication_older_than?(3.months.ago)
+            return false if last_communication_newer_than?(1.week.ago)
           end
 
-          can_send_nosp &&
-            @criteria.nosp_served? == false &&
-            @criteria.balance >= arrear_accumulation_by_number_weeks(4)
+          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
         end
 
         def last_communication_between_three_months_one_week?

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
@@ -112,6 +112,15 @@ describe 'Send Letter Two Rule', type: :feature do
       last_communication_action: letter_1_in_arrears_sent_code,
       eviction_date: 5.days.from_now.to_date,
       courtdate: ''
+    },
+    # active agreement
+    {
+      outcome: :no_action,
+      weekly_rent: 5,
+      balance: 15.0,
+      active_agreement: true,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code
     }
   ]
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_nosp_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_nosp_spec.rb
@@ -29,17 +29,6 @@ describe 'Send NOSP Rule', type: :feature do
       eviction_date: nil,
       courtdate: ''
     },
-    # nosp has been served, other data isn't right, no other detail
-    # not clear why this test is passing when `@criteria.nosp_served? == false &&` is removed
-    {
-      outcome: :no_action,
-      nosps_in_last_year: 0,
-      nosp_served: true,
-      weekly_rent: 5,
-      balance: 50.0,
-      last_communication_date: 2.months.ago.to_date,
-      last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2
-    },
     # out of date nosp, heavily in arrears, recent letter 2
     {
       outcome: :send_NOSP,

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -49,7 +49,7 @@ module Stubs
     end
 
     def nosp_expiry_date
-      attributes[:nosp_expiry_date] || '2019-12-30 16:43:10'.to_date
+      attributes[:nosp_expiry_date]
     end
 
     def courtdate


### PR DESCRIPTION
This PR attempts to make the business rules around 'escaping' a particular classification, e.g.  
> if it's got an agreement on, don't send a NOSP.

This refactoring/exploration exposed some weird conditions/edge cases. This PR includes fixing the behaviour for these cases.

Notably, there is still duplication across each classification, the tests are hard to read, and other classification methods are still opaque. I hope to address these next.