### PR TITLE
income collection letter template fix

### DIFF
--- a/app/models/hackney/income_collection/letter.rb
+++ b/app/models/hackney/income_collection/letter.rb
@@ -57,7 +57,7 @@ module Hackney
         # tenant address doesn't have full 5 lines, we need to add enough breaks
         # to make up for that otherwise the whole letter won't pass gov notify validation
         (5 - address_lines.length).times do
-          address_lines.push('<br>')
+          address_lines.push(' ')
         end
 
         address_lines.join('<br>')

--- a/app/models/hackney/income_collection/letter.rb
+++ b/app/models/hackney/income_collection/letter.rb
@@ -8,7 +8,7 @@ module Hackney
       attr_reader :tenancy_ref, :address_line1, :address_line2,
                   :address_line3, :address_line4, :address_post_code,
                   :payment_ref, :total_collectable_arrears_balance,
-                  :title, :forename, :surname, :errors
+                  :title, :forename, :surname, :errors, :tenant_address
 
       # Following the pattern used in Letter.rb
       # We don't need template_path at the moment.
@@ -24,15 +24,17 @@ module Hackney
 
         @tenancy_ref = validated_params[:tenancy_ref]
         @payment_ref = validated_params[:payment_ref]
-        @address_line1 = validated_params[:address_line1]
-        @address_line2 = validated_params[:address_line2]
-        @address_line3 = validated_params[:address_line3]
-        @address_line4 = validated_params[:address_line4]
-        @address_post_code = validated_params[:address_post_code]
         @total_collectable_arrears_balance = format('%.2f', (validated_params[:total_collectable_arrears_balance] || 0))
         @title = validated_params[:title]
         @forename = validated_params[:forename]
         @surname = validated_params[:surname]
+        @tenant_address = build_tenant_address([
+          validated_params[:address_line1],
+          validated_params[:address_line2],
+          validated_params[:address_line3],
+          validated_params[:address_line4],
+          validated_params[:address_post_code]
+        ])
       end
 
       def validate_mandatory_fields(mandatory_fields, letter_params)
@@ -44,6 +46,21 @@ module Hackney
         )
 
         letter_params
+      end
+
+      private
+
+      def build_tenant_address(address_lines)
+        address_lines = address_lines.select(&:present?)
+
+        # Our templates are designed to have 5 lines in the address window. If the
+        # tenant address doesn't have full 5 lines, we need to add enough breaks
+        # to make up for that otherwise the whole letter won't pass gov notify validation
+        (5 - address_lines.length).times do
+          address_lines.push('<br>')
+        end
+
+        address_lines.join('<br>')
       end
     end
   end

--- a/lib/hackney/pdf/templates/income/partials/tenant_address.html.erb
+++ b/lib/hackney/pdf/templates/income/partials/tenant_address.html.erb
@@ -1,11 +1,5 @@
 <div class="tenant-address">
   <strong><%= @letter.forename %> <%= @letter.surname %></strong>
   <br>
-  <%= [
-    @letter.address_line1,
-    @letter.address_line2,
-    @letter.address_line3,
-    @letter.address_line4,
-    @letter.address_post_code
-  ].select(&:present?).join('<br>').html_safe %>
+  <%= @letter.tenant_address.html_safe %>
 </div>

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe Hackney::IncomeCollection::Letter do
+  let(:letter_params) do
+    {
+      tenancy_ref: Faker::Number.number(6),
+      payment_ref: Faker::Number.number(8),
+      total_collectable_arrears_balance: Faker::Number.number(3),
+      title: Faker::Job.title,
+      forename: Faker::Name.first_name,
+      surname: Faker::Name.last_name,
+      address_line1: 'Address 1',
+      address_line2: 'Address 2',
+      address_line3: address_line3,
+      address_line4: address_line4,
+      address_post_code: 'E1 1YE'
+    }
+  end
+  let(:address_line3) { nil }
+  let(:address_line4) { nil }
+
+  let(:letter) { described_class.new(letter_params) }
+
+  describe '#build_tenant_address' do
+    let(:built_address) { letter.tenant_address }
+
+    context 'with all address lines present' do
+      let(:address_line3) { 'Address 3' }
+      let(:address_line4) { 'Address 4' }
+
+      it 'returns 5 lines' do
+        expect(built_address.split(/(?<=<br>)/).size).to eq(5)
+      end
+
+      it 'contains 4 line breaks' do
+        parts = built_address.split(/(?<=<br>)/)
+        parts.select! { |part| part.include?('<br>') }
+
+        expect(parts.size).to eq(4)
+      end
+    end
+
+    context 'with missing address line 4' do
+      let(:address_line3) { 'Address 3' }
+      let(:address_line4) { nil }
+
+      it 'returns 5 lines' do
+        expect(built_address.split(/(?<=<br>)/).size).to eq(5)
+      end
+
+      it 'contains 4 line breaks' do
+        parts = built_address.split(/(?<=<br>)/)
+        parts.select! { |part| part.include?('<br>') }
+
+        expect(parts.size).to eq(4)
+      end
+    end
+
+    context 'with missing address line 4 and line 3' do
+      let(:address_line3) { nil }
+      let(:address_line4) { nil }
+
+      it 'returns 5 lines' do
+        expect(built_address.split(/(?<=<br>)/).size).to eq(5)
+      end
+
+      it 'contains 4 line breaks' do
+        parts = built_address.split(/(?<=<br>)/)
+        parts.select! { |part| part.include?('<br>') }
+
+        expect(parts.size).to eq(4)
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/pdf/test_income_template.erb
+++ b/spec/lib/hackney/pdf/test_income_template.erb
@@ -5,4 +5,5 @@
   <li>forename: <%= @letter.forename %></li>
   <li>surname: <%= @letter.surname %></li>
   <li>formatted address: <%= @letter.tenant_address %></li>
