### PR TITLE
[MA-264] Pagination for View Letters page

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -26,8 +26,8 @@ class DocumentsController < ApplicationController
   def index
     render json: letter_use_case_factory.get_all_documents.execute(
       payment_ref: params.fetch(:payment_ref, nil),
-      page_number: params.fetch(:page_number, 1),
-      documents_per_page: params.fetch(:documents_per_page, 20)
+      page_number: params.fetch(:page_number, 1).to_i,
+      documents_per_page: params.fetch(:documents_per_page, 20).to_i
     )
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,7 +24,11 @@ class DocumentsController < ApplicationController
   end
 
   def index
-    render json: letter_use_case_factory.get_all_documents.execute(payment_ref: params.fetch(:payment_ref, nil))
+    render json: letter_use_case_factory.get_all_documents.execute(
+      payment_ref: params.fetch(:payment_ref, nil),
+      page_number: params.fetch(:page_number, 1),
+      documents_per_page: params.fetch(:documents_per_page, 20)
+    )
   end
 
   private

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -3,6 +3,8 @@ module Hackney
     class Storage
       attr_reader :document_model
 
+      PaginatedDocumentsResponse = Struct.new(:documents, :number_of_pages, :page_number)
+
       HACKNEY_BUCKET_DOCS = Rails.application.config_for('cloud_storage')['bucket_docs']
       UPLOADING_CLOUD_STATUS = :uploading
 
@@ -52,11 +54,7 @@ module Hackney
         number_of_pages = (query.count.to_f / documents_per_page).ceil
         query.limit(documents_per_page).offset((page_number-1) * documents_per_page)
 
-        OpenStruct.new(
-          documents: query,
-          number_of_pages: number_of_pages,
-          page_number: page_number
-          )
+        PaginatedDocumentsResponse.new(query, number_of_pages, page_number)
       end
 
       def documents_to_update_status(time:)

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -46,13 +46,12 @@ module Hackney
         { filepath: response.path, document: document }
       end
 
-
       def all_documents(payment_ref: nil, page_number:, documents_per_page:)
         query = document_model.exclude_uploaded.order(created_at: :DESC)
         query = query.by_payment_ref(payment_ref) if payment_ref.present?
 
         number_of_pages = (query.count.to_f / documents_per_page).ceil
-        query.limit(documents_per_page).offset((page_number-1) * documents_per_page)
+        query.limit(documents_per_page).offset((page_number - 1) * documents_per_page)
 
         PaginatedDocumentsResponse.new(query, number_of_pages, page_number)
       end

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -44,12 +44,19 @@ module Hackney
         { filepath: response.path, document: document }
       end
 
-      def all_documents(payment_ref: nil)
-        if payment_ref.present?
-          document_model.by_payment_ref(payment_ref).exclude_uploaded.order(created_at: :DESC)
-        else
-          document_model.exclude_uploaded.order(created_at: :DESC)
-        end
+
+      def all_documents(payment_ref: nil, page_number:, documents_per_page:)
+        query = document_model.exclude_uploaded.order(created_at: :DESC)
+        query = query.by_payment_ref(payment_ref) if payment_ref.present?
+
+        number_of_pages = (query.count.to_f / documents_per_page).ceil
+        query.limit(documents_per_page).offset((page_number-1) * documents_per_page)
+
+        OpenStruct.new(
+          documents: query,
+          number_of_pages: number_of_pages,
+          page_number: page_number
+          )
       end
 
       def documents_to_update_status(time:)

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -51,7 +51,7 @@ module Hackney
         query = query.by_payment_ref(payment_ref) if payment_ref.present?
 
         number_of_pages = (query.count.to_f / documents_per_page).ceil
-        query.limit(documents_per_page).offset((page_number - 1) * documents_per_page)
+        query = query.limit(documents_per_page).offset((page_number - 1) * documents_per_page)
 
         PaginatedDocumentsResponse.new(query, number_of_pages, page_number)
       end

--- a/lib/hackney/letter/all_documents_use_case.rb
+++ b/lib/hackney/letter/all_documents_use_case.rb
@@ -6,16 +6,19 @@ module Hackney
       end
 
       def execute(payment_ref: nil, page_number: 1, documents_per_page: 20)
-        @cloud_storage.all_documents(
+        response = @cloud_storage.all_documents(
           payment_ref: payment_ref,
           page_number: page_number,
           documents_per_page: documents_per_page
-        ).each do |doc|
-          metadata = doc.metadata ?  doc.parsed_metadata : {}
-          metadata[:username] = doc.username
+        )
 
