### PR TITLE
[MA-317] Refactor NOSP hash to object

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -4,7 +4,7 @@ class TenanciesController < ApplicationController
       tenancy_ref: params.fetch(:tenancy_ref)
     )
 
-    render json: @tenancy.as_json,
+    render json: @tenancy.as_json(methods: :nosp),
            status: @tenancy.nil? ? :not_found : :ok
   end
 

--- a/app/models/hackney/income/models/case_priority.rb
+++ b/app/models/hackney/income/models/case_priority.rb
@@ -30,6 +30,10 @@ module Hackney
           is_paused_until ? is_paused_until.future? : false
         end
 
+        def nosp
+          @nosp ||= Hackney::Domain::Nosp.new(served_date: nosp_served_date)
+        end
+
         def self.not_paused
           where('is_paused_until < ? OR is_paused_until is null', Date.today)
         end

--- a/lib/hackney/domain/nosp.rb
+++ b/lib/hackney/domain/nosp.rb
@@ -1,0 +1,52 @@
+module Hackney
+  module Domain
+    # What a NOSP is:
+    #
+    # Expires Date is when the NOSP can now be actioned upon.
+    #   The Tenant has 28 days to pay the arrears before Court action can take place.
+    #   This is the "cooling off period".
+    #
+    # Served - This is when there is a date from UH
+    # Cool off Period - This is the period from NOSP served to 28 days after
+    # Active - This when the Tenant can be taken to court if the arrears are "high" enough; after
+    #          the cooling off period.
+    # Valid - This is during the cooling off period and when the NOSP is "active".
+    class Nosp
+      attr_reader :served_date, :expires_date, :valid_until_date
+
+      def initialize(served_date:)
+        @served_date = served_date
+
+        calculate_properties
+      end
+
+      def served?
+        @served_date.present?
+      end
+
+      def active?
+        @active || false
+      end
+
+      def valid?
+        @valid || false
+      end
+
+      def in_cool_off_period?
+        @in_cool_off_period || false
+      end
+
+      private
+
+      def calculate_properties
+        return unless served?
+
+        @expires_date = @served_date + 28.days
+        @valid_until_date = @expires_date + 52.weeks
+        @in_cool_off_period = @expires_date > Time.zone.now
+        @valid = @valid_until_date > Time.zone.now
+        @active = @valid && @expires_date < Time.zone.now
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -116,7 +116,7 @@ module Hackney
         def send_sms?
           return false if @criteria.balance.blank?
           return false if @criteria.last_communication_action.present?
-          return false if @criteria.nosp_served?
+          return false if @criteria.nosp.served?
           return false if @criteria.active_agreement?
 
           @criteria.balance >= 5
@@ -126,7 +126,7 @@ module Hackney
           return false if @criteria.balance.blank?
           return false if @criteria.weekly_gross_rent.blank?
 
-          return false if @criteria.nosp_served?
+          return false if @criteria.nosp.served?
           return false if @criteria.active_agreement?
 
           return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&
@@ -140,7 +140,7 @@ module Hackney
           return false if @criteria.weekly_gross_rent.blank?
 
           return false if @criteria.active_agreement?
-          return false if @criteria.nosp_served?
+          return false if @criteria.nosp.served?
 
           return false unless @criteria.last_communication_action.in?(valid_actions_for_letter_two_to_progress)
 
@@ -156,9 +156,9 @@ module Hackney
 
           return false if @criteria.active_agreement?
 
-          return false if @criteria.nosp[:valid]
+          return false if @criteria.nosp.valid?
 
-          if @criteria.nosp[:served_date].blank?
+          unless @criteria.nosp.served?
             return false unless @criteria.last_communication_action.in?(valid_actions_for_nosp_to_progress)
             return false if last_communication_older_than?(3.months.ago)
             return false if last_communication_newer_than?(1.week.ago)
@@ -175,8 +175,8 @@ module Hackney
 
           return false if @criteria.last_communication_action.in?(after_court_warning_letter_actions)
 
-          return false unless @criteria.nosp[:valid]
-          return false unless @criteria.nosp[:active]
+          return false unless @criteria.nosp.valid?
+          return false unless @criteria.nosp.active?
 
           balance_is_in_arrears_by_number_of_weeks?(4)
         end
