### PR TITLE
[MA-324] Be more clever with calculating grace amount

### DIFF
--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -222,10 +222,10 @@ module Hackney
         end
 
         def balance_with_1_week_grace
-          @criteria.balance - calculate_grace_amount
+          @criteria.balance - calculated_grace_amount
         end
 
-        def calculate_grace_amount
+        def calculated_grace_amount
           grace_amount = @criteria.weekly_gross_rent + @criteria.total_payment_amount_in_week
 
           return 0 if grace_amount.negative?

--- a/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
+++ b/lib/hackney/income/tenancy_prioritiser/tenancy_classification.rb
@@ -222,7 +222,15 @@ module Hackney
         end
 
         def balance_with_1_week_grace
-          @criteria.balance - @criteria.weekly_gross_rent
+          @criteria.balance - calculate_grace_amount
+        end
+
+        def calculate_grace_amount
+          grace_amount = @criteria.weekly_gross_rent + @criteria.total_payment_amount_in_week
+
+          return 0 if grace_amount.negative?
+
+          grace_amount
         end
 
         def arrear_accumulation_by_number_weeks(weeks)

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_one_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_one_spec.rb
@@ -8,6 +8,7 @@ describe 'Send Letter One Rule', type: :feature do
       nosp_served_date: nil,
       weekly_rent: 10,
       balance: 20.0,
+      total_payment_amount_in_week: 0,
       is_paused_until: '',
       active_agreement: false,
       last_communication_date: 2.weeks.ago.to_date,
@@ -34,6 +35,7 @@ describe 'Send Letter One Rule', type: :feature do
       nosp_served_date: nil,
       weekly_rent: 5,
       balance: 0.0,
+      total_payment_amount_in_week: -5,
       is_paused_until: '',
       active_agreement: false,
       last_communication_date: nil,
@@ -194,6 +196,76 @@ describe 'Send Letter One Rule', type: :feature do
       eviction_date: '',
       courtdate: 1.year.ago,
       court_outcome: 'SOMETHING'
+    },
+    # partial payment in week; arrears not high enough
+    {
+      outcome: :no_action,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 4.0,
+      total_payment_amount_in_week: -6,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: '',
+      eviction_date: '',
+      courtdate: nil
+    },
+    # partial payment in week + missed one week of rent
+    {
+      outcome: :send_letter_one,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 14.0,
+      total_payment_amount_in_week: -6,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: '',
+      eviction_date: '',
+      courtdate: nil
+    },
+    # full payment in week
+    {
+      outcome: :send_letter_one,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 10.0,
+      total_payment_amount_in_week: -10,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: '',
+      eviction_date: '',
+      courtdate: nil
+    },
+    # full payment in week but Arrears over 10
+    {
+      outcome: :send_letter_one,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 20.0,
+      total_payment_amount_in_week: -10,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: '',
+      eviction_date: '',
+      courtdate: nil
+    },
+    # over payment in week but Arrears over 10
+    {
+      outcome: :send_letter_one,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 20.0,
+      total_payment_amount_in_week: -20,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: '',
+      eviction_date: '',
+      courtdate: nil
     }
   ]
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/classifications/send_letter_two_spec.rb
@@ -9,6 +9,7 @@ describe 'Send Letter Two Rule', type: :feature do
       nosp_served_date: nil,
       weekly_rent: 5,
       balance: 20,
+      total_payment_amount_in_week: 0,
       is_paused_until: '',
       active_agreement: false,
       last_communication_date: 14.days.ago.to_date,
@@ -140,6 +141,76 @@ describe 'Send Letter Two Rule', type: :feature do
       eviction_date: '',
       courtdate: 1.year.ago,
       court_outcome: 'SOMETHING'
