### PR TITLE
Fix latest agreement date field

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -233,11 +233,11 @@ module Hackney
               ORDER BY action_date DESC
             )
             DECLARE @LatestActiveAgreementDate SMALLDATETIME = (
-              SELECT TOP 1 arag_statusdate
+              SELECT TOP 1 arag_startdate
               FROM [dbo].[arag]
               WHERE tag_ref = @TenancyRef
               AND arag_status = @ActiveArrearsAgreementStatus
-              ORDER BY arag_statusdate DESC
+              ORDER BY arag_startdate DESC
             )
             DECLARE @BreachAgreementDate SMALLDATETIME = (
               SELECT TOP 1 arag_statusdate

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -486,16 +486,17 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
           create_uh_arrears_agreement(
             tenancy_ref: tenancy_ref,
             status: '200',
-            status_entry_date: 2.days.ago
+            agreement_start_date: 2.days.ago
           )
           create_uh_arrears_agreement(
             tenancy_ref: tenancy_ref,
             status: '200',
-            status_entry_date: yesterday
+            agreement_start_date: yesterday
           )
           create_uh_arrears_agreement(
             tenancy_ref: tenancy_ref,
-            status: '300'
+            status: '300',
+            agreement_start_date: Date.today
           )
         end
 
@@ -527,7 +528,7 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
         end
       end
 
-      context 'when there is a breache of agreement' do
+      context 'when there is a breach of agreement' do
         before do
           create_uh_arrears_agreement(
             tenancy_ref: tenancy_ref,

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -86,14 +86,15 @@ module UniversalHousingHelper
     )
   end
 
-  def create_uh_arrears_agreement(tenancy_ref:, status:, status_entry_date: Date.today, expected_balance: nil)
+  def create_uh_arrears_agreement(tenancy_ref:, status:, status_entry_date: nil, expected_balance: nil, agreement_start_date: nil)
     Hackney::UniversalHousing::Client.connection[:arag].insert(
       arag_ref: Faker::IDNumber.valid,
       tag_ref: tenancy_ref,
       arag_status: status,
       arag_breached: false,
       arag_statusdate: status_entry_date,
-      arag_lastexpectedbal: expected_balance
+      arag_lastexpectedbal: expected_balance,
+      arag_startdate: agreement_start_date
     )
   end
 


### PR DESCRIPTION
**What?**
- Update so that it is looking for `arag_startdate` instead of `arag_statusdate`

**Why?**
- The latest agreement date was incorrect, so the classifications were not  falling into the correct buckets