### PR TITLE
Documents handling

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -19,6 +19,10 @@ class DocumentsController < ApplicationController
     send_file doc_download[:filepath], type: doc.mime_type, filename: letter_file_name(doc)
   end
 
+  def review_failure
+    render json: letter_use_case_factory.review_failure.execute(document_id: params.fetch(:id))
+  end
+
   def index
     render json: letter_use_case_factory.get_all_documents.execute(payment_ref: params.fetch(:payment_ref, nil))
   end

--- a/app/models/hackney/cloud/document.rb
+++ b/app/models/hackney/cloud/document.rb
@@ -4,7 +4,10 @@ module Hackney
       # the end status maps to https://docs.notifications.service.gov.uk/java.html#status-letter
       # Accepted    GOV.UK Notify has sent the letter to the provider to be printed.
       # Received    The provider has printed and dispatched the letter.
-      enum status: { uploading: 0, uploaded: 1, received: 2, accepted: 3, 'validation-failed' => 4, downloaded: 5, queued: 6 }
+      enum status: {
+        uploading: 0, uploaded: 1, received: 2, accepted: 3, 'validation-failed' => 4,
+        downloaded: 5, queued: 6, failure_reviewed: 7
+      }
 
       scope :by_payment_ref, ->(payment_ref) { where("JSON_EXTRACT(metadata, '$.payment_ref') = ?", payment_ref) }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
     get '/documents/:id/download/', to: 'documents#download'
     get '/documents/', to: 'documents#index'
+    post '/documents/:id/review_failure', to: 'documents#review_failure'
 
     post '/messages/letters/send', to: 'letters#send_letter'
     post '/messages/letters', to: 'letters#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
     get '/documents/:id/download/', to: 'documents#download'
     get '/documents/', to: 'documents#index'
-    post '/documents/:id/review_failure', to: 'documents#review_failure'
+    patch '/documents/:id/review_failure', to: 'documents#review_failure'
 
     post '/messages/letters/send', to: 'letters#send_letter'
     post '/messages/letters', to: 'letters#create'

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -44,7 +44,7 @@ module Hackney
 
       def all_documents(payment_ref: nil)
         if payment_ref.present?
-          document_model.by_payment_ref(payment_ref).order(created_at: :DESC)
+          document_model.by_payment_ref(payment_ref).exclude_uploaded.order(created_at: :DESC)
         else
           document_model.exclude_uploaded.order(created_at: :DESC)
         end
@@ -73,6 +73,7 @@ module Hackney
 
         evt = Raven::Event.new(message: message)
         Raven.send_event(evt) if document.failed?
+        document
       end
 
       private

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -1,6 +1,8 @@
 module Hackney
   module Cloud
     class Storage
+      attr_reader :document_model
+
       HACKNEY_BUCKET_DOCS = Rails.application.config_for('cloud_storage')['bucket_docs']
       UPLOADING_CLOUD_STATUS = :uploading
 
@@ -75,10 +77,6 @@ module Hackney
         Raven.send_event(evt) if document.failed?
         document
       end
-
-      private
-
-      attr_reader :document_model
     end
   end
 end

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -66,11 +66,13 @@ module Hackney
       end
 
       def update_document_status(document:, status:)
+        raise "Invalid document status: #{status}" unless document_model.statuses.include?(status)
+
         Rails.logger.info "Document ext_message_id #{document.ext_message_id} found with status #{status}"
         document.status = status
         document.save!
 
-        message = "Document has been set to #{status} - id: #{document.id}, uuid: #{document.uuid}"
+        message = "Document has been set to #{document.status} - id: #{document.id}, uuid: #{document.uuid}"
         Rails.logger.info message
 
         evt = Raven::Event.new(message: message)

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -73,11 +73,10 @@ module Hackney
 
       def enqueue_request_all_precompiled_letter_states
         enqueue_job = Hackney::Income::Jobs::RequestPrecompiledLetterStateJob
-        document_store = Hackney::Cloud::Document
 
         Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates.new(
           enqueue_job: enqueue_job,
-          document_store: document_store
+          document_store: cloud_storage
         )
       end
 

