### PR TITLE
Wait for DB in development/test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: docker-compose run -e RAILS_ENV=test --rm app rspec
       - run:
           name: Run linting
-          command: docker-compose run --rm app rubocop
+          command: docker-compose run -e RAILS_ENV=test --rm app rubocop
       - store_artifacts:
           path: coverage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,23 +15,6 @@ jobs:
           command: |
             docker-compose build
       - run:
-          name: install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.3.0
-      - run:
-          name: Start db container
-          command: docker-compose up -d incomeapi-db 
-      - run:
-          name: Wait for db container
-          command: dockerize -wait tcp://localhost:3306 -timeout 1m
-      - run:
-          name: Create db
-          command: docker-compose run -e RAILS_ENV=test --rm app rails db:create
-      - run:
-          name: Run migrations
-          command: docker-compose run -e RAILS_ENV=test --rm app rails db:migrate
-      - run:
           name: Run tests
           command: docker-compose run -e RAILS_ENV=test --rm app rspec
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,13 @@ jobs:
           command: aws ecr get-login --region $AWS_REGION --no-include-email | sh
       - run:
           name: Build projects
-          command: |
-            docker-compose build
+          command: make docker-build
       - run:
           name: Run tests
-          command: docker-compose run -e RAILS_ENV=test --rm app rspec
+          command: make test
       - run:
           name: Run linting
-          command: docker-compose run -e RAILS_ENV=test --rm app rubocop
+          command: make lint
       - store_artifacts:
           path: coverage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,22 @@ RUN wget https://web.archive.org/web/20191028054637/http://www.freetds.org/files
   make && \
   make install
 
+ENV DOCKERIZE_VERSION=v0.3.0
+RUN wget --quiet https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+ tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+ rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 ENV RAILS_ENV ${RAILS_ENV}
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle check || bundle install
 
+# Add a script to be executed every time the container starts.
+COPY bin/entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
 COPY . /app
 EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -19,23 +19,21 @@ serve:
 	-rm tmp/pids/server.pid &> /dev/null
 	docker-compose up
 
-.PHONY: test-setup
-test-setup:
-	docker-compose run --rm app /bin/bash -c "rake db:drop RAILS_ENV=test \
-																						&& rake db:create RAILS_ENV=test \
-																						&& rake db:migrate RAILS_ENV=test"
-
-.PHONY: test
-test:
-	docker-compose run --rm app rspec
-
 .PHONY: shell
 shell:
 	docker-compose run --rm app /bin/bash
 
+.PHONY: test-db-destroy
+test-db-destroy:
+	docker-compose rm --stop -v incomeapi-db
+
+.PHONY: test
+test:
+	docker-compose run --rm -e "RAILS_ENV=test" app rspec
+
 .PHONY: lint
 lint:
-	docker-compose run --rm app rubocop
+	docker-compose run --rm -e RAILS_ENV=test app rubocop
 
 .PHONY: check
 check: lint test

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-db-destroy:
 
 .PHONY: test
 test:
-	docker-compose run --rm -e "RAILS_ENV=test" app rspec
+	docker-compose run --rm -e RAILS_ENV=test app rspec
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ $ make serve
 
 #### Testing
 
-To setup or reset your test database run
+To reset your test database run
 
 ```sh
-$ make test-setup
+$ make test-db-destroy
 ```
 
 To run tests:
@@ -123,11 +123,11 @@ Then we have an automated four step deployment process, which runs in CircleCI.
 2. Browse to 'Commits'.
 3. Locate and click the checks indicator for the commit you would like to deploy from.
 4. Click a stage's 'Details' link.
-5. Confirm the commit SHA is the same  
-  5.1. On Circle CI, the hash is shown on the right-hand side of the page, under 'Triggered by'.  
+5. Confirm the commit SHA is the same
+  5.1. On Circle CI, the hash is shown on the right-hand side of the page, under 'Triggered by'.
   5.2. Compare this with the hash shown in the commits list.
 6. Once you are happy, click 'Rerun workflow' on Circle CI.
-7. There are **manual stages** that need to be triggered within the workflow.  
+7. There are **manual stages** that need to be triggered within the workflow.
 Remember to do this, or the new workflow/deployment will not make it to production.
 
 ### Connection to Universal Housing
