### PR TITLE
Refactor classification methods

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -86,7 +86,7 @@ module Hackney
           return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&
                           last_communication_newer_than?(3.months.ago)
 
-          @criteria.balance >= @criteria.weekly_rent
+          @criteria.balance >= arrear_accumulation_by_number_weeks(1)
         end
 
         def send_letter_two?
@@ -104,7 +104,7 @@ module Hackney
           return false if last_communication_newer_than?(1.week.ago)
           return false if last_communication_older_than?(3.months.ago)
 
-          @criteria.balance >= @criteria.weekly_rent * 3
+          @criteria.balance >= arrear_accumulation_by_number_weeks(3)
         end
 
         def send_nosp?

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -35,14 +35,16 @@ module Hackney
         end
 
         def send_court_warning_letter?
-          return false if @criteria.nosp_served_date.blank?
+          return false if @case_priority.paused?
+          return false if @criteria.active_agreement?
 
-          @criteria.last_communication_action != Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT &&
-            @criteria.nosp_served? &&
-            @criteria.nosp_served_date <= 28.days.ago.to_date &&
-            @criteria.balance >= arrear_accumulation_by_number_weeks(4) &&
-            @case_priority.paused? == false &&
-            @criteria.active_agreement? == false
+          return false if @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
+
+          return false unless @criteria.nosp_served?
+          return false if @criteria.nosp_served_date.blank?
+          return false if @criteria.nosp_served_date > 28.days.ago.to_date
+
+          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
         end
 
         def apply_for_court_date?

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -115,14 +115,12 @@ module Hackney
         end
 
         def apply_for_court_date?
-          return false if @case_priority.paused?
           return false unless @criteria.nosp_served?
 
           return false unless @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
           return false if last_communication_newer_than?(2.weeks.ago)
 
           return false if @criteria.nosp_served_date > 28.days.ago.to_date
-          return false if @criteria.courtdate.present? && @criteria.courtdate > Time.zone.now
 
           @criteria.balance >= arrear_accumulation_by_number_weeks(4)
         end

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -60,10 +60,10 @@ module Hackney
           @criteria.balance >= arrear_accumulation_by_number_weeks(4)
         end
 
+
         def send_sms?
           return false if @criteria.last_communication_action.present?
           return false if @criteria.nosp_served?
-          return false unless last_communication_between_three_months_one_week?
           return false if @case_priority.paused?
           return false if @criteria.active_agreement?
 
@@ -126,12 +126,6 @@ module Hackney
           end
 
           @criteria.balance >= arrear_accumulation_by_number_weeks(4)
-        end
-
-        def last_communication_between_three_months_one_week?
-          return false if @criteria.last_communication_date.nil?
-
-          last_communication_older_than?(1.week.ago) && last_communication_newer_than?(3.months.ago)
         end
 
         def last_communication_older_than?(date)

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -95,18 +95,21 @@ module Hackney
         end
 
         def send_letter_two?
+          return false if @case_priority.paused?
           return false if @criteria.active_agreement?
+          return false if @criteria.nosp_served?
 
           valid_actions = [
             Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
             Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH
           ]
 
-          @criteria.last_communication_action.in?(valid_actions) &&
-            @criteria.balance >= arrear_accumulation_by_number_weeks(3) &&
-            @criteria.nosp_served? == false &&
-            last_communication_between_three_months_one_week? &&
-            @case_priority.paused? == false
+          return false unless @criteria.last_communication_action.in?(valid_actions)
+
+          return false if last_communication_newer_than?(1.week.ago)
+          return false if last_communication_older_than?(3.months.ago)
+
+          @criteria.balance >= @criteria.weekly_rent * 3
         end
 
         def send_nosp?

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -12,6 +12,7 @@ module Hackney
 
           wanted_action ||= :no_action if @criteria.eviction_date.present?
           wanted_action ||= :no_action if @criteria.courtdate.present? && @criteria.courtdate >= Time.zone.now
+          wanted_action ||= :no_action if @case_priority.paused?
 
           wanted_action ||= :apply_for_court_date if apply_for_court_date?
           wanted_action ||= :send_court_warning_letter if send_court_warning_letter?
@@ -37,14 +38,12 @@ module Hackney
         def send_sms?
           return false if @criteria.last_communication_action.present?
           return false if @criteria.nosp_served?
