### PR TITLE
exclude downloaded documents from requesting govnotify letter statuses

### DIFF
--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -58,7 +58,7 @@ module Hackney
 
       def documents_to_update_status(time:)
         document_model.where('updated_at >= ?', time).exclude_uploaded
-                      .where.not(status: %i[nil validation-failed received])
+                      .where.not(status: %i[nil validation-failed received downloaded])
       end
 
       def upload(bucket_name, content, filename)

--- a/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
+++ b/spec/lib/hackney/notification/enqueue_request_all_precompiled_letter_states_spec.rb
@@ -59,7 +59,7 @@ describe Hackney::Notification::EnqueueRequestAllPrecompiledLetterStates do
       it { expect(subject.documents).to include(accepted) }
       it { expect(subject.documents).not_to include(received) }
       it { expect(subject.documents).not_to include(failed) }
-      it { expect(subject.documents).to include(downloaded) }
+      it { expect(subject.documents).not_to include(downloaded) }
       it { expect(subject.documents).to include(queued) }
 
       it 'all statuses should be checked' do


### PR DESCRIPTION
`Downloaded` letters don't get sent to gov, so fetching the gov notify state raises an exception. 

https://sentry.io/organizations/london-borough-of-hackney/issues/1451931946/?project=1276456&query=is%3Aunresolved