### PR TITLE
Change the schedule to run after the payments have been processed

### DIFF
--- a/schedule.yml
+++ b/schedule.yml
@@ -7,7 +7,7 @@
 
   tenancy_sync:
     class: TenancySync
-    cron: '0 0 17 * * *' # 5pm everyday
+    cron: '0 30 20 * * *' # 8:30pm everyday
 
   request_all_precompiled_letter_states:
     class: RequestAllPrecompiledLetterStates


### PR DESCRIPTION
Payments are batch run at 19:45 in UH so give a good time for it to 
finish before we look at accounts.