@@ -185,12 +185,12 @@ module Hackney
           return false if @criteria.balance.blank?
           return false if @criteria.weekly_gross_rent.blank?
 
-          return false unless @criteria.nosp_served?
+          return false unless @criteria.nosp.served?
 
           return false unless @criteria.last_communication_action.in?(valid_actions_for_apply_for_court_date_to_progress)
           return false if last_communication_newer_than?(2.weeks.ago)
 
-          return false unless @criteria.nosp[:active]
+          return false unless @criteria.nosp.active?
 
           return false if @criteria.courtdate.present? && @criteria.courtdate > @criteria.last_communication_date
 

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -38,12 +38,6 @@ module Hackney
           weekly_rent + weekly_service + weekly_other_charge
         end
 
-        def nosp_served_date
-          return nil if date_not_valid?(attributes[:nosp_served_date])
-
-          attributes[:nosp_served_date].to_date
-        end
-
         def universal_credit
           attributes[:universal_credit]
         end
@@ -58,10 +52,6 @@ module Hackney
 
         def uc_direct_payment_received
           attributes[:uc_direct_payment_received]
-        end
-
-        def nosp_expiry_date
-          nosp[:expires_date]
         end
 
         def courtdate
@@ -108,14 +98,6 @@ module Hackney
           attributes.fetch(:breached_agreements_count)
         end
 
-        def nosp_served?
-          nosp[:served_date].present?
-        end
-
-        def active_nosp?
-          nosp[:active]
-        end
-
         # FIXME: implementation needs confirming, will return to later
         def broken_court_order?
           false
@@ -148,34 +130,26 @@ module Hackney
           }
         end
 
+        def nosp_served_date
+          return nil if date_not_valid?(attributes[:nosp_served_date])
+
+          attributes[:nosp_served_date].to_date
+        end
+
+        def nosp_expiry_date
+          nosp.expires_date
+        end
+
+        def nosp_served?
+          nosp.served?
+        end
+
+        def active_nosp?
+          nosp.active?
+        end
+
         def nosp
-          expires_date = nil
-          valid_until_date = nil
-          active = false
-          in_cool_off_period = false
-          valid = false
-
-          if nosp_served_date.present?
-            # Expires Date is when the NOSP can now be actioned upon.
-            # The Tenant has 28 days to pay the arrears before Court action can take place.
-            # This is the "cooling off period".
-            # Active - This when the Tenant can be taken to court if the arrears are "high" enough.
-            # Valid - This is during the cooling off period and when the NOSP is "active".
-            expires_date = nosp_served_date + 28.days
-            valid_until_date = expires_date + 52.weeks
-            active = expires_date < Time.zone.now
-            in_cool_off_period = expires_date > Time.zone.now
-            valid = valid_until_date > Time.zone.now
-          end
-
-          {
-            served_date: nosp_served_date,
-            expires_date: expires_date,
-            valid_until_date: valid_until_date,
-            active: valid && active,
-            in_cool_off_period: in_cool_off_period,
-            valid: valid
-          }
+          @nosp ||= Hackney::Domain::Nosp.new(served_date: nosp_served_date)
         end
 
         def self.format_action_codes_for_sql

--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -7,8 +7,7 @@ module Hackney
             build_sql,
             tenancy_ref,
             Hackney::Income::ACTIVE_ARREARS_AGREEMENT_STATUS,
-            Hackney::Income::BREACHED_ARREARS_AGREEMENT_STATUS,
-            Hackney::Income::NOSP_ACTION_DIARY_CODE
+            Hackney::Income::BREACHED_ARREARS_AGREEMENT_STATUS
           ]
 
           new(tenancy_ref, attributes.first.symbolize_keys)
@@ -207,7 +206,6 @@ module Hackney
             DECLARE @TenancyRef VARCHAR(60) = ?
             DECLARE @ActiveArrearsAgreementStatus VARCHAR(60) = ?
             DECLARE @BreachedArrearsAgreementStatus VARCHAR(60) = ?
