### PR TITLE
Ensure Sync is run at a sensible time

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
+++ b/lib/hackney/income/tenancy_prioritiser/universal_housing_criteria.rb
@@ -179,41 +179,41 @@ module Hackney
 
             DECLARE @UniversalCredit SMALLDATETIME = (
               SELECT TOP 1 action_date
-              FROM araction
+              FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               AND action_code = 'UCC'
               ORDER BY action_date DESC
             )
             DECLARE @UCVerificationComplete SMALLDATETIME = (
               SELECT TOP 1 action_date
-              FROM araction
+              FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               AND action_code = 'UC1'
               ORDER BY action_date DESC
             )
             DECLARE @UCDirectPaymentRequested SMALLDATETIME = (
               SELECT TOP 1 action_date
-              FROM araction
+              FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               AND action_code = 'UC2'
               ORDER BY action_date DESC
             )
             DECLARE @UCDirectPaymentReceived SMALLDATETIME = (
               SELECT TOP 1 action_date
-              FROM araction
+              FROM araction WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               AND action_code = 'UC3'
               ORDER BY action_date DESC
             )
             DECLARE @MostRecentAgreementDate SMALLDATETIME = (
               SELECT TOP 1 arag_startdate
-              FROM [dbo].[arag]
+              FROM [dbo].[arag] WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               ORDER BY arag_startdate DESC
             )
             DECLARE @MostRecentAgreementStatus CHAR(10) = (
               SELECT TOP 1 arag_status
-              FROM [dbo].[arag]
+              FROM [dbo].[arag] WITH (NOLOCK)
               WHERE tag_ref = @TenancyRef
               ORDER BY arag_startdate DESC
             )
@@ -238,8 +238,8 @@ module Hackney
               @UCDirectPaymentReceived as uc_direct_payment_received,
               @MostRecentAgreementDate as most_recent_agreement_date,
               @MostRecentAgreementStatus as most_recent_agreement_status
-            FROM [dbo].[tenagree]
-            LEFT OUTER JOIN [dbo].[property] ON [dbo].[property].prop_ref = [dbo].[tenagree].prop_ref
+            FROM [dbo].[tenagree] WITH (NOLOCK)
+            LEFT OUTER JOIN [dbo].[property] WITH (NOLOCK) ON [dbo].[property].prop_ref = [dbo].[tenagree].prop_ref
             WHERE tag_ref = @TenancyRef
           SQL
         end

--- a/schedule.yml
+++ b/schedule.yml
@@ -5,9 +5,12 @@
     every: 55s
     class: HelloHealthcheck
 
+  # We need to run the sync after the Data Warehouse is refreshed. That task starts at 9pm and takes
+  # around 9 hours to complete. However, the first couple of hours is where the data we care about
+  # is imported and then reports are the remaing time.
   tenancy_sync:
     class: TenancySync
-    cron: '0 30 20 * * *' # 8:30pm everyday
+    cron: '0 0 2 * * *' # 2am everyday
 
   request_all_precompiled_letter_states:
     class: RequestAllPrecompiledLetterStates


### PR DESCRIPTION
Sensible Time: 
- When the data import into the warehouse is finished + buffer time
- Gives us buffer time for more cases to use sync'd across (~6500 takes about 15min)

Also, ensured we are not Locking tables during the sync as this is a request from Hackney Support