### PR TITLE
filtering cases by pause reason

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -7,6 +7,7 @@ class CasesController < ApplicationController
       number_per_page: cases_params[:number_per_page],
       filters: {
         is_paused: cases_params[:is_paused],
+        pause_reason: cases_params[:pause_reason],
         classification: cases_params[:recommended_actions],
         patch: cases_params[:patch],
         full_patch: cases_params[:full_patch],
@@ -20,7 +21,10 @@ class CasesController < ApplicationController
 
   def cases_params
     params.require(REQUIRED_INDEX_PARAMS)
-    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[is_paused patch recommended_actions full_patch upcoming_evictions upcoming_court_dates])
+    allowed_params = params.permit(REQUIRED_INDEX_PARAMS + %i[
+      is_paused patch recommended_actions full_patch
+      upcoming_evictions upcoming_court_dates pause_reason
+    ])
 
     allowed_params[:is_paused] = ActiveModel::Type::Boolean.new.cast(allowed_params[:is_paused])
     allowed_params[:full_patch] = ActiveModel::Type::Boolean.new.cast(allowed_params[:full_patch])
@@ -29,6 +33,8 @@ class CasesController < ApplicationController
 
     allowed_params[:page_number] = min_1(allowed_params[:page_number].to_i)
     allowed_params[:number_per_page] = min_1(allowed_params[:number_per_page].to_i)
+
+    allowed_params[:pause_reason] = allowed_params.fetch(:pause_reason, nil)
 
     allowed_params
   end

--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -55,6 +55,7 @@ module Hackney
 
         order_options   = 'eviction_date' if filters[:upcoming_evictions].present?
         order_options   = 'courtdate' if filters[:upcoming_court_dates].present?
+        order_options   = 'is_paused_until' if filters[:is_paused]
         order_options ||= by_balance
 
         query.order(order_options).map(&method(:build_tenancy_list_item))
@@ -84,6 +85,8 @@ module Hackney
           query = query.where(classification: filters[:classification])
         elsif only_show_immediate_actions?(filters)
           query = query.where.not(classification: :no_action).or(query.where(classification: nil))
+        elsif filters[:pause_reason].present?
+          query = query.where(pause_reason: filters[:pause_reason])
         end
 
         return query if filters[:is_paused].nil?

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -21,6 +21,7 @@ describe CasesController do
           .to receive(:execute)
           .with(page_number: 1, number_per_page: 1, filters: {
             is_paused: nil,
+            pause_reason: nil,
             classification: nil,
             patch: nil,
             full_patch: nil,
@@ -29,6 +30,26 @@ describe CasesController do
           })
 
         get :index, params: { page_number: 0, number_per_page: 0 }
+      end
+    end
+
+    context 'when retrieving paused cases filtered by paused reason' do
+      let(:pause_reason) { Faker::Lorem.word }
+
+      it 'pause reason should be passed to the use case' do
+        allow(view_my_cases_instance)
+          .to receive(:execute)
+          .with(page_number: 1, number_per_page: 1, filters: {
+            classification: nil,
+            patch: nil,
+            full_patch: nil,
+            upcoming_evictions: nil,
+            upcoming_court_dates: nil,
+            is_paused: true,
+            pause_reason: pause_reason
+          })
+
+        get :index, params: { is_paused: true, pause_reason: pause_reason, number_per_page: 1, page_number: 1 }
       end
     end
 
@@ -54,7 +75,8 @@ describe CasesController do
             patch: nil,
             full_patch: nil,
             upcoming_evictions: nil,
-            upcoming_court_dates: nil
+            upcoming_court_dates: nil,
+            pause_reason: nil
           })
           .and_return(cases: [], number_per_page: 1)
 
@@ -86,6 +108,7 @@ describe CasesController do
           .to receive(:execute)
           .with(page_number: page_number, number_per_page: number_per_page, filters: {
             is_paused: false,
+            pause_reason: nil,
             classification: nil,
             patch: nil,
             full_patch: nil,
@@ -109,6 +132,7 @@ describe CasesController do
           .to receive(:execute)
           .with(page_number: page_number, number_per_page: number_per_page, filters: {
             is_paused: nil,
+            pause_reason: nil,
             classification: nil,
             patch: patch,
             full_patch: nil,

--- a/spec/lib/hackney/income/view_cases_spec.rb
+++ b/spec/lib/hackney/income/view_cases_spec.rb
@@ -154,6 +154,48 @@ describe Hackney::Income::ViewCases do
 
           expect(subject.cases.count).to eq(1)
         end
+
+        context 'when filtering paused cases by pause reason' do
+          subject {
+            view_cases.execute(
+              page_number: page_number,
+              number_per_page: number_per_page,
+              filters: {
+                is_paused: true,
+                pause_reason: pause_reason
+              }
+            )
+          }
+
+          let(:pause_reason) { Faker::Lorem.word }
+
+          it 'returns only paused cases filtered by pause reason' do
+            expect(stored_tenancies_gateway)
+              .to receive(:get_tenancies)
+              .with(a_hash_including(
+                      page_number: page_number,
+                      number_per_page: number_per_page,
+                      filters: {
+                        is_paused: true,
+                        pause_reason: pause_reason
+                      }
+                    ))
+              .and_call_original
+
+            expect(stored_tenancies_gateway)
+              .to receive(:number_of_pages)
+              .with(a_hash_including(
+                      number_per_page: number_per_page,
+                      filters: {
+                        is_paused: true,
+                        pause_reason: pause_reason
+                      }
+                    ))
+              .and_call_original
+
+            expect(subject.cases.count).to eq(1)
+          end
+        end
       end
 
       context 'when filtering cases by patch' do


### PR DESCRIPTION
passing `pause_reason` to `/api/v1/cases` will now return a list of cases filtered by pause reason