### PR TITLE
Refactor Criteria SQL statement

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -4,8 +4,13 @@ class TenanciesController < ApplicationController
       tenancy_ref: params.fetch(:tenancy_ref)
     )
 
-    render json: @tenancy.as_json(methods: :nosp),
-           status: @tenancy.nil? ? :not_found : :ok
+    render json: @tenancy.as_json(
+      methods: :nosp,
+      except: %i[
+        days_in_arrears number_of_broken_agreements nosp_expiry_date latest_active_agreement_date
+        breach_agreement_date expected_balance
+      ]
+    ), status: @tenancy.nil? ? :not_found : :ok
   end
 
   def update

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -17,17 +17,14 @@ module Hackney
 
         begin
           gateway_model_instance.tap do |tenancy|
-            tenancy.update(
+            tenancy.assign_attributes(
               balance: criteria.balance,
               weekly_rent: criteria.weekly_rent,
-              days_in_arrears: criteria.days_in_arrears,
               days_since_last_payment: criteria.days_since_last_payment,
-              number_of_broken_agreements: criteria.number_of_broken_agreements,
               active_agreement: criteria.active_agreement?,
               broken_court_order: criteria.broken_court_order?,
               nosp_served: criteria.nosp_served?,
               nosp_served_date: criteria.nosp_served_date,
-              nosp_expiry_date: criteria.nosp_expiry_date,
               last_communication_action: criteria.last_communication_action,
               last_communication_date: criteria.last_communication_date,
               active_nosp: criteria.active_nosp?,
@@ -40,11 +37,10 @@ module Hackney
               uc_rent_verification: criteria. uc_rent_verification,
               uc_direct_payment_requested: criteria.uc_direct_payment_requested,
               uc_direct_payment_received: criteria.uc_direct_payment_received,
-              latest_active_agreement_date: criteria.latest_active_agreement_date,
-              breach_agreement_date: criteria.breach_agreement_date,
-              expected_balance: criteria.expected_balance,
               payment_ref: criteria.payment_ref
             )
+
+            tenancy.save! if tenancy.changed?
           end
         rescue ActiveRecord::RecordNotUnique
           Rails.logger.error("A Tenancy with tenancy_ref: '#{tenancy_ref}' was inserted during find_or_create_by create operation, retrying...")
@@ -112,7 +108,6 @@ module Hackney
       def build_tenancy_list_item(model)
         {
           tenancy_ref: model.tenancy_ref,
-
           balance: model.balance,
           days_in_arrears: model.days_in_arrears,
           days_since_last_payment: model.days_since_last_payment,

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -65,25 +65,19 @@ describe TenanciesController, type: :controller do
           active_nosp: nil,
           assigned_user_id: nil,
           balance: tenancy_1.balance.to_s,
-          breach_agreement_date: nil,
           broken_court_order: nil,
           case_id: 1,
           classification: nil,
           court_outcome: nil,
           courtdate: nil,
-          days_in_arrears: tenancy_1.days_in_arrears,
           days_since_last_payment: nil,
           eviction_date: nil,
-          expected_balance: nil,
           is_paused_until: nil,
           last_communication_action: nil,
           last_communication_date: nil,
-          latest_active_agreement_date: nil,
           nosp: { served_date: nil },
-          nosp_expiry_date: nil,
           nosp_served: nil,
           nosp_served_date: nil,
-          number_of_broken_agreements: nil,
           patch_code: nil,
           pause_comment: nil,
           pause_reason: nil,
@@ -129,7 +123,6 @@ describe TenanciesController, type: :controller do
             nosp_served_date: nosp_served_date.iso8601(3),
             # The follwoing attributes are stored on the Case Pirority Model
             active_nosp: nil,
-            nosp_expiry_date: nil,
             nosp_served: nil
           )
         )

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -56,9 +56,7 @@ describe Hackney::Income::StoredTenanciesGateway do
 
           balance: attributes.fetch(:criteria).balance,
           weekly_rent: attributes.fetch(:criteria).weekly_rent,
