### PR TITLE
Fix error on nil latest active agreement date

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -39,6 +39,7 @@ module Hackney
         def send_court_agreement_breach_letter?
           return false if @criteria.number_of_broken_agreements < 1
           return false if @criteria.active_agreement? == true
+          return false if @criteria.latest_active_agreement_date.blank?
           return false if @criteria.latest_active_agreement_date <= @criteria.courtdate
           return false if @criteria.breach_agreement_date + 3.days > Date.today
           return false if @criteria.balance >= @criteria.expected_balance

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_agreement_breach_letter_spec.rb
@@ -90,6 +90,20 @@ describe 'Send Court Agreement Breach Letter Rule', type: :feature do
       last_communication_action: Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT,
       last_communication_date: 1.month.ago,
       number_of_broken_agreements: 1
+    },
+    {
+      # when the latest agctive agreement date does not exist
+      outcome: :no_action,
+      active_agreement: false,
+      court_outcome: 'AGR',
+      courtdate: 8.days.ago,
+      latest_active_agreement_date: nil,
+      balance: 1234,
+      expected_balance: 10,
+      breach_agreement_date: 4.days.ago,
+      last_communication_action: Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT,
+      last_communication_date: 1.month.ago,
+      number_of_broken_agreements: 1
     }
     # {
     #   #last communicated action was not send court warning letter

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -37,11 +37,11 @@ module Stubs
     end
 
     def latest_active_agreement_date
-      attributes[:latest_active_agreement_date] || 20.years.from_now.to_date
+      attributes[:latest_active_agreement_date]
     end
 
     def breach_agreement_date
-      attributes[:breach_agreement_date] || 10.years.from_now.to_date
+      attributes[:breach_agreement_date]
     end
 
     def balance


### PR DESCRIPTION
**What?**

- Remove stubbed date for latest active agreement date

- Add test which checks when latest active agreement date is nil

**Why?**

- Sync didn't run because the classifications wasn't handling a latest active agreement date of nil 