### PR TITLE
WIP Use mysql in dev and test env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'sqlite3'
   gem 'timecop'
   gem 'webmock'
+  gem 'yaml_db'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,9 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     wkhtmltopdf-binary (0.12.4)
+    yaml_db (0.7.0)
+      rails (>= 3.0)
+      rake (>= 0.8.7)
 
 PLATFORMS
   ruby
@@ -366,6 +369,7 @@ DEPENDENCIES
   uk_postcode
   webmock
   wkhtmltopdf-binary
+  yaml_db
 
 BUNDLED WITH
    1.17.3

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,14 +1,18 @@
-development:
-  adapter: mysql2
-  encoding: utf8
-  database: db/development
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch("DB_USERNAME") %>
-  password: <%= ENV.fetch("DB_PASSWORD") %>
-test:
-  adapter: mysql2
-  encoding: utf8
-  database: db/test
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch("DB_USERNAME") %>
-  password: <%= ENV.fetch("DB_PASSWORD") %>
+# All environments are injected via DATABASE_URL
+
+# development:
+#   adapter: mysql2
+#   encoding: utf8
+#   database: app-database-<%= ENV.fetch("RAILS_ENV") %>
+#   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+#   username: <%= ENV.fetch("MYSQL_USERNAME") %>
+#   password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+# test:
+#   adapter: mysql2
+#   encoding: utf8
+#   database: app-database-test
+#   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+#   username: <%= ENV.fetch("MYSQL_USERNAME") %>
+#   password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+
+  # staging and production should be injected via DATABASE_URL

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,17 +1,14 @@
-sqlite: &sqlite
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
 development:
-  <<: *sqlite
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+  adapter: mysql2
+  encoding: utf8
+  database: db/development
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("DB_USERNAME") %>
+  password: <%= ENV.fetch("DB_PASSWORD") %>
 test:
-  <<: *sqlite
-  database: db/test.sqlite3
-
-# production should be injected via DATABASE_URL
+  adapter: mysql2
+  encoding: utf8
+  database: db/test
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV.fetch("DB_USERNAME") %>
+  password: <%= ENV.fetch("DB_PASSWORD") %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2020_01_06_154443) do
 
-  create_table "case_priorities", force: :cascade do |t|
+  create_table "case_priorities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -24,11 +24,11 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.boolean "broken_court_order"
     t.boolean "nosp_served"
     t.boolean "active_nosp"
-    t.integer "assigned_user_id"
+    t.bigint "assigned_user_id"
     t.datetime "is_paused_until"
     t.string "pause_reason"
     t.text "pause_comment"
-    t.integer "case_id"
+    t.bigint "case_id"
     t.datetime "nosp_served_date"
     t.datetime "nosp_expiry_date"
     t.decimal "weekly_rent", precision: 10, scale: 2
@@ -45,20 +45,20 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.datetime "uc_direct_payment_received"
     t.datetime "latest_active_agreement_date"
     t.datetime "breach_agreement_date"
-    t.decimal "expected_balance"
+    t.decimal "expected_balance", precision: 10
     t.string "payment_ref"
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
     t.index ["case_id"], name: "index_case_priorities_on_case_id"
     t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true
   end
 
-  create_table "cases", force: :cascade do |t|
+  create_table "cases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", force: :cascade do |t|
+  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "uuid", null: false
     t.string "extension", null: false
     t.string "metadata"
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "provider_uid"
     t.string "provider"
     t.string "name"
@@ -100,4 +100,5 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.integer "role", default: 0
   end
 
+  add_foreign_key "case_priorities", "users", column: "assigned_user_id"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
+      - DB_USERNAME=${DB_USERNAME}
+      - DB_PASSWORD=${DB_PASSWORD}
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,10 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
-      - DB_USERNAME=${DB_USERNAME}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - MYSQL_USERNAME=foo
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
+      - DATABASE_URL=mysql2://root:bar@db-development/app-database-development
     ports:
       - 3000:3000
     volumes:
@@ -24,6 +26,8 @@ services:
     depends_on:
       - universal_housing_simulator
       - redis
+      - db-development
+      - db-test
   universal_housing_simulator:
     image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator-loaded:latest
     ports:
@@ -34,3 +38,34 @@ services:
     hostname: redis
     ports:
       - 6379:6379
+  db-development:
+    image: mysql:5.7
+    volumes:
+      - dev_data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_DATABASE=app-database-development
+      - MYSQL_USERNAME=foo
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
+    ports:
+      - "3307:3306"
+    expose:
+      - '3306'
+  db-test:
+    image: mysql:5.7
+    restart: always
+    environment:
+      - MYSQL_DATABASE=app-database-test
+      - MYSQL_USERNAME=foo
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
+    volumes:
+      - test_data:/var/lib/mysql
+    ports:
+      - "3308:3309"
+    expose:
+      - '3309'
+volumes:
+  dev_data: {}
+  test_data: {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] = 'test'
+ENV['DATABASE_URL']= 'mysql2://root:bar@db-test/app-database-test'
 
 ENV['TENANCY_API_HOST'] = 'example.com'
 ENV['TENANCY_API_KEY'] = '1234'


### PR DESCRIPTION
### Context
In production/staging MySQL db is used by injecting the DB using the `DATABASE_URL` env var, while development and test environments are running SQLlite db. We want these env to be identical.

### Changes in this PR
- Update docker-compose so we can run MySQL `db-development` and `db-test` in a separate container and inject them using `DATABASE_URL` 

### Jira ticket 
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-117