@@ -192,18 +192,18 @@ In order to change any of these variables you will need to:
 3. Locate and select **Task Definitions** on the left-hand sidebar
 4. Search for `task-income-` in the 'Filter in this page' field above the table.
 5. Select `income-api-production` or `income-api-staging`.
-6. Click on the Task definition you'd like to base your new one off.  
+6. Click on the Task definition you'd like to base your new one off.
 This will usually be the most recent, i.e. the one with the greatest tag number.
 7. Click **Create new revision**
 8. Locate 'Container definitions' and select the `income-api-production-worker` container.
 9. Locate the 'ENVIRONMENT' section of the slide-out.
-10. Add/Modify the relevant Environment Variables.  
+10. Add/Modify the relevant Environment Variables.
 11. Click **Update** at the bottom of the slide-out when you have finished making changes/additions.
-12. Click **Create** at the bottom of the 'Create new revision' page.  
-13. Verify that the Environment Variables have been inputted correctly, to check this click on the **JSON** tab of the newly created task definition 
+12. Click **Create** at the bottom of the 'Create new revision' page.
+13. Verify that the Environment Variables have been inputted correctly, to check this click on the **JSON** tab of the newly created task definition
 14. Check that all the Environment Variables are correct, look for issues such as trailing whitespace e.g. `AUTOMATE_INCOME_COLLECTION_LETTER_ONE\t` (i.e. trailing \<TAB\> character) or special characters.
 15. If you find any issues with any of the Environment Variables, follow the above steps to create a new Task Definition with the correct ones.
-16. There is now a new Task Definition, but it has not been applied yet.  
+16. There is now a new Task Definition, but it has not been applied yet.
 **You must ENSURE YOU [REDEPLOY](#manual-redeployment) to have your changes applied**
 
 **IMPORTANT: IF YOU UPDATE THE TASK DEFINITION BY CHANGING ANY OF THE ABOVE YOU NEED TO REDEPLOY IN ORDER FOR THE NEW INSTANCE TO USE THE NEW TASK DEFINITION**

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Starting $RAILS_ENV"
+
+if [ "$RAILS_ENV" = "test" ] || [ "$RAILS_ENV" = "development" ]
+then
+  DATABASE_SERVICE=tcp://incomeapi-db:3306
+  echo "Waiting for database to come up on $DATABASE_SERVICE"
+  # Wait for database to come up
+  dockerize -wait "$DATABASE_SERVICE" -timeout 1m
+fi
+
+# Migrate database
+rails db:migrate
+
+# Start app
+exec "$@"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -10,6 +10,9 @@ then
   echo "Waiting for database to come up on $DATABASE_SERVICE"
   # Wait for database to come up
   dockerize -wait "$DATABASE_SERVICE" -timeout 1m
+
+  # Create database - will not fail if it already exists
+  rails db:create
 fi
 
 # Migrate database

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -20,8 +20,6 @@ services:
       - 3000:3000
     volumes:
       - ${INCOME_API_DIR}:/app
-    working_dir: /app
-    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - 3000:3000
     volumes:
       - .:/app
-    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
With a separate MySQL container, the first time it boots it can take a
little while to populate the docker volume with the necessary data.

This will happen whenever the `dev_data` docker volume is removed.

## Changes proposed in this pull request
* Add `dockerize`, a helper script that waits for services to
be connectable before allowing the service to start.
* Simplify the startup commands for the service.
* Auto create db if it doesn't already exist before migration.

All the above mean that every time you start the service using `docker-compose up` you'll get a database with all the right schema (whether it existed before or not).

See:
* https://github.com/jwilder/dockerize
* https://docs.docker.com/compose/rails/

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Would be good to get another set of eyes on the Dockerfile, and docker-compose files.

I'm not sure if we'll want to remove the `["sh","-c","rails db:migrate ; rails s"]` commands from the web task in AWS for staging and production. The image will now run migration as part of the entrypoint, running migrate twice may just slow boot time down a little.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
I don't have one - should I raise one first?

## Things to check

- [x] ~If this code includes a migration adding or changing columns, it also backfills existing records for consistency~
- [x] ~Environment variables have been updated~