+        response.documents.each do |doc|
+          metadata = doc.parsed_metadata
+          metadata[:username] = doc.username
           doc.metadata = metadata.to_json
         end
+
+        response
       end
     end
   end

--- a/lib/hackney/letter/all_documents_use_case.rb
+++ b/lib/hackney/letter/all_documents_use_case.rb
@@ -5,11 +5,13 @@ module Hackney
         @cloud_storage = cloud_storage
       end
 
-      def execute(payment_ref: nil)
-        @cloud_storage.all_documents(payment_ref: payment_ref)
-                      .each do |doc|
-          metadata = JSON.parse(doc.metadata).deep_symbolize_keys if doc.metadata
-          metadata ||= {}
+      def execute(payment_ref: nil, page_number: 1, documents_per_page: 20)
+        @cloud_storage.all_documents(
+          payment_ref: payment_ref,
+          page_number: page_number,
+          documents_per_page: documents_per_page
+        ).each do |doc|
+          metadata = doc.metadata ?  doc.parsed_metadata : {}
           metadata[:username] = doc.username
 
           doc.metadata = metadata.to_json

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -4,28 +4,16 @@ describe DocumentsController do
   let(:page_number) { 1 }
   let(:documents_per_page) { 10 }
   describe '#index' do
-    it 'returns paginated documents' do
+    it 'returns all documents' do
       expect_any_instance_of(Hackney::Letter::AllDocumentsUseCase)
