### PR TITLE
Return pause attributes in Cases payload

### DIFF
--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -123,7 +123,10 @@ module Hackney
           eviction_date: model.eviction_date,
           latest_active_agreement_date: model.latest_active_agreement_date,
           breach_agreement_date: model.breach_agreement_date,
-          expected_balance: model.expected_balance
+          expected_balance: model.expected_balance,
+          pause_reason: model.pause_reason,
+          pause_comment: model.pause_comment,
+          is_paused_until: model.is_paused_until
         }
       end
     end

--- a/lib/hackney/income/view_cases.rb
+++ b/lib/hackney/income/view_cases.rb
@@ -21,14 +21,14 @@ module Hackney
           filters: filters
         )
 
-        assigned_tenancy_refs = tenancies.map { |t| t.fetch(:tenancy_ref) }
-        full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(assigned_tenancy_refs)
+        case_priority_refs = tenancies.map { |t| t.fetch(:tenancy_ref) }
+        full_tenancies = @tenancy_api_gateway.get_tenancies_by_refs(case_priority_refs)
 
-        cases = tenancies.map do |assigned_tenancy|
-          tenancy = full_tenancies.find { |t| t.fetch(:ref) == assigned_tenancy.fetch(:tenancy_ref) }
+        cases = tenancies.map do |case_priority|
+          tenancy = full_tenancies.find { |t| t.fetch(:ref) == case_priority.fetch(:tenancy_ref) }
           next if tenancy.nil?
 
-          build_tenancy_list_item(tenancy, assigned_tenancy)
+          build_tenancy_list_item(tenancy, case_priority)
         end.compact
 
         Response.new(cases, number_of_pages)
@@ -36,7 +36,7 @@ module Hackney
 
       private
 
-      def build_tenancy_list_item(tenancy, assigned_tenancy)
+      def build_tenancy_list_item(tenancy, case_priority)
         {
           ref: tenancy.fetch(:ref),
           current_balance: tenancy.fetch(:current_balance),
@@ -51,22 +51,27 @@ module Hackney
             postcode: tenancy.dig(:primary_contact, :postcode)
           },
 
-          balance: assigned_tenancy.fetch(:balance),
-          days_in_arrears: assigned_tenancy.fetch(:days_in_arrears),
-          days_since_last_payment: assigned_tenancy.fetch(:days_since_last_payment),
-          number_of_broken_agreements: assigned_tenancy.fetch(:number_of_broken_agreements),
-          active_agreement: assigned_tenancy.fetch(:active_agreement),
-          broken_court_order: assigned_tenancy.fetch(:broken_court_order),
-          nosp_served: assigned_tenancy.fetch(:nosp_served),
-          active_nosp: assigned_tenancy.fetch(:active_nosp),
-          courtdate: assigned_tenancy.fetch(:courtdate),
-          court_outcome: assigned_tenancy.fetch(:court_outcome),
-          eviction_date: assigned_tenancy.fetch(:eviction_date),
-          classification: assigned_tenancy.fetch(:classification),
-          patch_code: assigned_tenancy.fetch(:patch_code),
-          latest_active_agreement_date: assigned_tenancy.fetch(:latest_active_agreement_date),
-          breach_agreement_date: assigned_tenancy.fetch(:latest_active_agreement_date),
-          expected_balance: assigned_tenancy.fetch(:expected_balance)
+          balance: case_priority.fetch(:balance),
+          days_in_arrears: case_priority.fetch(:days_in_arrears),
+          days_since_last_payment: case_priority.fetch(:days_since_last_payment),
+          number_of_broken_agreements: case_priority.fetch(:number_of_broken_agreements),
+          active_agreement: case_priority.fetch(:active_agreement),
+          broken_court_order: case_priority.fetch(:broken_court_order),
+          nosp_served: case_priority.fetch(:nosp_served),
+          active_nosp: case_priority.fetch(:active_nosp),
+          courtdate: case_priority.fetch(:courtdate),
+          court_outcome: case_priority.fetch(:court_outcome),
+          eviction_date: case_priority.fetch(:eviction_date),
+          classification: case_priority.fetch(:classification),
+          patch_code: case_priority.fetch(:patch_code),
+          latest_active_agreement_date: case_priority.fetch(:latest_active_agreement_date),
+          breach_agreement_date: case_priority.fetch(:latest_active_agreement_date),
+          expected_balance: case_priority.fetch(:expected_balance),
+          pause: {
+            reason: case_priority.fetch(:pause_reason),
+            comment: case_priority.fetch(:pause_comment),
+            until: case_priority.fetch(:is_paused_until)
+          }
         }
       end
     end

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -101,8 +101,6 @@ describe Hackney::Income::StoredTenanciesGateway do
         Faker::Number.number(1).to_i.times do
           multiple_attributes.append(
             tenancy_ref: Faker::Internet.slug,
-            priority_band: Faker::Internet.slug,
-            priority_score: Faker::Number.number(5).to_i,
             balance: Faker::Number.number(3).to_i
           )
         end