+  <li>total_collectable_arrears_balance: <%= @letter.total_collectable_arrears_balance %></li>
 </ul>

--- a/spec/lib/hackney/pdf/test_income_template.erb
+++ b/spec/lib/hackney/pdf/test_income_template.erb
@@ -4,9 +4,5 @@
   <li>tenancy_ref: <%=  @letter.tenancy_ref %></li>
   <li>forename: <%= @letter.forename %></li>
   <li>surname: <%= @letter.surname %></li>
-  <li>address_line1: <%= @letter.address_line1 %></li>
-  <li>address_line2: <%= @letter.address_line2 %></li>
-  <li>address_line3: <%= @letter.address_line3 %></li>
-  <li>address_post_code: <%= @letter.address_post_code %></li>
-  <li>total_collectable_arrears_balance: <%= @letter.total_collectable_arrears_balance %></li>
+  <li>formatted address: <%= @letter.tenant_address %></li>
 </ul>

--- a/spec/lib/hackney/pdf/translated_test_income_template.html
+++ b/spec/lib/hackney/pdf/translated_test_income_template.html
@@ -5,4 +5,5 @@
   <li>forename: Bloggs</li>
   <li>surname: Joe</li>
   <li>formatted address: 508 Saint Cloud Road<br>Southwalk<br>London<br>London<br>SE1 0SW</li>
+  <li>total_collectable_arrears_balance: 3506.90</li>
 </ul>

--- a/spec/lib/hackney/pdf/translated_test_income_template.html
+++ b/spec/lib/hackney/pdf/translated_test_income_template.html
@@ -4,9 +4,5 @@
   <li>tenancy_ref: 1234567890</li>
   <li>forename: Bloggs</li>
   <li>surname: Joe</li>
-  <li>address_line1: 508 Saint Cloud Road</li>
-  <li>address_line2: Southwalk</li>
-  <li>address_line3: London</li>
-  <li>address_post_code: SE1 0SW</li>
-  <li>total_collectable_arrears_balance: 3506.90</li>
+  <li>formatted address: 508 Saint Cloud Road<br>Southwalk<br>London<br>London<br>SE1 0SW</li>
 </ul>

--- a/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
+++ b/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
@@ -5,4 +5,5 @@
   <li>forename: </li>
   <li>surname: </li>
   <li>formatted address: 508 Saint Cloud Road<br><br><br><br><br><br><br><br></li>
+  <li>total_collectable_arrears_balance: 3506.90</li>
 </ul>

--- a/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
+++ b/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
@@ -4,6 +4,6 @@
   <li>tenancy_ref: 1234567890</li>
   <li>forename: </li>
   <li>surname: </li>
-  <li>formatted address: 508 Saint Cloud Road<br><br><br><br><br><br><br><br></li>
+  <li>formatted address: 508 Saint Cloud Road<br> <br> <br> <br> </li>
   <li>total_collectable_arrears_balance: 3506.90</li>
 </ul>

--- a/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
+++ b/spec/lib/hackney/pdf/translated_test_income_template_with_blanks.html
@@ -4,9 +4,5 @@
   <li>tenancy_ref: 1234567890</li>
   <li>forename: </li>
   <li>surname: </li>
-  <li>address_line1: 508 Saint Cloud Road</li>
-  <li>address_line2: </li>
-  <li>address_line3: </li>
-  <li>address_post_code: </li>
-  <li>total_collectable_arrears_balance: 3506.90</li>
+  <li>formatted address: 508 Saint Cloud Road<br><br><br><br><br><br><br><br></li>
 </ul>


### PR DESCRIPTION
appending empty lines to income collection letters so they pass gov notify validation

currently some address weren't passing validation because everything was brought up by one line
<img width="449" alt="Screenshot 2019-12-17 at 16 04 01" src="https://user-images.githubusercontent.com/8051117/71012316-d9640880-20e6-11ea-9c5b-5a6563a05bbb.png">