-            DECLARE @NospActionDiaryCode VARCHAR(60) = ?
             DECLARE @PaymentTypes table(payment_type varchar(3))
             INSERT INTO @PaymentTypes VALUES ('RBA'), ('RBP'), ('RBR'), ('RCI'), ('RCO'), ('RCP'), ('RDD'), ('RDN'), ('RDP'), ('RDR'), ('RDS'), ('RDT'), ('REF'), ('RHA'), ('RHB'), ('RIT'), ('RML'), ('RPD'), ('RPO'), ('RPY'), ('RQP'), ('RRC'), ('RRP'), ('RSO'), ('RTM'), ('RUC'), ('RWA')
             DECLARE @CommunicationTypes table(communication_types varchar(60))
@@ -231,9 +229,6 @@ module Hackney
             )
             DECLARE @NospServedDate SMALLDATETIME = (
               SELECT u_notice_served FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
-            )
-            DECLARE @NospExpiryDate SMALLDATETIME = (
-              SELECT u_notice_expiry FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
             )
             DECLARE @Courtdate SMALLDATETIME = (
               SELECT courtdate FROM [dbo].[tenagree] WHERE tag_ref = @TenancyRef
@@ -268,8 +263,6 @@ module Hackney
             DECLARE @RemainingTransactions INT = (SELECT COUNT(tag_ref) FROM [dbo].[rtrans] WITH (NOLOCK) WHERE tag_ref = @TenancyRef)
             DECLARE @ActiveAgreementsCount INT = (SELECT COUNT(tag_ref) FROM [dbo].[arag] WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND arag_status = @ActiveArrearsAgreementStatus)
             DECLARE @BreachedAgreementsCount INT = (SELECT COUNT(tag_ref) FROM [dbo].[arag] WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND arag_status = @BreachedArrearsAgreementStatus)
-            DECLARE @NospsInLastYear INT = (SELECT COUNT(tag_ref) FROM araction WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND action_code = @NospActionDiaryCode AND action_date >= CONVERT(date, DATEADD(year, -1, GETDATE())))
-            DECLARE @NospsInLastMonth INT = (SELECT COUNT(tag_ref) FROM araction WITH (NOLOCK) WHERE tag_ref = @TenancyRef AND action_code = @NospActionDiaryCode AND action_date >= CONVERT(date, DATEADD(month, -1, GETDATE())))
 
             DECLARE @LastCommunicationAction VARCHAR(60) = (
               #{build_last_communication_sql_query(column: 'action_code')}
@@ -361,10 +354,7 @@ module Hackney
               @ArrearsStartDate as arrears_start_date,
               @ActiveAgreementsCount as active_agreements_count,
               @BreachedAgreementsCount as breached_agreements_count,
-              @NospsInLastYear as nosps_in_last_year,
-              @NospsInLastMonth as nosps_in_last_month,
               @NospServedDate as nosp_served_date,
-              @NospExpiryDate as nosp_expiry_date,
               @Courtdate as courtdate,
               @CourtOutcome as court_outcome,
               @LatestActiveAgreementDate as latest_active_agreement_date,

--- a/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria_spec.rb
@@ -711,15 +711,20 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
       context 'when there is no NOSP served date' do
         let(:nosp_notice_served_date) { nil }
 
-        it 'contains sensible defaults' do
-          expect(criteria.nosp).to eq(
-            served_date: nil,
-            expires_date: nil,
-            valid_until_date: nil,
-            active: false,
-            in_cool_off_period: false,
-            valid: false
-          )
+        it 'is not cooling off' do
+          expect(criteria.nosp.in_cool_off_period?).to eq(false)
+        end
+
+        it 'is not valid' do
+          expect(criteria.nosp.valid?).to eq(false)
+        end
+
+        it 'is not active' do
+          expect(criteria.nosp.active?).to eq(false)
+        end
+
+        it 'has not been served' do
+          expect(criteria.nosp.served?).to eq(false)
         end
       end
 
@@ -727,45 +732,60 @@ describe Hackney::Income::TenancyPrioritiser::UniversalHousingCriteria, universa
         context 'with a served date that is in cooling off' do
           let(:nosp_notice_served_date) { 27.days.ago }
 
-          it 'has correct values' do
-            expect(criteria.nosp).to eq(
-              served_date: nosp_notice_served_date.to_date,
-              expires_date: 1.day.from_now.to_date,
-              valid_until_date: (1.day.from_now + 52.weeks).to_date,
-              active: false,
-              in_cool_off_period: true,
-              valid: true
-            )
+          it 'is cooling off' do
+            expect(criteria.nosp.in_cool_off_period?).to eq(true)
+          end
+
+          it 'is valid' do
+            expect(criteria.nosp.valid?).to eq(true)
+          end
+
+          it 'is not active' do
+            expect(criteria.nosp.active?).to eq(false)
+          end
+
+          it 'has been served' do
+            expect(criteria.nosp.served?).to eq(true)
           end
         end
 
         context 'with a served date that is over 28 days ago' do
           let(:nosp_notice_served_date) { 29.days.ago }
 
-          it 'has correct values' do
-            expect(criteria.nosp).to eq(
-              served_date: nosp_notice_served_date.to_date,
-              expires_date: 1.day.ago.to_date,
-              valid_until_date: (1.day.ago + 52.weeks).to_date,
-              active: true,
-              in_cool_off_period: false,
-              valid: true
-            )
+          it 'is not cooling off' do
+            expect(criteria.nosp.in_cool_off_period?).to eq(false)
+          end
+
+          it 'is valid' do
+            expect(criteria.nosp.valid?).to eq(true)
+          end
+
+          it 'is active' do
+            expect(criteria.nosp.active?).to eq(true)
+          end
+
+          it 'has been served' do
+            expect(criteria.nosp.served?).to eq(true)
           end
         end
 
         context 'with a served date that is over 13 months ago' do
           let(:nosp_notice_served_date) { 57.weeks.ago }
 
-          it 'has correct values' do
-            expect(criteria.nosp).to eq(
-              served_date: nosp_notice_served_date.to_date,
-              expires_date: 53.weeks.ago.to_date,
-              valid_until_date: 1.week.ago.to_date,
-              active: false,
-              in_cool_off_period: false,
-              valid: false
-            )
+          it 'is not cooling off' do
+            expect(criteria.nosp.in_cool_off_period?).to eq(false)
+          end
+
+          it 'is not valid' do
+            expect(criteria.nosp.valid?).to eq(false)
+          end
+
+          it 'is not active' do
+            expect(criteria.nosp.active?).to eq(false)
+          end
+
+          it 'has been served' do
+            expect(criteria.nosp.served?).to eq(true)
           end
         end
       end

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -68,14 +68,6 @@ module Stubs
       weekly_rent.to_i + weekly_service.to_i + weekly_other_charge.to_i
     end
 
-    def nosp_served_date
-      attributes[:nosp_served_date]
-    end
-
-    def nosp_expiry_date
-      nosp[:expires_date]
-    end
-
     def courtdate
       attributes[:courtdate]
     end
@@ -100,37 +92,24 @@ module Stubs
       attributes[:most_recent_agreement] || attributes[:active_agreement]
     end
 
-    def nosp_served?
-      nosp[:served_date].present?
+    def nosp
+      @nosp ||= Hackney::Domain::Nosp.new(served_date: nosp_served_date)
     end
 
-    def nosp
-      expires_date = nil
-      valid_until_date = nil
-      active = false
-      in_cool_off_period = false
-      valid = false
+    def nosp_served_date
+      attributes[:nosp_served_date]
+    end
 
-      if nosp_served_date.present?
-        expires_date = nosp_served_date + 28.days
-        valid_until_date = expires_date + 52.weeks
-        active = expires_date < Time.zone.now
-        in_cool_off_period = expires_date > Time.zone.now
-        valid = valid_until_date > Time.zone.now
-      end
-
-      {
-        served_date: nosp_served_date,
-        expires_date: expires_date,
-        valid_until_date: valid_until_date,
-        active: valid && active,
-        in_cool_off_period: in_cool_off_period,
-        valid: valid
-      }
+    def nosp_served?
+      nosp.served?
     end
 
     def active_nosp?
-      nosp[:active]
+      nosp.active?
+    end
+
+    def nosp_expiry_date
+      nosp.expires_date
     end
 
     def number_of_broken_agreements


### PR DESCRIPTION
### Why

We have some complex logic so lets move it to be a Domain object that is easier to understand

### What

Create a domain object and reuse it where we care about NOSPs

### Future work

Once the Front End is updated to work with this new Object we should remove the fields we no longer care about on the Case Priority
- `nosp_expires_date`
- `active_nosp?`
- `nosp_served`