@@ -228,10 +226,13 @@ describe Hackney::Income::StoredTenanciesGateway do
     let(:num_paused_cases) { Faker::Number.between(2, 10) }
     let(:num_active_cases) { Faker::Number.between(2, 20) }
     let(:num_pages) { Faker::Number.between(1, 5) }
+    let(:pause_reason) { Faker::Lorem.word }
+    let(:pause_comment) { Faker::Lorem.paragraph }
+    let(:is_paused_until_date) { Faker::Date.forward(3) }
 
     before do
       num_paused_cases.times do
-        create(:case_priority, balance: 40, is_paused_until: Faker::Date.forward(1))
+        create(:case_priority, balance: 40, is_paused_until: is_paused_until_date, pause_reason: pause_reason, pause_comment: pause_comment)
       end
 
       (num_active_cases - 2).times do
@@ -263,6 +264,12 @@ describe Hackney::Income::StoredTenanciesGateway do
 
         it 'only return only paused tenancies' do
           expect(subject.count).to eq(num_paused_cases)
+        end
+
+        it 'results contain pause attributes' do
+          expect(subject).to all(include(pause_reason: pause_reason))
+          expect(subject).to all(include(pause_comment: pause_comment))
+          expect(subject).to all(include(is_paused_until: is_paused_until_date))
         end
       end
 

--- a/spec/lib/hackney/income/view_cases_spec.rb
+++ b/spec/lib/hackney/income/view_cases_spec.rb
@@ -110,7 +110,12 @@ describe Hackney::Income::ViewCases do
 
                                            latest_active_agreement_date: tenancy_priority_factors.fetch(:latest_active_agreement_date),
                                            breach_agreement_date: tenancy_priority_factors.fetch(:latest_active_agreement_date),
-                                           expected_balance: tenancy_priority_factors.fetch(:expected_balance)
+                                           expected_balance: tenancy_priority_factors.fetch(:expected_balance),
+                                           pause: {
+                                             reason: tenancy_priority_factors.fetch(:pause_reason),
+                                             comment: tenancy_priority_factors.fetch(:pause_comment),
+                                             until: tenancy_priority_factors.fetch(:is_paused_until)
+                                           }
                                          ))
       end
 
@@ -232,7 +237,10 @@ describe Hackney::Income::ViewCases do
       classification: 'no_action',
       latest_active_agreement_date: 1.week.ago,
       breach_agreement_date: 5.days.ago,
-      expected_balance: Faker::Commerce.price
+      expected_balance: Faker::Commerce.price,
+      pause_reason: Faker::Lorem.characters(3),
+      pause_comment: Faker::Lorem.characters(3),
+      is_paused_until: Date.today + 1.day
     }
   end
 


### PR DESCRIPTION
### Why

Users need to see pause_reason in their worktray

### What
Return pause object with:
- reason, 
- comment
- until 
in the Cases payload

```
{
    "cases": [
        {
            "ref": "0109179/01",
            "current_balance": {
                "value": 10797.16,
                "currency_code": "GBP"
            },
            "current_arrears_agreement_status": null,
            "latest_action": {
                "code": "RMD",
                "date": "2020-01-20T10:55:00.000Z"
            },
            "primary_contact": {
                "name": "Ervin Koroglu",
                "short_address": "140 Fletching Road",
                "postcode": "E5 9QR"
            },
            "balance": "10797.16",
            "days_in_arrears": 1780,
            "days_since_last_payment": 1249,
            "number_of_broken_agreements": 0,
            "active_agreement": false,
            "broken_court_order": false,
            "nosp_served": false,
            "active_nosp": false,
            "courtdate": null,
            "court_outcome": "   ",
            "eviction_date": null,
            "classification": "send_letter_two",
            "patch_code": "E04",
            "latest_active_agreement_date": null,
            "breach_agreement_date": null,
            "expected_balance": null,
            "pause": {
              "reason": "pause reason",
              "comment": "pause_comment",
              "until": "pause until date"
            }
        }
    ]
    "number_of_pages": 718
}


```