### PR TITLE
Resolve container reference when running all services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             DOCKERIZE_VERSION: v0.3.0
       - run:
           name: Start db container
-          command: docker-compose up -d db 
+          command: docker-compose up -d incomeapi-db 
       - run:
           name: Wait for db container
           command: dockerize -wait tcp://localhost:3306 -timeout 1m

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ development:
   database: app-database-<%= ENV.fetch("RAILS_ENV") %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+  password: bar
   host: incomeapi-db
 test:
   adapter: mysql2
@@ -12,7 +12,7 @@ test:
   database: app-database-<%= ENV.fetch("RAILS_ENV") %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: <%= ENV.fetch("MYSQL_PASSWORD") %>
+  password: bar
   host: incomeapi-db
 
   # staging and production should be injected via DATABASE_URL

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@ development:
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: <%= ENV.fetch("MYSQL_PASSWORD") %>
-  host: db
+  host: incomeapi-db
 test:
   adapter: mysql2
   encoding: utf8
@@ -13,6 +13,6 @@ test:
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: <%= ENV.fetch("MYSQL_PASSWORD") %>
-  host: db
+  host: incomeapi-db
 
   # staging and production should be injected via DATABASE_URL

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -28,14 +28,14 @@ services:
       - universal_housing_simulator
       - redis
       - tenancyapi
-      - db
+      - incomeapi-db
   redis:
     image: redis:5.0.3-alpine
     command: ["redis-server", "--appendonly", "yes"]
     hostname: redis
     ports:
       - 6379:6379
-  db:
+  incomeapi-db:
     image: mysql:5.7
     volumes:
       - dev_data:/var/lib/mysql

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -16,8 +16,6 @@ services:
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
       - TENANCY_API_HOST=http://tenancyapi:80
       - TENANCY_API_KEY=''
-      - MYSQL_PASSWORD=bar
-      - MYSQL_ROOT_PASSWORD=bar
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     depends_on:
       - universal_housing_simulator
       - redis
-      - db
+      - incomeapi-db
   universal_housing_simulator:
     image: 775052747630.dkr.ecr.eu-west-2.amazonaws.com/hackney/universal-housing-simulator-loaded:latest
     ports:
@@ -35,7 +35,7 @@ services:
     hostname: redis
     ports:
       - 6379:6379
-  db:
+  incomeapi-db:
     image: mysql:5.7
     volumes:
       - dev_data:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - GOV_NOTIFY_API_KEY=${GOV_NOTIFY_API_KEY}
-      - MYSQL_PASSWORD=bar
-      - MYSQL_ROOT_PASSWORD=bar
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
##  Context
This is an issue when running `make run-all` using the [Frontend](https://github.com/LBHackney-IT/LBH-IncomeCollection). Both income-api and uh-simulator creates a db container with identical name, renaming solves the issue

## Changes proposed in this pull request
Rename `db` container to `incomeapi-db`
