### PR TITLE
Only get master accounts from Universal Housing

### DIFF
--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -6,18 +6,18 @@ module Hackney
           database.extension :identifier_mangling
           database.identifier_input_method = database.identifier_output_method = nil
 
-          query = database[:tenagree]
-
-          query
-            .where { Sequel[:tenagree][:cur_bal] > 0 }
-            .where(Sequel[:tenagree][:tenure] => SECURE_TENURE_TYPE)
-            .where(Sequel[:tenagree][:terminated].cast(:integer) => 0)
-            .select { Sequel[:tenagree][:tag_ref].as(:tag_ref) }
-            .map { |record| record[:tag_ref].strip }
+          database[:tenagree]
+            .select(:tag_ref)
+            .where { cur_bal > 0 }
+            .where(tenure: SECURE_TENURE_TYPE)
+            .where(terminated: 0)
+            .where(agr_type: MASTER_ACCOUNT_TYPE)
+            .map { |item| item[:tag_ref].strip }
         end
       end
 
       SECURE_TENURE_TYPE = 'SEC'.freeze
+      MASTER_ACCOUNT_TYPE = 'M'.freeze
     end
   end
 end

--- a/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
@@ -18,7 +18,37 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
       before { create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 50.00) }
 
       it 'returns that tenancy' do
-        expect(subject).to eq(%w[000001/01])
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'with a tenancy ref that includes whitespace' do
+      before { create_uh_tenancy_agreement(tenancy_ref: ' 000001/01 ', current_balance: 50.00) }
+
+      it 'strips the whitespace' do
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'when there are three tenancies in arrears, but only one is a master account' do
+      before do
+        create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 50.00, agreement_type: 'M')
+        create_uh_tenancy_agreement(tenancy_ref: '000002/01', current_balance: 50.00, agreement_type: 'R')
+        create_uh_tenancy_agreement(tenancy_ref: '000003/01', current_balance: 50.00, agreement_type: 'X')
+      end
+
+      it 'returns only the master account tenancy' do
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'when there is one tenancy in arrears' do
+      before do
+        create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 50.00)
+      end
+
+      it 'returns that tenancy' do
+        expect(subject).to eq(['000001/01'])
       end
     end
 
@@ -55,7 +85,7 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
       before { create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 100.00, tenure_type: 'SEC') }
 
       it 'returns the tenancy' do
-        expect(subject).to eq(%w[000001/01])
+        expect(subject).to eq(['000001/01'])
       end
     end
 

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -4,7 +4,7 @@ module UniversalHousingHelper
                                   tenure_type: 'SEC', high_action: '111', u_saff_rentacc: '', house_ref: '',
                                   nosp_notice_served_date: '1900-01-01 00:00:00 +0000', nosp_notice_expiry_date: '1900-01-01 00:00:00 +0000',
                                   money_judgement: 0.0, charging_order: 0.0, bal_dispute: 0.0, courtdate: '1900-01-01 00:00:00 +0000',
-                                  court_outcome: nil, eviction_date: '1900-01-01 00:00:00 +0000')
+                                  court_outcome: nil, eviction_date: '1900-01-01 00:00:00 +0000', agreement_type: 'M')
     Hackney::UniversalHousing::Client.connection[:tenagree].insert(
       tag_ref: tenancy_ref,
       cur_bal: current_balance,
@@ -46,7 +46,8 @@ module UniversalHousingHelper
       cot: cot,
       u_money_judgement: money_judgement,
       u_charging_order: charging_order,
-      u_bal_dispute: bal_dispute
+      u_bal_dispute: bal_dispute,
+      agr_type: agreement_type
     )
   end
   # rubocop:enable Metrics/ParameterLists


### PR DESCRIPTION
Some accounts in the `tenagree` table are sub-accounts of others, but we don't want to retrieve these (and we certainly don't want to do things like send them letters!).

Accounts that we do want to retrieve have a value of 'M' in tenagree.agr_type. There is a lookup table to give this value more semantic meaning, but joining onto this table probably gives us little long-term benefit (as we're using the database as the integration layer anyway).

Notably, this gateway is what we use for our 'sync', which pulls across all the cases we show in our various worktrays in the service.

This PR also includes a small bit of cleanup on the query, which passes the tests and shouldn't affect the raw SQL generated, it's just a little easier to read.