### PR TITLE
[MA-320] Only sync the patches we care about 

### DIFF
--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -16,6 +16,7 @@ module Hackney
           if @restrict_patches
             query = query.left_join(:property, prop_ref: :prop_ref)
                          .where(Sequel[:property][:arr_patch] => @permitted_patches)
+                         .or(Sequel[:property][:arr_patch] => nil)
           end
 
           query

--- a/lib/hackney/income/universal_housing_tenancies_gateway.rb
+++ b/lib/hackney/income/universal_housing_tenancies_gateway.rb
@@ -1,12 +1,24 @@
 module Hackney
   module Income
     class UniversalHousingTenanciesGateway
+      def initialize(restrict_patches: false, patches: [])
+        @restrict_patches = restrict_patches
+        @permitted_patches = patches
+      end
+
       def tenancies_in_arrears
         Hackney::UniversalHousing::Client.with_connection do |database|
           database.extension :identifier_mangling
           database.identifier_input_method = database.identifier_output_method = nil
 
-          database[:tenagree]
+          query = database[:tenagree]
+
+          if @restrict_patches
+            query = query.left_join(:property, prop_ref: :prop_ref)
+                         .where(Sequel[:property][:arr_patch] => @permitted_patches)
+          end
+
+          query
             .select(:tag_ref)
             .where { cur_bal > 0 }
             .where(tenure: SECURE_TENURE_TYPE)

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -179,7 +179,10 @@ module Hackney
       end
 
       def uh_tenancies_gateway
-        Hackney::Income::UniversalHousingTenanciesGateway.new
+        Hackney::Income::UniversalHousingTenanciesGateway.new(
+          restrict_patches: ENV.fetch('RESTRICT_PATCHES', false),
+          patches: ENV.fetch('PERMITTED_PATCHES', '').split(',')
+        )
       end
 
       private

--- a/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
@@ -121,7 +121,7 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
           end
         end
 
-        context 'when a tenancy is does not have a patch and when one has an accepted patch' do
+        context 'when a tenancy either has no patch or has an accepted patch' do
           before do
             create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, prop_ref: 'PROP1')
             create_uh_property(property_ref: 'PROP1', patch_code: 'Z01')
@@ -135,7 +135,7 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
         end
       end
 
-      context 'without a list of acceptable patches given' do
+      context 'without being given a list of acceptable patches' do
         let(:gateway) { described_class.new(restrict_patches: true) }
 
         before do

--- a/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
@@ -94,5 +94,46 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
         expect(subject).to eq([])
       end
     end
+
+    context 'when patches are restricted' do
+      context 'when a list of acceptable patches is given' do
+        let(:gateway) { described_class.new(restrict_patches: true, patches: %w[X01 Y01 Z01]) }
+
+        context 'when a tenancy is not in an accepted patch' do
+          before do
+            create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, prop_ref: 'PROP1')
+            create_uh_property(property_ref: 'PROP1', patch_code: 'B01')
+          end
+
+          it 'does not return the tenancy' do
+            expect(subject).to be_empty
+          end
+        end
+
+        context 'when a tenancy is in one of the accepted patches' do
+          before do
+            create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, prop_ref: 'PROP1')
+            create_uh_property(property_ref: 'PROP1', patch_code: 'Z01')
+          end
+
+          it 'includes the tenancy' do
+            expect(subject).to eq(%w[00001/01])
+          end
+        end
+      end
+
+      context 'without a list of acceptable patches given' do
+        let(:gateway) { described_class.new(restrict_patches: true) }
+
+        before do
+          create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, prop_ref: 'PROP1')
+          create_uh_property(property_ref: 'PROP1', patch_code: 'B01')
+        end
+
+        it 'returns no tenancies' do
+          expect(subject).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_tenancies_gateway_spec.rb
@@ -120,6 +120,19 @@ describe Hackney::Income::UniversalHousingTenanciesGateway, universal: true do
             expect(subject).to eq(%w[00001/01])
           end
         end
+
+        context 'when a tenancy is does not have a patch and when one has an accepted patch' do
+          before do
+            create_uh_tenancy_agreement(tenancy_ref: '00001/01', current_balance: 10.0, prop_ref: 'PROP1')
+            create_uh_property(property_ref: 'PROP1', patch_code: 'Z01')
+            create_uh_tenancy_agreement(tenancy_ref: '00002/01', current_balance: 10.0, prop_ref: 'PROP2')
+            create_uh_property(property_ref: 'PROP2', patch_code: nil)
+          end
+
+          it 'includes the tenancy' do
+            expect(subject).to eq(%w[00001/01 00002/01])
+          end
+        end
       end
 
       context 'without a list of acceptable patches given' do


### PR DESCRIPTION
There are some Tenancies with Patches like `WIC` that we do not care about so we should not sync them.