### PR TITLE
Remove classification stub defaults

### DIFF
--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -30,7 +30,6 @@ shared_examples 'TenancyClassification' do |condition_matrix|
   let(:criteria) { Stubs::StubCriteria.new(attributes) }
   let(:case_priority) { build(:case_priority, is_paused_until: is_paused_until) }
 
-  let(:is_paused_until) { nil }
   let(:attributes) do
     {
       balance: balance,
@@ -46,23 +45,11 @@ shared_examples 'TenancyClassification' do |condition_matrix|
     }
   end
 
-  let(:balance) { 5.00 }
-  let(:weekly_rent) { 5.0 }
-  let(:last_communication_date) { '' }
-  let(:last_communication_action) { nil }
-  let(:active_agreement) { nil }
-  let(:nosps_in_last_year) { nil }
-  let(:nosp_served_date) { '' }
-  let(:nosp_expiry_date) { '' }
-  let(:courtdate) { '' }
-  let(:eviction_date) { '' }
-
   condition_matrix.each do |options|
     message = build_context_message(options)
 
     context "when #{message}" do
       let(:is_paused_until) { options[:is_paused_until] }
-
       let(:balance) { options[:balance] }
       let(:weekly_rent) { options[:weekly_rent] }
       let(:last_communication_date) { options[:last_communication_date] }

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -59,7 +59,7 @@ shared_examples 'TenancyClassification' do |condition_matrix|
       let(:nosp_served_date) { options[:nosp_served_date] }
       let(:nosp_expiry_date) { options[:nosp_expiry_date] }
       let(:courtdate) { options[:courtdate] }
-      let(:eviction_date) { options[:eviction_date] || '' }
+      let(:eviction_date) { options[:eviction_date] }
 
       it "returns `#{options[:outcome]}`" do
         expect(subject).to eq(options[:outcome])

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -53,19 +53,19 @@ module Stubs
     end
 
     def courtdate
-      attributes[:courtdate] || '2005-12-13 12:43:10'.to_date
+      attributes[:courtdate]
     end
 
     def eviction_date
-      attributes[:eviction_date] || '2007-09-20 10:30:00'.to_date
+      attributes[:eviction_date]
     end
 
     def patch_code
-      attributes[:patch_code] || 'E01'
+      attributes[:patch_code]
     end
 
     def broken_court_order?
-      attributes[:broken_court_order] || false
+      attributes[:broken_court_order]
     end
 
     def days_in_arrears
@@ -73,7 +73,7 @@ module Stubs
     end
 
     def active_agreement?
-      attributes[:active_agreement] || false
+      attributes[:active_agreement]
     end
 
     def nosp_served?
@@ -82,7 +82,7 @@ module Stubs
     end
 
     def active_nosp?
-      attributes[:active_nosp] || false
+      attributes[:active_nosp]
     end
 
     def number_of_broken_agreements
@@ -90,11 +90,11 @@ module Stubs
     end
 
     def payment_amount_delta
-      attributes[:payment_amount_delta] || 0
+      attributes[:payment_amount_delta]
     end
 
     def payment_date_delta
-      attributes[:payment_date_delta] || 0
+      attributes[:payment_date_delta]
     end
 
     private


### PR DESCRIPTION
Some of these tripped me up whilst I was working in this area, so scout's code applies!

Most of these defaults aren't necessary for the specs to pass, but they do sometimes cause newly written specs to give false positives.

I wasn't able to remove some of the defaults as some tests do rely on them. Some of these specs are around unused functionality, but I didn't want to let the scope of this particular change grow.

I also removed an extra context block that wasn't necessary.