### PR TITLE
Add test for no breach agreement date

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -41,7 +41,7 @@ module Hackney
           return false if @criteria.active_agreement? == true
           return false if @criteria.latest_active_agreement_date.blank?
           return false if @criteria.latest_active_agreement_date <= @criteria.courtdate
-          return false if @criteria.breach_agreement_date + 3.days > Date.today
+          return false if @criteria.breach_agreement_date.present? && @criteria.breach_agreement_date + 3.days > Date.today
           return false if @criteria.balance >= @criteria.expected_balance
           return false unless @criteria.court_outcome == 'AGR'
           return false unless @criteria.last_communication_action.in?(valid_actions_for_court_agreement_breach_letter_to_progress)

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_court_agreement_breach_letter_spec.rb
@@ -104,6 +104,20 @@ describe 'Send Court Agreement Breach Letter Rule', type: :feature do
       last_communication_action: Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT,
       last_communication_date: 1.month.ago,
       number_of_broken_agreements: 1
+    },
+    {
+      # where there is no breach agreement date
+      outcome: :send_court_agreement_breach_letter,
+      active_agreement: false,
+      court_outcome: 'AGR',
+      courtdate: 8.days.ago,
+      latest_active_agreement_date: 7.days.ago,
+      balance: 5,
+      expected_balance: 10,
+      breach_agreement_date: nil,
+      last_communication_action: Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT,
+      last_communication_date: 1.month.ago,
+      number_of_broken_agreements: 1
     }
     # {
     #   #last communicated action was not send court warning letter


### PR DESCRIPTION
**What**

- Add test when the breach agreement date doesn't exit

- If all other conditions are met for a court ordered agreement but there is no date for when the agreement was breached, then it will still fall into the `send_court_agreement_breach_letter` bucket.

**Why?**

- So the sync can run without errors