+    },
+    # partial payment in week; arrears not high enough
+    {
+      outcome: :no_action,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 4.0,
+      total_payment_amount_in_week: -6,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 14.days.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      eviction_date: '',
+      courtdate: nil
+    },
+    # partial payment in week + missed one week of rent
+    {
+      outcome: :send_letter_two,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 14.0,
+      total_payment_amount_in_week: -6,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 14.days.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      eviction_date: '',
+      courtdate: nil
+    },
+    # full payment in week
+    {
+      outcome: :send_letter_two,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 10.0,
+      total_payment_amount_in_week: -10,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 14.days.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      eviction_date: '',
+      courtdate: nil
+    },
+    # full payment in week but Arrears over 10
+    {
+      outcome: :send_letter_two,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 20.0,
+      total_payment_amount_in_week: -10,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 14.days.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      eviction_date: '',
+      courtdate: nil
+    },
+    # over payment in week but Arrears over 10
+    {
+      outcome: :send_letter_two,
+      nosp_served_date: nil,
+      weekly_rent: 10,
+      balance: 20.0,
+      total_payment_amount_in_week: -20,
+      is_paused_until: '',
+      active_agreement: false,
+      last_communication_date: 14.days.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      eviction_date: '',
+      courtdate: nil
     }
   ]
 

--- a/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
@@ -165,23 +165,23 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
     end
   end
 
-  describe '#calculate_grace_amount' do
+  describe '#calculated_grace_amount' do
     it 'uses #weekly_gross_rent' do
       expect(criteria).to receive(:weekly_gross_rent).and_return(0)
 
-      assign_classification.send(:calculate_grace_amount)
+      assign_classification.send(:calculated_grace_amount)
     end
 
     it 'uses #total_payment_amount_in_week' do
       expect(criteria).to receive(:total_payment_amount_in_week).and_return(0)
 
-      assign_classification.send(:calculate_grace_amount)
+      assign_classification.send(:calculated_grace_amount)
     end
 
     context 'when there is no payment in the week' do
       it 'returns the total weekly gross rent' do
-        calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
-        expect(calculate_grace_amount).to eq(weekly_rent)
+        calculated_grace_amount = assign_classification.send(:calculated_grace_amount)
+        expect(calculated_grace_amount).to eq(weekly_rent)
       end
     end
 
@@ -190,8 +190,8 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
         let(:total_payment_amount_in_week) { -2 }
 
         it 'returns not the total weekly rent' do
-          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
-          expect(calculate_grace_amount).to eq(weekly_rent + total_payment_amount_in_week)
+          calculated_grace_amount = assign_classification.send(:calculated_grace_amount)
+          expect(calculated_grace_amount).to eq(weekly_rent + total_payment_amount_in_week)
         end
       end
 
@@ -199,8 +199,8 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
         let(:total_payment_amount_in_week) { -5 }
 
         it 'returns not the total weekly rent' do
-          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
-          expect(calculate_grace_amount).to eq(0)
+          calculated_grace_amount = assign_classification.send(:calculated_grace_amount)
+          expect(calculated_grace_amount).to eq(0)
         end
       end
 
@@ -208,8 +208,8 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
         let(:total_payment_amount_in_week) { -10 }
 
         it 'returns not the total weekly rent' do
-          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
-          expect(calculate_grace_amount).to eq(0)
+          calculated_grace_amount = assign_classification.send(:calculated_grace_amount)
+          expect(calculated_grace_amount).to eq(0)
         end
       end
     end

--- a/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
+++ b/spec/lib/hackney/income/tenancy_prioritiser/tenancy_classification_spec.rb
@@ -15,7 +15,8 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
       last_communication_date: last_communication_date,
       last_communication_action: last_communication_action,
       eviction_date: eviction_date,
-      payment_ref: Faker::Number.number(10)
+      payment_ref: Faker::Number.number(10),
+      total_payment_amount_in_week: total_payment_amount_in_week
     }
   end
 
@@ -27,6 +28,7 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
   let(:last_communication_date) { 8.days.ago.to_date }
   let(:last_communication_action) { nil }
   let(:eviction_date) { 6.days.ago.to_date }