-          return false if @case_priority.paused?
           return false if @criteria.active_agreement?
 
           @criteria.balance >= 5
         end
 
         def send_letter_one?
-          return false if @case_priority.paused?
           return false if @criteria.nosp_served?
           return false if @criteria.active_agreement?
 
@@ -63,7 +62,6 @@ module Hackney
         end
 
         def send_letter_two?
-          return false if @case_priority.paused?
           return false if @criteria.active_agreement?
           return false if @criteria.nosp_served?
 
@@ -81,7 +79,6 @@ module Hackney
         end
 
         def send_nosp?
-          return false if @case_priority.paused?
           return false if @criteria.active_agreement?
           return false if @criteria.nosp_served?
 
@@ -102,7 +99,6 @@ module Hackney
         end
 
         def send_court_warning_letter?
-          return false if @case_priority.paused?
           return false if @criteria.active_agreement?
 
           return false if @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -34,33 +34,6 @@ module Hackney
           raise ArgumentError, "Tried to classify a case as #{wanted_action}, but this is not on the list of valid classifications."
         end
 
-        def send_court_warning_letter?
-          return false if @case_priority.paused?
-          return false if @criteria.active_agreement?
-
-          return false if @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
-
-          return false unless @criteria.nosp_served?
-          return false if @criteria.nosp_served_date.blank?
-          return false if @criteria.nosp_served_date > 28.days.ago.to_date
-
-          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
-        end
-
-        def apply_for_court_date?
-          return false if @case_priority.paused?
-          return false unless @criteria.nosp_served?
-
-          return false unless @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
-          return false if last_communication_newer_than?(2.weeks.ago)
-
-          return false if @criteria.nosp_served_date > 28.days.ago.to_date
-          return false if @criteria.courtdate.present? && @criteria.courtdate > Time.zone.now
-
-          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
-        end
-
-
         def send_sms?
           return false if @criteria.last_communication_action.present?
           return false if @criteria.nosp_served?
@@ -124,6 +97,32 @@ module Hackney
             return false if last_communication_older_than?(3.months.ago)
             return false if last_communication_newer_than?(1.week.ago)
           end
+
+          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
+        end
+
+        def send_court_warning_letter?
+          return false if @case_priority.paused?
+          return false if @criteria.active_agreement?
+
+          return false if @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
+
+          return false unless @criteria.nosp_served?
+          return false if @criteria.nosp_served_date.blank?
+          return false if @criteria.nosp_served_date > 28.days.ago.to_date
+
+          @criteria.balance >= arrear_accumulation_by_number_weeks(4)
+        end
+
+        def apply_for_court_date?
+          return false if @case_priority.paused?
+          return false unless @criteria.nosp_served?
+
+          return false unless @criteria.last_communication_action == Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
+          return false if last_communication_newer_than?(2.weeks.ago)
+
+          return false if @criteria.nosp_served_date > 28.days.ago.to_date
+          return false if @criteria.courtdate.present? && @criteria.courtdate > Time.zone.now
 
           @criteria.balance >= arrear_accumulation_by_number_weeks(4)
         end

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_warning_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_warning_letter_spec.rb
@@ -136,6 +136,13 @@ describe 'Send Court Warning Letter Rule', type: :feature do
       last_communication_action: nil,
       eviction_date: nil,
       courtdate: 10.months.ago
+    },
+    # missing served date
+    {
+      outcome: :no_action,
+      nosps_in_last_year: 1,
+      weekly_rent: 5,
+      balance: 25.0 # 5 * weekly_rent
     }
   ]
 

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -45,7 +45,7 @@ module Stubs
     end
 
     def nosp_served_date
-      attributes[:nosp_served_date] || '2019-12-13 12:43:10'.to_date
+      attributes[:nosp_served_date]
     end
 
     def nosp_expiry_date


### PR DESCRIPTION
I've been looking at letter one/two/nosp classifications, and refactored some of these methods to try and get more clarity on the gaps (#282 and #283). 

This PR covers the rest of these methods. See individual commits for more detail about the steps I've taken.

I want to think more about how to clearly express "this policy applies to this subset of classifications", so I've pulled out the `paused?` check, but not `active_agreement?`.

I've also not made any significant changes to the test suite - I would like to try and make our examples more clear if we continue working on classifications.