--- a/lib/hackney/letter/review_failure.rb
+++ b/lib/hackney/letter/review_failure.rb
@@ -1,0 +1,14 @@
+module Hackney
+  module Letter
+    class ReviewFailure
+      def initialize(cloud_storage:)
+        @cloud_storage = cloud_storage
+      end
+
+      def execute(document_id:)
+        document = @cloud_storage.document_model.find(document_id)
+        @cloud_storage.update_document_status(document: document, status: :failure_reviewed)
+      end
+    end
+  end
+end

--- a/lib/hackney/letter/use_case_factory.rb
+++ b/lib/hackney/letter/use_case_factory.rb
@@ -19,6 +19,12 @@ module Hackney
         )
       end
 
+      def review_failure
+        Hackney::Letter::ReviewFailure.new(
+          cloud_storage: cloud_storage
+        )
+      end
+
       def save_letter_to_cloud
         UseCases::SaveLetterToCloud.new(
           Rails.configuration.cloud_adapter

--- a/lib/hackney/notification/request_precompiled_letter_state.rb
+++ b/lib/hackney/notification/request_precompiled_letter_state.rb
@@ -7,7 +7,7 @@ module Hackney
             message_id: document.ext_message_id
           )
 
-        update_document(document: document, status: response[:status])
+        document_store.update_document_status(document: document, status: response[:status])
 
         if document.income_collection? && document.failed?
           related_case = case_priority_store.by_payment_ref(document.parsed_metadata[:payment_ref])
@@ -22,18 +22,6 @@ module Hackney
         end
 
         response
-      end
-
-      def update_document(document:, status:)
-        Rails.logger.info "Document ext_message_id #{document.ext_message_id} found with status #{status}"
-        document.status = status
-        document.save!
-
-        message = "Document has been set to #{status} - id: #{document.id}, uuid: #{document.uuid}"
-        Rails.logger.info message
-
-        evt = Raven::Event.new(message: message)
-        Raven.send_event(evt) if document.failed?
       end
     end
   end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -20,4 +20,15 @@ describe DocumentsController do
       end
     end
   end
+
+  describe '#review_failure' do
+    let(:document_id) { Faker::Number.number(3) }
+
+    it 'correct usecase is called' do
+      expect_any_instance_of(Hackney::Letter::ReviewFailure)
+        .to receive(:execute).with(document_id: document_id)
+
+      post :review_failure, params: { id: document_id }
+    end
+  end
 end

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -31,18 +31,22 @@ describe Hackney::Cloud::Storage, type: :model do
       subject { storage.all_documents(payment_ref: payment_ref_param) }
 
       let(:payment_ref) { Faker::Number.number(10) }
-      let!(:new_document) { create(:document, metadata: { payment_ref: payment_ref }.to_json) }
+      let!(:uploaded_document) { create(:document, status: :uploaded, metadata: { payment_ref: payment_ref }.to_json) }
+      let!(:downloaded_document) { create(:document, status: :downloaded, metadata: { payment_ref: payment_ref }.to_json) }
+      let!(:accepted_document) { create(:document, status: :accepted, metadata: { payment_ref: payment_ref }.to_json) }
 
       context 'when payment_ref exists' do
         let(:payment_ref_param) { payment_ref }
 
-        it { is_expected.to include(new_document) }
+        it { is_expected.to include(downloaded_document) }
+        it { is_expected.to include(accepted_document) }
+        it { is_expected.not_to include(uploaded_document) }
       end
 
       context 'when payment_ref does not exist' do
         let(:payment_ref_param) { 'NON-EXISTENT-PAYMENT-REF' }
 
-        it { is_expected.not_to include(new_document) }
+        it { is_expected.not_to include([downloaded_document, uploaded_document, accepted_document]) }
       end
     end
   end
@@ -93,6 +97,30 @@ describe Hackney::Cloud::Storage, type: :model do
             .and_return(double(:tempfile, path: '/tmp/tempfile'))
 
           expect(storage.read_document(document.id)[:filepath]).to eq('/tmp/tempfile')
