### PR TITLE
Resolve Sentry concurrent DB migration issue

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -11,8 +11,8 @@ then
   # Wait for database to come up
   dockerize -wait "$DATABASE_SERVICE" -timeout 1m
 
-  # Create database - will not fail if it already exists
-  rails db:create
+  # Setup the database - safe if it is already configured
+  rails db:setup
 fi
 
 # Start app

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -15,8 +15,5 @@ then
   rails db:create
 fi
 
-# Migrate database
-rails db:migrate
-
 # Start app
 exec "$@"

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -20,6 +20,7 @@ services:
       - 3000:3000
     volumes:
       - ${INCOME_API_DIR}:/app
+    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - 3000:3000
     volumes:
       - .:/app
+    command: sh -c 'rails db:migrate && rails s --binding=0.0.0.0'
     depends_on:
       - universal_housing_simulator
       - redis


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Earlier today I merged #381 which had logic to run the following steps when the container was started:
* create a database in dev/test if it doesn't already exist
* migrate automatically

Running the migration automatically causes issues when multiple instances of the image are instantiated at the same time, since multiple migrations will be executed against the same database.

This happens when deploying to staging & production

See sentry error [ActiveRecord::ConcurrentMigrationError](https://sentry.io/organizations/london-borough-of-hackney/issues/1690594841)

## Changes proposed in this pull request
<!-- List all the changes -->
* Remove automatic migration logic from entrypoint.
* Replace `db:create` with `db:setup`. The latter will load the schema so that the test/dev environment is ready to go when it loads.
* Restore migration command in docker-compose files.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check it out locally, with your current database as configured pre-checkout.

Then try destroying the volumes, and re run

```bash
docker kill  $(docker ps -q)
docker rm $(docker ps -a -q)
docker volume rm $(docker volume ls -q)

make test
```

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
-

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