+  let(:total_payment_amount_in_week) { 0 }
 
   context 'when there are no arrears' do
     context 'with difference balances' do
@@ -159,6 +161,56 @@ describe Hackney::Income::TenancyPrioritiser::TenancyClassification do
 
       it 'contains action codes within the UH Criteria Codes' do
         expect(unused_action_codes_required_for_uh_criteria_sql).to be_empty
+      end
+    end
+  end
+
+  describe '#calculate_grace_amount' do
+    it 'uses #weekly_gross_rent' do
+      expect(criteria).to receive(:weekly_gross_rent).and_return(0)
+
+      assign_classification.send(:calculate_grace_amount)
+    end
+
+    it 'uses #total_payment_amount_in_week' do
+      expect(criteria).to receive(:total_payment_amount_in_week).and_return(0)
+
+      assign_classification.send(:calculate_grace_amount)
+    end
+
+    context 'when there is no payment in the week' do
+      it 'returns the total weekly gross rent' do
+        calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
+        expect(calculate_grace_amount).to eq(weekly_rent)
+      end
+    end
+
+    context 'when there is a payment in the week' do
+      context 'with the total payment amount not being above the weekly rent' do
+        let(:total_payment_amount_in_week) { -2 }
+
+        it 'returns not the total weekly rent' do
+          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
+          expect(calculate_grace_amount).to eq(weekly_rent + total_payment_amount_in_week)
+        end
+      end
+
+      context 'with the total payment amount equals the weekly rent' do
+        let(:total_payment_amount_in_week) { -5 }
+
+        it 'returns not the total weekly rent' do
+          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
+          expect(calculate_grace_amount).to eq(0)
+        end
+      end
+
+      context 'with the total payment amount is more than the weekly rent' do
+        let(:total_payment_amount_in_week) { -10 }
+
+        it 'returns not the total weekly rent' do
+          calculate_grace_amount = assign_classification.send(:calculate_grace_amount)
+          expect(calculate_grace_amount).to eq(0)
+        end
       end
     end
   end

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -50,7 +50,8 @@ shared_examples 'TenancyClassification' do |condition_matrix|
       number_of_broken_agreements: number_of_broken_agreements,
       expected_balance: expected_balance,
       most_recent_agreement: most_recent_agreement,
-      days_since_last_payment: days_since_last_payment
+      days_since_last_payment: days_since_last_payment,
+      total_payment_amount_in_week: total_payment_amount_in_week
     }
   end
 
@@ -72,6 +73,7 @@ shared_examples 'TenancyClassification' do |condition_matrix|
       let(:expected_balance) { options[:expected_balance] }
       let(:most_recent_agreement) { options[:most_recent_agreement] }
       let(:days_since_last_payment) { options[:days_since_last_payment] }
+      let(:total_payment_amount_in_week) { options[:total_payment_amount_in_week] }
 
       it "returns `#{options[:outcome]}`" do
         expect(subject).to eq(options[:outcome])

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -104,6 +104,10 @@ module Stubs
       attributes[:most_recent_agreement]
     end
 
+    def total_payment_amount_in_week
+      attributes[:total_payment_amount_in_week] || 0
+    end
+
     private
 
     attr_reader :attributes


### PR DESCRIPTION
We were previously not considering payments made within a week (the grace period) of the grace amount (1 week gross rent). Therefore, if someone was in small arrears (less than one weeks gross rent) it will not be shown correctly.

This change removes payments made in the week period from the grace amount, allowing us to calculate the correct grace amount.

E.g. 
Start of week 
- balance = 140
- rent = 100
- payments = 0
- grace = rent - payments -> 100
- arrears = balance - grace -> 40

After one payment
- balance = 100
- rent = 100
- payments = 40
- grace = rent - payments -> 60
- arrears = balance - grace -> 40

So if later in the week  if there's another payment 
- balance = 40
- rent = 100
- payments = 40 + 60 -> 100
- grace = rent - payments -> 0
- arrears = balance - grace -> 40