### PR TITLE
Remove Sidekiq warning in test env

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,3 +68,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+# Disable warning when running sidekiq in test environment
+RSpec::Sidekiq.configure do |config|
+  config.warn_when_jobs_not_processed_by_sidekiq = false if Rails.env.test?
+end


### PR DESCRIPTION
## Context
Sidekiq is not processing jobs in test env, therefore showing a warning anytime we run the tests

## Changes in this PR
- Remove Warning when running tests
### Before:
![image](https://user-images.githubusercontent.com/22743709/81960635-29e58080-9609-11ea-9230-4c9e8df6ad4b.png)
