### PR TITLE
check if case is in worktray before pausing after action diary was added

### DIFF
--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -131,7 +131,8 @@ module Hackney
       def add_action_diary_and_pause_case
         UseCases::AddActionDiaryAndPauseCase.new(
           sql_pause_tenancy_gateway: sql_pause_tenancy_gateway,
-          add_action_diary: add_action_diary
+          add_action_diary: add_action_diary,
+          get_tenancy: get_tenancy
         )
       end
 

--- a/lib/use_cases/add_action_diary_and_pause_case.rb
+++ b/lib/use_cases/add_action_diary_and_pause_case.rb
@@ -1,8 +1,9 @@
 module UseCases
   class AddActionDiaryAndPauseCase
-    def initialize(sql_pause_tenancy_gateway:, add_action_diary:)
+    def initialize(sql_pause_tenancy_gateway:, add_action_diary:, get_tenancy:)
       @sql_pause_tenancy_gateway = sql_pause_tenancy_gateway
       @add_action_diary = add_action_diary
+      @get_tenancy = get_tenancy
     end
 
     def execute(tenancy_ref:, action_code:, comment:, username:)
@@ -14,6 +15,7 @@ module UseCases
       )
 
       return unless code_pauses_case?(action_code)
+      return if tenancy_not_in_worktray?(tenancy_ref)
 
       @sql_pause_tenancy_gateway.set_paused_until(
         tenancy_ref: tenancy_ref,
@@ -27,6 +29,10 @@ module UseCases
 
     def code_pauses_case?(code)
       Hackney::Tenancy::ActionCodes::CODES_THAT_PAUSES_CASES.include?(code)
+    end
+
+    def tenancy_not_in_worktray?(tenancy_ref)
+      @get_tenancy.execute(tenancy_ref: tenancy_ref).nil?
     end
   end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When an sms is sent the case is automatically paused for a day to be resynced tomorrow, however if a user sends an sms/email to a customer in credit the case can not be paused as it is not in the worktray and this causes a sentry error. 
https://sentry.io/organizations/london-borough-of-hackney/issues/1623106077/?project=1276456


## Changes proposed in this pull request
<!-- List all the changes -->
- Check if case is in a worktray before pausing the case

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-204

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
