### PR TITLE
Stop default binding to localhost

### DIFF
--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - ${INCOME_API_DIR}:/app
     working_dir: /app
-    command: sh -c 'rails db:migrate && rails s'
+    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - 3000:3000
     volumes:
       - .:/app
-    command: sh -c 'rails db:migrate && rails s'
+    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis


### PR DESCRIPTION
So `rails s` used to bind to `0.0.0.0`, but after 4.2 it binds to `localhost`.

Similar to [IncomeCollection](https://github.com/LBHackney-IT/LBH-IncomeCollection/commit/004b56a7b157bd31f2b446f94ef1c6cabf8e3743#diff-86d9fe5965e75841a04a67004e57730e), this just reverses that and was needed to get the API working locally.

😸 