+        end
+      end
+    end
+
+    describe '#update_document_status' do
+
+      let(:document) { create(:document) }
+      let(:status) { [:received, :accepted, :downloaded, :queued, :failure_reviewed].sample }
+
+      it 'status is updated' do
+        updated_document = storage.update_document_status(document: document, status: status)
+
+        expect(updated_document.status).to eq(status.to_s)
+      end
+
+      context 'when status is failed' do
+        let(:status) { 'validation-failed' }
+
+        it 'raises Sentry notification' do
+          expect(Raven).to receive(:send_event)
+
+          updated_document = storage.update_document_status(document: document, status: status)
+
+          expect(updated_document.status).to eq(status)
         end
       end
     end

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -122,6 +122,15 @@ describe Hackney::Cloud::Storage, type: :model do
           expect(updated_document.status).to eq(status)
         end
       end
+
+      context 'when trying to set status to something invalid' do
+        let(:status) { :not_a_valid_status }
+
+        it 'raises a exception' do
+          expect { storage.update_document_status(document: document, status: status) }
+            .to raise_exception("Invalid document status: #{status}")
+        end
+      end
     end
   end
 end

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -102,9 +102,8 @@ describe Hackney::Cloud::Storage, type: :model do
     end
 
     describe '#update_document_status' do
-
       let(:document) { create(:document) }
-      let(:status) { [:received, :accepted, :downloaded, :queued, :failure_reviewed].sample }
+      let(:status) { %i[received accepted downloaded queued failure_reviewed].sample }
 
       it 'status is updated' do
         updated_document = storage.update_document_status(document: document, status: status)

--- a/spec/lib/hackney/letter/review_failure_spec.rb
+++ b/spec/lib/hackney/letter/review_failure_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Hackney::Letter::ReviewFailure do
+  describe '#execute' do
+    subject(:review_failure) { described_class.new(cloud_storage: storage) }
+
+    let(:cloud_adapter_fake) { double(:upload) }
+    let(:storage) { Hackney::Cloud::Storage.new(cloud_adapter_fake, Hackney::Cloud::Document) }
+
+    let(:id) { Random.rand(100) }
+
+    let(:document) { create(:document, id: id) }
+
+    it 'status is updated to failure_reviewed' do
+      expect(storage).to receive(:update_document_status).with(document: document, status: :failure_reviewed).and_call_original
+
+      expect { review_failure.execute(document_id: id) }
+        .to change { document.reload.status }.from('uploaded').to('failure_reviewed')
+    end
+  end
+end

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -51,6 +51,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       let!(:failed) { create(:document, status: 'validation-failed') }
       let!(:downloaded) { create(:document, status: :downloaded) }
       let!(:queued) { create(:document, status: :queued) }
+      let!(:failure_reviewed) { create(:document, status: :failure_reviewed) } # rubocop:disable LetSetup
 
       it { expect(subject.documents).to include(uploading) }
       it { expect(subject.documents).to include(uploaded) }

--- a/spec/lib/hackney/notification/request_precompiled_letter_state_spec.rb
+++ b/spec/lib/hackney/notification/request_precompiled_letter_state_spec.rb
@@ -4,7 +4,7 @@ describe Hackney::Notification::RequestPrecompiledLetterState do
   let!(:message_id) { SecureRandom.uuid }
   let(:notification_gateway) { Hackney::Income::StubNotificationsGateway.new }
   let(:add_action_diary_usecase) { double(Hackney::Tenancy::AddActionDiaryEntry) }
-  let(:document_store) { Hackney::Cloud::Document }
+  let(:document_store) { Hackney::Cloud::Storage.new(double(:adapter), Hackney::Cloud::Document) }
   let(:case_priority_store) { double(Hackney::Income::Models::CasePriority) }
 
   let(:notification_response) do


### PR DESCRIPTION
this allows users to mark documents as 'failure_reviewed" once the govnotify validation issues have been resolved. 

This is done by ` post '/documents/:id/review_failure'` from the front end
