### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Context
+<!-- Why are you making this change? What might surprise someone about it? -->
+
+## Changes proposed in this pull request
+<!-- List all the changes -->
+
+## Guidance to review
+<!-- How could someone else check this work? Which parts do you want more feedback on? -->
+
+## Link to Jira card
+<!-- https://hackney.atlassian.net/123-example-card -->
+
+## Things to check
+
+- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
+- [ ] Environment variables have been updated


### PR DESCRIPTION
## Context
As suggested on https://github.com/LBHackney-IT/lbh-income-api/pull/376 by @antonyoneill 
`I think it would also be useful to agree on a standard PR template to ensure that we capture the correct information to provide context to reviewers`

This is based on the template we used on Apply and I think it worked really well. This is just a proposal and I encourage you to suggest any changes or any different template. Also, some fields are optional, so don't be pressured to fill up everything...

## Changes proposed in this pull request
<!-- List all the changes -->
- Add a pull request template, so we can use a standard format when opening/reviewing a PR
