### PR TITLE
Add UH letter 1 as valid letter 2 precondition

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -93,7 +93,8 @@ module Hackney
 
         def send_letter_two?
           valid_actions = [
-            Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1
+            Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
+            Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH
           ]
 
           @criteria.last_communication_action.in?(valid_actions) &&

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
@@ -99,6 +99,19 @@ describe 'Send Letter Two Rule', type: :feature do
       eviction_date: '',
       courtdate: ''
     },
+    {
+      outcome: :send_letter_two,
+      nosps_in_last_year: 0,
+      nosp_expiry_date: '',
+      weekly_rent: 5,
+      balance: 15.0,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH,
+      eviction_date: '',
+      courtdate: ''
+    },
     # eviction date test
     {
       outcome: :no_action,


### PR DESCRIPTION
Cases will only be classified as 'send letter two' if a letter one has already been sent, so that the letters are sent in order.

This PR changes the 'send letter two' classification to understand that an additional code (`SO1`) also means 'letter one has been sent'.