### PR TITLE
Use mysql in dev and test env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
           command: |
             docker-compose build
       - run:
+          name: Create db
+          command: docker-compose run -e RAILS_ENV=test --rm app rails db:create
+      - run:
           name: Run migrations
           command: docker-compose run -e RAILS_ENV=test --rm app rails db:migrate
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,17 @@ jobs:
           command: |
             docker-compose build
       - run:
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run:
+          name: Start db container
+          command: docker-compose up -d db 
+      - run:
+          name: Wait for db container
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
+      - run:
           name: Create db
           command: docker-compose run -e RAILS_ENV=test --rm app rails db:create
       - run:

--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,9 @@ gem 'pdfkit'
 gem 'phonelib'
 gem 'redis-rails'
 gem 'sentry-raven'
-gem 'wkhtmltopdf-binary'
-
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
+gem 'wkhtmltopdf-binary'
 
 group :test do
   gem 'pdf-reader'
@@ -59,7 +58,6 @@ group :development, :test do
   gem 'pry'
   gem 'rspec-its'
   gem 'rspec-rails'
-  gem 'sqlite3'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -359,7 +358,6 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   timecop
   tiny_tds
   tzinfo-data

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ serve:
 	-rm tmp/pids/server.pid &> /dev/null
 	docker-compose up
 
+.PHONY: test-setup
+test-setup:
+	docker-compose run --rm app /bin/bash -c "rake db:drop RAILS_ENV=test \
+																						&& rake db:create RAILS_ENV=test \
+																						&& rake db:migrate RAILS_ENV=test"
+
 .PHONY: test
 test:
 	docker-compose run --rm app rspec

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ $ make serve
 
 #### Testing
 
