### PR TITLE
Increase Timeout as we have seen long time deploys on AWS's end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: Force new application deployment
           command: ecs-deploy --region $AWS_REGION --cluster $ECS_PRODUCTION_CLUSTER --service-name $ECS_PRODUCTION_APP_NAME --image $ECR_IMAGE_URL:production --timeout $ECS_DEPLOY_TIMEOUT --use-latest-task-def
-          no_output_timeout: 20m
+          no_output_timeout: 50m
 
 workflows:
   version: 2


### PR DESCRIPTION
So looking at the latest Prod deploy, here are our times for each EC2 instance being created/started:

Box 1:
```
Created at 2020-01-23 18:10:00 +0000
Started at 2020-01-23 18:10:32 +0000
```

Box 2: 
```
Created at 2020-01-23 18:39:18 +0000
Started at 2020-01-23 18:39:50 +0000
```

Box 3:
```
Created at 2020-01-23 18:48:58 +0000
Started at 2020-01-23 18:49:11 +0000
```

Using these times I've increased the timeout from Circle CI to be 50min. Not sure why the ECS is taking that long to deploy though.