-          days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
           days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-          number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
           active_agreement: attributes.fetch(:criteria).active_agreement?,
           broken_court_order: attributes.fetch(:criteria).broken_court_order?,
           nosp_served: attributes.fetch(:criteria).nosp_served?,
@@ -71,10 +69,7 @@ describe Hackney::Income::StoredTenanciesGateway do
           uc_rent_verification: attributes.fetch(:criteria).uc_rent_verification,
           uc_direct_payment_requested: attributes.fetch(:criteria).uc_direct_payment_requested,
           uc_direct_payment_received: attributes.fetch(:criteria).uc_direct_payment_received,
-          classification: classification,
-          latest_active_agreement_date: attributes.fetch(:criteria).latest_active_agreement_date,
-          breach_agreement_date: attributes.fetch(:criteria).latest_active_agreement_date,
-          expected_balance: attributes.fetch(:criteria).expected_balance
+          classification: classification
         )
       end
 
@@ -582,11 +577,8 @@ describe Hackney::Income::StoredTenanciesGateway do
   def expected_serialised_tenancy(attributes)
     {
       tenancy_ref: attributes.fetch(:tenancy_ref),
-
       balance: attributes.fetch(:criteria).balance,
-      days_in_arrears: attributes.fetch(:criteria).days_in_arrears,
       days_since_last_payment: attributes.fetch(:criteria).days_since_last_payment,
-      number_of_broken_agreements: attributes.fetch(:criteria).number_of_broken_agreements,
       active_agreement: attributes.fetch(:criteria).active_agreement?,
       broken_court_order: attributes.fetch(:criteria).broken_court_order?,
       nosp_served: attributes.fetch(:criteria).nosp_served?,
@@ -599,10 +591,7 @@ describe Hackney::Income::StoredTenanciesGateway do
       uc_rent_verification: attributes.fetch(:criteria).uc_rent_verification,
       uc_direct_payment_requested: attributes.fetch(:criteria).uc_direct_payment_requested,
       uc_direct_payment_received: attributes.fetch(:criteria).uc_direct_payment_received,
-      classification: classification,
-      latest_active_agreement_date: attributes.fetch(:criteria).latest_active_agreement_date,
-      breach_agreement_date: attributes.fetch(:criteria).breach_agreement_date,
-      expected_balance: attributes.fetch(:criteria).expected_balance
+      classification: classification
     }
   end
 end

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -36,20 +36,8 @@ module Stubs
       attributes[:court_outcome]
     end
 
-    def latest_active_agreement_date
-      attributes[:latest_active_agreement_date]
-    end
-
-    def breach_agreement_date
-      attributes[:breach_agreement_date]
-    end
-
     def balance
       attributes[:balance]
-    end
-
-    def expected_balance
-      attributes[:expected_balance] || 100.00
     end
 
     def weekly_rent
@@ -84,10 +72,6 @@ module Stubs
       attributes[:broken_court_order]
     end
 
-    def days_in_arrears
-      attributes[:days_in_arrears] || 7
-    end
-
     def active_agreement?
       attributes[:most_recent_agreement] || attributes[:active_agreement]
     end
@@ -110,10 +94,6 @@ module Stubs
 
     def nosp_expiry_date
       nosp.expires_date
-    end
-
-    def number_of_broken_agreements
-      attributes[:number_of_broken_agreements] || 0
     end
 
     def payment_ref


### PR DESCRIPTION
- Only do one query to the `tenagree` table
- Rip out more attributes we do not use
- Uses `LEFT OUTER JOIN` as the `tenagree` might not always have a `property` (rare but lets keep the same behaviour as before)

Note: I have not removed the columns as I'm not 100% I can delete them. Due to not having good development data. We can deploy this to staging, see how it goes then add a migration to remove columns.