+To setup or reset your test database run
+
+```sh
+$ make test-setup
+```
+
+To run tests:
+
+```sh
+$ make test
+```
+
 To run linting and tests:
 
 ```sh

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,17 +1,18 @@
-sqlite: &sqlite
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
 development:
-  <<: *sqlite
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+  adapter: mysql2
+  encoding: utf8
+  database: app-database-<%= ENV.fetch("RAILS_ENV") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+  host: db
 test:
-  <<: *sqlite
-  database: db/test.sqlite3
+  adapter: mysql2
+  encoding: utf8
+  database: app-database-<%= ENV.fetch("RAILS_ENV") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+  host: db
 
-# production should be injected via DATABASE_URL
+  # staging and production should be injected via DATABASE_URL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2020_01_06_154443) do
 
-  create_table "case_priorities", force: :cascade do |t|
+  create_table "case_priorities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -24,11 +24,11 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.boolean "broken_court_order"
     t.boolean "nosp_served"
     t.boolean "active_nosp"
-    t.integer "assigned_user_id"
+    t.bigint "assigned_user_id"
     t.datetime "is_paused_until"
     t.string "pause_reason"
     t.text "pause_comment"
-    t.integer "case_id"
+    t.bigint "case_id"
     t.datetime "nosp_served_date"
     t.datetime "nosp_expiry_date"
     t.decimal "weekly_rent", precision: 10, scale: 2
@@ -45,20 +45,20 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.datetime "uc_direct_payment_received"
     t.datetime "latest_active_agreement_date"
     t.datetime "breach_agreement_date"
-    t.decimal "expected_balance"
+    t.decimal "expected_balance", precision: 10
     t.string "payment_ref"
     t.index ["assigned_user_id"], name: "index_case_priorities_on_assigned_user_id"
     t.index ["case_id"], name: "index_case_priorities_on_case_id"
     t.index ["tenancy_ref"], name: "index_case_priorities_on_tenancy_ref", unique: true
   end
 
-  create_table "cases", force: :cascade do |t|
+  create_table "cases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
+  create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "documents", force: :cascade do |t|
+  create_table "documents", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "uuid", null: false
     t.string "extension", null: false
     t.string "metadata"
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "provider_uid"
     t.string "provider"
     t.string "name"
@@ -100,4 +100,5 @@ ActiveRecord::Schema.define(version: 2020_01_06_154443) do
     t.integer "role", default: 0
   end
 
+  add_foreign_key "case_priorities", "users", column: "assigned_user_id"
 end

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -16,6 +16,8 @@ services:
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
       - TENANCY_API_HOST=http://tenancyapi:80
       - TENANCY_API_KEY=''
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
     ports:
       - 3000:3000
     volumes:
@@ -26,9 +28,22 @@ services:
       - universal_housing_simulator
       - redis
       - tenancyapi
+      - db
   redis:
     image: redis:5.0.3-alpine
     command: ["redis-server", "--appendonly", "yes"]
     hostname: redis
     ports:
       - 6379:6379
+  db:
+    image: mysql:5.7
+    volumes:
+      - dev_data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
+    ports:
+      - 3306:3306
+volumes:
+  dev_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
   db:
     image: mysql:5.7
     volumes:
-      - ${PWD}/db/data:/var/lib/mysql
+      - dev_data:/var/lib/mysql
     restart: always
     environment:
       - MYSQL_PASSWORD=bar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
     ports:
       - 3000:3000
     volumes:
@@ -22,6 +24,7 @@ services:
     depends_on:
       - universal_housing_simulator
       - redis
+      - db
   universal_housing_simulator:
     image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator-loaded:latest
     ports:
@@ -32,3 +35,15 @@ services:
     hostname: redis
     ports:
       - 6379:6379
+  db:
+    image: mysql:5.7
+    volumes:
+      - ${PWD}/db/data:/var/lib/mysql
+    restart: always
+    environment:
+      - MYSQL_PASSWORD=bar
+      - MYSQL_ROOT_PASSWORD=bar
+    ports:
+      - 3306:3306
+volumes:
+  dev_data: {}

--- a/lib/hackney/cloud/storage.rb
+++ b/lib/hackney/cloud/storage.rb
@@ -58,8 +58,9 @@ module Hackney
       end
 
       def documents_to_update_status(time:)
-        document_model.where('updated_at >= ?', time).exclude_uploaded
-                      .where.not(status: %i[nil validation-failed received downloaded])
+        document_model.where('updated_at >= ?', time)
+                      .where.not(status: %i[uploaded validation-failed received downloaded])
+                      .where.not(status: nil)
       end
 
       def upload(bucket_name, content, filename)

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -66,7 +66,7 @@ describe TenanciesController, type: :controller do
           assigned_user_id: nil,
           balance: tenancy_1.balance.to_s,
           broken_court_order: nil,
-          case_id: 1,
+          case_id: tenancy_1.case_id,
           classification: nil,
           court_outcome: nil,
           courtdate: nil,
@@ -114,13 +114,13 @@ describe TenanciesController, type: :controller do
             tenancy_ref: tenancy_1.tenancy_ref,
             nosp: {
               active: true,
-              expires_date: (nosp_served_date + 28.days).iso8601(3),
+              expires_date: (nosp_served_date + 28.days).strftime('%FT%T.000Z'),
               in_cool_off_period: false,
-              served_date: nosp_served_date.iso8601(3),
-              valid_until_date: (nosp_served_date + 28.days + 52.weeks).iso8601(3),
+              served_date: nosp_served_date.strftime('%FT%T.000Z'),
+              valid_until_date: (nosp_served_date + 28.days + 52.weeks).strftime('%FT%T.000Z'),
               valid: true
             },
-            nosp_served_date: nosp_served_date.iso8601(3),
+            nosp_served_date: nosp_served_date.strftime('%FT%T.000Z'),
             # The follwoing attributes are stored on the Case Pirority Model
             active_nosp: nil,
             nosp_served: nil

--- a/spec/requests/income_collection_letters_spec.rb
+++ b/spec/requests/income_collection_letters_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe 'Income Collection Letters', type: :request do
             'id' => 'income_collection_letter_1'
           },
           'username' => user[:name],
-          'document_id' => 1,
           'errors' => []
         }
       }
@@ -80,11 +79,16 @@ RSpec.describe 'Income Collection Letters', type: :request do
 
         # UUID: is always different can ignore this.
         # TODO: Test `preview` content separatly
-        keys_to_ignore = %w[preview uuid]
+        keys_to_ignore = %w[preview uuid document_id]
 
-        json_response = JSON.parse(response.body).except(*keys_to_ignore)
+        full_response = JSON.parse(response.body)
+        filtered_response = full_response.except(*keys_to_ignore)
 
-        expect(json_response).to eq(expected_json_response_as_hash)
+        expect(filtered_response).to eq(expected_json_response_as_hash)
+
+        keys_to_ignore.each do |key|
+          expect(full_response).to have_key(key)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
In production/staging MySQL db is used by injecting the DB using the `DATABASE_URL` env var, while development and test environments are running SQLlite db. We want these env to be identical.

### Changes in this PR
- Update docker-compose so we can run MySQL `db-development` and `db-test` in a separate container and inject them using `DATABASE_URL` 

### Jira ticket 
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-117