-        .to receive(:execute)
-        .with(payment_ref: nil, page_number: page_number, documents_per_page: documents_per_page)
-        .and_return(
+        .to receive(:execute).with(
           payment_ref: nil,
-          page_number: page_number,
-          documents_per_page: documents_per_page
+          page_number: 1,
+          documents_per_page: 20
         )
 
-
-      get :index, params: { page_number: page_number, documents_per_page: documents_per_page }
-
-      expect(response.body).to eq(
-      {
-          payment_ref: nil,
-          page_number: page_number,
-          documents_per_page: documents_per_page
-      }.to_json
-    )
+      get :index
     end
-  end
 
     context 'when the payment_ref param is present' do
       let(:payment_ref) { Faker::Number.number(10) }
@@ -37,6 +25,7 @@ describe DocumentsController do
         get :index, params: { payment_ref: payment_ref, page_number: page_number, documents_per_page: documents_per_page }
       end
     end
+  end
 
 
   describe '#review_failure' do

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -1,25 +1,43 @@
 require 'rails_helper'
 
 describe DocumentsController do
+  let(:page_number) { 1 }
+  let(:documents_per_page) { 10 }
   describe '#index' do
-    it 'returns all documents' do
+    it 'returns paginated documents' do
       expect_any_instance_of(Hackney::Letter::AllDocumentsUseCase)
         .to receive(:execute)
+        .with(payment_ref: nil, page_number: page_number, documents_per_page: documents_per_page)
+        .and_return(
+          payment_ref: nil,
+          page_number: page_number,
+          documents_per_page: documents_per_page
+        )
 
-      get :index
+
+      get :index, params: { page_number: page_number, documents_per_page: documents_per_page }
+
+      expect(response.body).to eq(
+      {
+          payment_ref: nil,
+          page_number: page_number,
+          documents_per_page: documents_per_page
+      }.to_json
+    )
     end
+  end
 
     context 'when the payment_ref param is present' do
       let(:payment_ref) { Faker::Number.number(10) }
 
       it 'returns all documents filtered by payment_ref' do
         expect_any_instance_of(Hackney::Letter::AllDocumentsUseCase)
-          .to receive(:execute).with(payment_ref: payment_ref)
+          .to receive(:execute).with(payment_ref: payment_ref, page_number: page_number, documents_per_page: documents_per_page)
 
-        get :index, params: { payment_ref: payment_ref }
+        get :index, params: { payment_ref: payment_ref, page_number: page_number, documents_per_page: documents_per_page }
       end
     end
-  end
+
 
   describe '#review_failure' do
     let(:document_id) { Faker::Number.number(3) }

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe DocumentsController do
   let(:page_number) { 1 }
   let(:documents_per_page) { 10 }
+
   describe '#index' do
     it 'returns all documents' do
       expect_any_instance_of(Hackney::Letter::AllDocumentsUseCase)
@@ -26,7 +27,6 @@ describe DocumentsController do
       end
     end
   end
-
 
   describe '#review_failure' do
     let(:document_id) { Faker::Number.number(3) }

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -15,6 +15,13 @@ describe Hackney::Cloud::Storage, type: :model do
   end
 
   describe 'retrieve all document' do
+    subject {
+      storage.all_documents(
+        documents_per_page: documents_per_page,
+        page_number: page_number
+      )
+    }
+
     let!(:uploaded) { create(:document, status: :uploaded) }
 
     before do
@@ -25,31 +32,26 @@ describe Hackney::Cloud::Storage, type: :model do
       create(:document, status: :queued)
     end
 
-    subject {
-      storage.all_documents(
-        documents_per_page: documents_per_page,
-        page_number: page_number
-      )
-    }
-
     it 'retrieves all documents except for the one marked as "uploaded"' do
       expect(subject.documents).not_to include(uploaded)
     end
 
-    context 'returns a paginated set of documents' do
-      let(:documents_per_page){ 3 }
+    context 'when documents are paginated' do
+      let(:documents_per_page) { 3 }
 
       it { expect(subject.number_of_pages).to eq(2) }
-      it {expect(subject.page_number).to eq(1)}
-      it {expect(subject.documents).to all(be_an(Hackney::Cloud::Document))}
+      it { expect(subject.page_number).to eq(1) }
+      it { expect(subject.documents).to all(be_an(Hackney::Cloud::Document)) }
     end
 
     context 'when payment_ref param is used' do
-      subject { storage.all_documents(
-        payment_ref: payment_ref_param,
-        documents_per_page: documents_per_page,
-        page_number: page_number
-      ) }
+      subject {
+        storage.all_documents(
+          payment_ref: payment_ref_param,
+          documents_per_page: documents_per_page,
+          page_number: page_number
+        )
+      }
 
       let(:payment_ref) { Faker::Number.number(10) }
       let!(:uploaded_document) { create(:document, status: :uploaded, metadata: { payment_ref: payment_ref }.to_json) }

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe Hackney::Cloud::Storage, type: :model do
   let(:cloud_adapter_fake) { double(:upload) }
   let(:storage) { described_class.new(cloud_adapter_fake, Hackney::Cloud::Document) }
+  let(:page_number) { 1 }
+  let(:documents_per_page) { 10 }
 
   describe '#upload' do
     it 'saves the file and return the ID' do
@@ -23,12 +25,31 @@ describe Hackney::Cloud::Storage, type: :model do
       create(:document, status: :queued)
     end
 
+    subject {
+      storage.all_documents(
+        documents_per_page: documents_per_page,
+        page_number: page_number
+      )
+    }
+
     it 'retrieves all documents except for the one marked as "uploaded"' do
-      expect(storage.all_documents).not_to include(uploaded)
+      expect(subject.documents).not_to include(uploaded)
+    end
+
+    context 'returns a paginated set of documents' do
+      let(:documents_per_page){ 3 }
+
+      it { expect(subject.number_of_pages).to eq(2) }
+      it {expect(subject.page_number).to eq(1)}
+      it {expect(subject.documents).to all(be_an(Hackney::Cloud::Document))}
     end
 
     context 'when payment_ref param is used' do
-      subject { storage.all_documents(payment_ref: payment_ref_param) }
+      subject { storage.all_documents(
+        payment_ref: payment_ref_param,
+        documents_per_page: documents_per_page,
+        page_number: page_number
+      ) }
 
       let(:payment_ref) { Faker::Number.number(10) }
       let!(:uploaded_document) { create(:document, status: :uploaded, metadata: { payment_ref: payment_ref }.to_json) }
@@ -38,15 +59,15 @@ describe Hackney::Cloud::Storage, type: :model do
       context 'when payment_ref exists' do
         let(:payment_ref_param) { payment_ref }
 
-        it { is_expected.to include(downloaded_document) }
-        it { is_expected.to include(accepted_document) }
-        it { is_expected.not_to include(uploaded_document) }
+        it { expect(subject.documents).to include(downloaded_document) }
+        it { expect(subject.documents).to include(accepted_document) }
+        it { expect(subject.documents).not_to include(uploaded_document) }
       end
 
       context 'when payment_ref does not exist' do
         let(:payment_ref_param) { 'NON-EXISTENT-PAYMENT-REF' }
 
-        it { is_expected.not_to include([downloaded_document, uploaded_document, accepted_document]) }
+        it { expect(subject.documents).not_to include([downloaded_document, uploaded_document, accepted_document]) }
       end
     end
   end

--- a/spec/lib/hackney/cloud/storage_spec.rb
+++ b/spec/lib/hackney/cloud/storage_spec.rb
@@ -42,6 +42,7 @@ describe Hackney::Cloud::Storage, type: :model do
       it { expect(subject.number_of_pages).to eq(2) }
       it { expect(subject.page_number).to eq(1) }
       it { expect(subject.documents).to all(be_an(Hackney::Cloud::Document)) }
+      it { expect(subject.documents.size).to eq(3) }
     end
 
     context 'when payment_ref param is used' do

--- a/spec/lib/hackney/letter/all_documents_use_case_spec.rb
+++ b/spec/lib/hackney/letter/all_documents_use_case_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Hackney::Letter::AllDocumentsUseCase do
+    subject(:all_documents_use_case) { described_class.new(cloud_storage: storage) }
+
+    let(:cloud_adapter_fake) { double(:upload) }
+    let(:storage) { Hackney::Cloud::Storage.new(cloud_adapter_fake, Hackney::Cloud::Document) }
+
+    let(:username) { Faker::Name.name }
+
+    before do
+      create(:document, username: username, status: :received)
+      create(:document, username: username, status: :accepted)
+    end
+
+    it 'parses and populates metadata accordingly' do
+      documents = all_documents_use_case.execute.documents
+
+      documents.each do |document|
+        expect(document.metadata).to include(username)
+      end
+    end
+end

--- a/spec/lib/hackney/letter/all_documents_use_case_spec.rb
+++ b/spec/lib/hackney/letter/all_documents_use_case_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
 describe Hackney::Letter::AllDocumentsUseCase do
-    subject(:all_documents_use_case) { described_class.new(cloud_storage: storage) }
+  subject(:all_documents_use_case) { described_class.new(cloud_storage: storage) }
 
-    let(:cloud_adapter_fake) { double(:upload) }
-    let(:storage) { Hackney::Cloud::Storage.new(cloud_adapter_fake, Hackney::Cloud::Document) }
+  let(:cloud_adapter_fake) { double(:upload) }
+  let(:storage) { Hackney::Cloud::Storage.new(cloud_adapter_fake, Hackney::Cloud::Document) }
 
-    let(:username) { Faker::Name.name }
+  let(:username) { Faker::Name.name }
 
-    before do
-      create(:document, username: username, status: :received)
-      create(:document, username: username, status: :accepted)
+  before do
+    create(:document, username: username, status: :received)
+    create(:document, username: username, status: :accepted)
+  end
+
+  it 'parses and populates metadata accordingly' do
+    documents = all_documents_use_case.execute.documents
+
+    documents.each do |document|
+      expect(document.metadata).to include(username)
     end
-
-    it 'parses and populates metadata accordingly' do
-      documents = all_documents_use_case.execute.documents
-
-      documents.each do |document|
-        expect(document.metadata).to include(username)
-      end
-    end
+  end
 end

--- a/spec/requests/downloading_a_letter_pdf_spec.rb
+++ b/spec/requests/downloading_a_letter_pdf_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe 'Downloading a PDF', type: :request do
       it 'updates the status to downloaded' do
         get 'http://example.com/api/v1/documents'
         expect(response).to be_successful
-        response_payment_reference = JSON.parse(JSON.parse(response.body)[0]['metadata'])['payment_ref']
-        status = JSON.parse(response.body)[0]['status']
+        response_payment_reference = JSON.parse(JSON.parse(response.body)['documents'][0]['metadata'])['payment_ref']
+        status = JSON.parse(response.body)['documents'][0]['status']
         expect(response_payment_reference).to eq(payment_ref)
         expect(status).to eq('downloaded')
       end


### PR DESCRIPTION
Calling `GET  /api/v1/documents?payment_ref=876147&page_number=1&documents_per_page=1`
will now return: 
```json
{
  "documents": [{
    "id": 1,
    "uuid": "1eafd7b7-87fc-4a43-9fb2-37d3172f001a",
    "extension": ".pdf",
    "metadata": 
     "{\"username\":\"Valentine Schoen\",\"email\":\"gus@buckridge.io\",\"payment_ref\":\"876147\",\"template\":{\"path\":\"lib/hackney/pdf/templates/leasehold/letter_before_action.erb\",\"name\":\"Letter before action\",\"id\":\"letter_before_action\"}}",
    "filename": "1eafd7b7-87fc-4a43-9fb2-37d3172f001a.pdf",
    "url": "blah.com",
    "mime_type": "application/pdf",
    "status": "downloaded",
    "created_at": "2020-01-21T23:26:00.658Z",
    "updated_at": "2020-01-21T23:26:00.658Z",
    "ext_message_id": null,
    "username": "Valentine Schoen",
    "email": "gus@buckridge.io"
  }],
  "number_of_pages": 1,
  "page_number": 1
}
```
Params `payment_ref`, `page_number` and `documents_per_page` are optional 
