### PR TITLE
if username is longer than 40, shorten it

### DIFF
--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -44,9 +44,9 @@ module Hackney
 
         def action_diary_name(username)
           return username if username.length < 40
-          
-          username = username.split(" ")
-          username.map {|n| n.equal?(username.last) ? n.capitalize : n[0].capitalize }.join(". ")
+
+          username = username.split(' ')
+          username.map { |n| n.equal?(username.last) ? n.capitalize : n[0].capitalize }.join('. ')
         end
       end
     end

--- a/lib/hackney/tenancy/gateway/action_diary_gateway.rb
+++ b/lib/hackney/tenancy/gateway/action_diary_gateway.rb
@@ -28,7 +28,7 @@ module Hackney
             createdDate: date.iso8601
           }
 
-          body[:username] = username if username.present?
+          body[:username] = action_diary_name(username) if username.present?
 
           response = self.class.post('/api/v2/tenancies/arrears-action-diary', @options.merge(body: body.to_json))
 
@@ -38,6 +38,15 @@ module Hackney
           end
 
           response
+        end
+
+        private
+
+        def action_diary_name(username)
+          return username if username.length < 40
+          
+          username = username.split(" ")
+          username.map {|n| n.equal?(username.last) ? n.capitalize : n[0].capitalize }.join(". ")
         end
       end
     end

--- a/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/gateway/action_diary_gateway_spec.rb
@@ -69,6 +69,30 @@ describe Hackney::Tenancy::Gateway::ActionDiaryGateway do
         times: 1
       )
     end
+
+    it 'creates a entry with shortened user name if username supplied is longer than 40 chars' do
+      gateway.create_entry(
+        tenancy_ref: tenancy_ref,
+        action_code: action_code,
+        comment: comment,
+        username: 'Hubert Wolfeschlegelsteinhausenbergerdorff',
+        date: date
+      )
+
+      assert_requested(
+        :post, host + '/api/v2/tenancies/arrears-action-diary',
+        headers: required_headers,
+        body: {
+          tenancyAgreementRef: tenancy_ref,
+          actionCode: action_code,
+          actionCategory: '9',
+          comment: comment,
+          username: 'H. Wolfeschlegelsteinhausenbergerdorff',
+          createdDate: date
+        },
+        times: 1
+      )
+    end
   end
 
   context 'when tenancy api returns an error' do

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -257,7 +257,8 @@ module UniversalHousingHelper
       aline1: aline1,
       aline2: aline2,
       aline3: aline3,
-      aline4: aline4
+      aline4: aline4,
+      ci_post_code: ''
     )
   end
 

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -257,8 +257,7 @@ module UniversalHousingHelper
       aline1: aline1,
       aline2: aline2,
       aline3: aline3,
-      aline4: aline4,
-      ci_post_code: ''
+      aline4: aline4
     )
   end
 


### PR DESCRIPTION
## Context
It was reported that usernames that are longer than 40 characters raises an exception on the tenancy api 

## Changes proposed in this pull request
Proposing that we check the length of the username provided and if it's longer than 40 characters, change name to be `[first name]. [last name]`

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
https://hackney.atlassian.net/browse/MAAP-97?atlOrigin=eyJpIjoiNzY3YjRjYTRkZDIwNDE5ZmIwY2Q1MWE4MTVlYTM0NGMiLCJwIjoiaiJ9
## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
