### PR TITLE
Classification refactor - Apply For Outright Possession Warrant

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -11,11 +11,12 @@ module Hackney
           end
 
           def execute
-            actions = []
+            rulesets = [
+              Rulesets::ReviewFailedLetter,
+              Rulesets::ApplyForOutrightPossessionWarrant
+            ]
 
-            actions << Rulesets::ReviewFailedLetter.execute(@case_priority, @criteria, @documents)
-
-            actions << Rulesets::ApplyForOutrightPossessionWarrant.execute(@helpers, @case_priority, @criteria, @documents)
+            actions = rulesets.map { |ruleset| ruleset.execute(@helpers, @case_priority, @criteria, @documents) }
 
             actions << :court_breach_visit if court_breach_visit?
             actions << :court_breach_no_payment if court_breach_no_payment?

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -15,7 +15,7 @@ module Hackney
 
             actions << Rulesets::ReviewFailedLetter.execute(@case_priority, @criteria, @documents)
 
-            actions << :apply_for_outright_possession_warrant if apply_for_outright_possession_warrant?
+            actions << Rulesets::ApplyForOutrightPossessionWarrant.execute(@helpers, @case_priority, @criteria, @documents)
 
             actions << :court_breach_visit if court_breach_visit?
             actions << :court_breach_no_payment if court_breach_no_payment?
@@ -60,17 +60,6 @@ module Hackney
           def validate_wanted_action(wanted_action)
             return false if Hackney::Income::Models::CasePriority.classifications.key?(wanted_action)
             raise ArgumentError, "Tried to classify a case as #{wanted_action}, but this is not on the list of valid classifications."
-          end
-
-          def apply_for_outright_possession_warrant?
-            return false if @helpers.should_prevent_action?
-            return false if @criteria.active_agreement?
-            return false if @criteria.courtdate.blank?
-            return false if @criteria.courtdate.future?
-            return false if @criteria.courtdate < 3.months.ago
-            return false if @criteria.last_communication_action.in?(after_apply_for_outright_possession_actions)
-
-            @criteria.court_outcome.in?(outright_possession_court_outcome_codes)
           end
 
           def court_breach_visit?
@@ -364,19 +353,6 @@ module Hackney
               Hackney::Tenancy::ActionCodes::ADJOURNED_ON_TERMS_COURT_OUTCOME,
               Hackney::Tenancy::ActionCodes::POSTPONED_POSSESSIOON_COURT_OUTCOME,
               Hackney::Tenancy::ActionCodes::SUSPENDED_POSSESSION_COURT_OUTCOME
-            ]
-          end
-
-          def outright_possession_court_outcome_codes
-            [
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
-            ]
-          end
-
-          def after_apply_for_outright_possession_actions
-            [
-              Hackney::Tenancy::ActionCodes::WARRANT_OF_POSSESSION
             ]
           end
 

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -7,6 +7,7 @@ module Hackney
             @criteria = criteria
             @case_priority = case_priority
             @documents = documents
+            @helpers = Helpers.new(case_priority, criteria, documents)
           end
 
           def execute
@@ -62,61 +63,69 @@ module Hackney
           end
 
           def apply_for_outright_possession_warrant?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.active_agreement?
             return false if @criteria.courtdate.blank?
             return false if @criteria.courtdate.future?
             return false if @criteria.courtdate < 3.months.ago
             return false if @criteria.last_communication_action.in?(after_apply_for_outright_possession_actions)
 
-            @criteria.court_outcome.in?(outright_possession_court_outcome_codes) && should_prevent_action?
+            @criteria.court_outcome.in?(outright_possession_court_outcome_codes)
           end
 
           def court_breach_visit?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.courtdate.blank?
             return false unless court_breach_agreement?
 
             @criteria.last_communication_action.in?(court_breach_letter_actions) &&
               last_communication_older_than?(7.days.ago) &&
-              last_communication_newer_than?(3.months.ago) && should_prevent_action?
+              last_communication_newer_than?(3.months.ago)
           end
 
           def court_breach_no_payment?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.courtdate.blank?
             return false unless court_breach_agreement?
             return false if @criteria.days_since_last_payment.to_i < 8
 
             @criteria.last_communication_action.in?(valid_actions_for_court_breach_no_payment) &&
-              last_communication_older_than?(1.week.ago) && should_prevent_action?
+              last_communication_older_than?(1.week.ago)
           end
 
           def update_court_outcome_action?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.courtdate.blank?
             return false if @criteria.courtdate.future?
 
-            @criteria.court_outcome.blank? && should_prevent_action?
+            @criteria.court_outcome.blank?
           end
 
           def court_agreement_letter_action?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.last_communication_action.in?([
               Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
               Hackney::Tenancy::ActionCodes::VISIT_MADE
             ])
 
-            court_breach_agreement? && should_prevent_action?
+            court_breach_agreement?
           end
 
           def breached_agreement?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.most_recent_agreement.blank?
             return false if @criteria.most_recent_agreement[:start_date].blank?
 
-            @criteria.most_recent_agreement[:breached] && should_prevent_action?
+            @criteria.most_recent_agreement[:breached]
           end
 
           def informal_breached_agreement?
-            breached_agreement? && !court_breach_agreement? && should_prevent_action?
+            return false if @helpers.should_prevent_action?
+            breached_agreement? && !court_breach_agreement?
           end
 
           def informal_agreement_breach_letter?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.nosp.served?
             return false if @criteria.last_communication_action.in?([
               Hackney::Tenancy::ActionCodes::INFORMAL_BREACH_LETTER_SENT,
@@ -128,25 +137,28 @@ module Hackney
               return false if last_communication_newer_than?(7.days.ago)
             end
 
-            informal_breached_agreement? && should_prevent_action?
+            informal_breached_agreement?
           end
 
           def informal_breached_after_letter?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.nosp.served?
             return false if @criteria.last_communication_action != Hackney::Tenancy::ActionCodes::INFORMAL_BREACH_LETTER_SENT
             return false if last_communication_newer_than?(7.days.ago)
 
-            informal_breached_agreement? && should_prevent_action?
+            informal_breached_agreement?
           end
 
           def court_breach_agreement?
+            return false if @helpers.should_prevent_action?
             return false unless breached_agreement?
             return false if @criteria.courtdate.blank?
 
-            @criteria.most_recent_agreement[:start_date] > @criteria.courtdate && should_prevent_action?
+            @criteria.most_recent_agreement[:start_date] > @criteria.courtdate
           end
 
           def send_sms?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.courtdate.present?
             return false if @criteria.nosp.served?
@@ -160,10 +172,11 @@ module Hackney
                               last_communication_newer_than?(3.months.ago)
             end
 
-            @criteria.balance >= 5 && should_prevent_action? && no_court_date?
+            @criteria.balance >= 5 && no_court_date?
           end
 
           def send_letter_one?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.weekly_gross_rent.blank?
             return false if @criteria.nosp.served?
@@ -172,10 +185,11 @@ module Hackney
             return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&
                             last_communication_newer_than?(3.months.ago)
 
-            balance_is_in_arrears_by_amount?(10) && should_prevent_action? && no_court_date?
+            balance_is_in_arrears_by_amount?(10) && no_court_date?
           end
 
           def send_letter_two?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.weekly_gross_rent.blank?
 
@@ -187,10 +201,11 @@ module Hackney
             return false if last_communication_newer_than?(14.days.ago)
             return false if last_communication_older_than?(3.months.ago)
 
-            balance_is_in_arrears_by_amount?(10) && should_prevent_action? && no_court_date?
+            balance_is_in_arrears_by_amount?(10) && no_court_date?
           end
 
           def send_nosp?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.weekly_gross_rent.blank?
 
@@ -205,10 +220,11 @@ module Hackney
               return false if last_communication_newer_than?(1.week.ago)
             end
 
-            balance_is_in_arrears_by_number_of_weeks?(4) && should_prevent_action?
+            balance_is_in_arrears_by_number_of_weeks?(4)
           end
 
           def send_court_warning_letter?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.weekly_gross_rent.blank?
 
@@ -219,10 +235,11 @@ module Hackney
             return false unless @criteria.nosp.valid?
             return false unless @criteria.nosp.active?
 
-            balance_is_in_arrears_by_number_of_weeks?(4) && should_prevent_action?
+            balance_is_in_arrears_by_number_of_weeks?(4)
           end
 
           def apply_for_court_date?
+            return false if @helpers.should_prevent_action?
             return false if @criteria.balance.blank?
             return false if @criteria.weekly_gross_rent.blank?
             return false if @criteria.active_agreement?
@@ -236,7 +253,7 @@ module Hackney
 
             return false if @criteria.courtdate.present? && @criteria.courtdate > @criteria.last_communication_date
 
-            balance_is_in_arrears_by_number_of_weeks?(4) && should_prevent_action?
+            balance_is_in_arrears_by_number_of_weeks?(4)
           end
 
           def case_has_eviction_date?
@@ -253,10 +270,6 @@ module Hackney
 
           def case_paused?
             @case_priority.paused?
-          end
-
-          def should_prevent_action?
-            !(case_has_eviction_date? || court_date_in_future? || case_paused?)
           end
 
           def last_communication_older_than?(date)

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -9,7 +9,7 @@ module Hackney
             @documents = documents
           end
 
-          def case_paused
+          def case_paused?
             @case_priority.paused?
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -1,0 +1,19 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        class Helpers
+          def initialize(case_priority, criteria, documents)
+            @criteria = criteria
+            @case_priority = case_priority
+            @documents = documents
+          end
+
+          def case_paused
+            @case_priority.paused?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -20,6 +20,10 @@ module Hackney
           def court_date_in_future?
             @criteria.courtdate.present? && @criteria.courtdate.future?
           end
+
+          def should_prevent_action?
+            case_has_eviction_date? || court_date_in_future? || case_paused?
+          end
         end
       end
     end

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -16,6 +16,10 @@ module Hackney
           def case_has_eviction_date?
             @criteria.eviction_date.present?
           end
+
+          def court_date_in_future?
+            @criteria.courtdate.present? && @criteria.courtdate.future?
+          end
         end
       end
     end

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -2,13 +2,7 @@ module Hackney
   module Income
     module TenancyClassification
       module V2
-        class Helpers
-          def initialize(case_priority, criteria, documents)
-            @criteria = criteria
-            @case_priority = case_priority
-            @documents = documents
-          end
-
+        module Helpers
           def case_paused?
             @case_priority.paused?
           end

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -12,6 +12,10 @@ module Hackney
           def case_paused?
             @case_priority.paused?
           end
+
+          def case_has_eviction_date?
+            @criteria.eviction_date.present?
+          end
         end
       end
     end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
@@ -1,0 +1,43 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class ApplyForOutrightPossessionWarrant
+            class << self
+              def execute(helpers, case_priority, criteria, documents)
+                return :apply_for_outright_possession_warrant if action_valid(helpers, case_priority, criteria, documents)
+              end
+
+              private
+
+              def action_valid(helpers, case_priority, criteria, documents)
+                return false if helpers.should_prevent_action?
+                return false if criteria.active_agreement?
+                return false if criteria.courtdate.blank?
+                return false if criteria.courtdate.future?
+                return false if criteria.courtdate < 3.months.ago
+                return false if criteria.last_communication_action.in?(blocking_communication_actions)
+
+                criteria.court_outcome.in?(prerequisite_court_outcomes_for_action)
+              end
+
+              def prerequisite_court_outcomes_for_action
+                [
+                  Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+                  Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+                ]
+              end
+
+              def blocking_communication_actions
+                [
+                  Hackney::Tenancy::ActionCodes::WARRANT_OF_POSSESSION
+                ]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
@@ -3,37 +3,35 @@ module Hackney
     module TenancyClassification
       module V2
         module Rulesets
-          class ApplyForOutrightPossessionWarrant
-            class << self
-              def execute(helpers, case_priority, criteria, documents)
-                return :apply_for_outright_possession_warrant if action_valid(helpers, case_priority, criteria, documents)
-              end
+          class ApplyForOutrightPossessionWarrant < BaseRuleset
+            def execute
+              return :apply_for_outright_possession_warrant if action_valid
+            end
 
-              private
+            private
 
-              def action_valid(helpers, case_priority, criteria, documents)
-                return false if helpers.should_prevent_action?
-                return false if criteria.active_agreement?
-                return false if criteria.courtdate.blank?
-                return false if criteria.courtdate.future?
-                return false if criteria.courtdate < 3.months.ago
-                return false if criteria.last_communication_action.in?(blocking_communication_actions)
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.active_agreement?
+              return false if @criteria.courtdate.blank?
+              return false if @criteria.courtdate.future?
+              return false if @criteria.courtdate < 3.months.ago
+              return false if @criteria.last_communication_action.in?(blocking_communication_actions)
 
-                criteria.court_outcome.in?(prerequisite_court_outcomes_for_action)
-              end
+              @criteria.court_outcome.in?(prerequisite_court_outcomes_for_action)
+            end
 
-              def prerequisite_court_outcomes_for_action
-                [
-                  Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-                  Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
-                ]
-              end
+            def prerequisite_court_outcomes_for_action
+              [
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+              ]
+            end
 
-              def blocking_communication_actions
-                [
-                  Hackney::Tenancy::ActionCodes::WARRANT_OF_POSSESSION
-                ]
-              end
+            def blocking_communication_actions
+              [
+                Hackney::Tenancy::ActionCodes::WARRANT_OF_POSSESSION
+              ]
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
@@ -1,0 +1,19 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class BaseRuleset
+            include V2::Helpers
+
+            def initialize(case_priority, criteria, documents)
+              @case_priority = case_priority
+              @criteria = criteria
+              @documents = documents
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
@@ -5,7 +5,7 @@ module Hackney
         module Rulesets
           class ReviewFailedLetter
             class << self
-              def execute(case_priority, criteria, documents)
+              def execute(helpers, case_priority, criteria, documents)
                 return :review_failed_letter if action_valid(case_priority, criteria, documents)
               end
 

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
@@ -6,8 +6,15 @@ module Hackney
           class ReviewFailedLetter
             class << self
               def execute(case_priority, criteria, documents)
-                return nil if documents.empty?
-                return :review_failed_letter if documents.most_recent.failed? && documents.most_recent.income_collection?
+                return :review_failed_letter if action_valid(case_priority, criteria, documents)
+              end
+
+              private
+
+              def action_valid(case_priority, criteria, documents)
+                return false if documents.empty?
+
+                documents.most_recent.failed? && documents.most_recent.income_collection?
               end
             end
           end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/review_failed_letter.rb
@@ -3,19 +3,17 @@ module Hackney
     module TenancyClassification
       module V2
         module Rulesets
-          class ReviewFailedLetter
-            class << self
-              def execute(helpers, case_priority, criteria, documents)
-                return :review_failed_letter if action_valid(case_priority, criteria, documents)
-              end
+          class ReviewFailedLetter < BaseRuleset
+            def execute
+              return :review_failed_letter if action_valid
+            end
 
-              private
+            private
 
-              def action_valid(case_priority, criteria, documents)
-                return false if documents.empty?
+            def action_valid
+              return false if @documents.empty?
 
-                documents.most_recent.failed? && documents.most_recent.income_collection?
-              end
+              @documents.most_recent.failed? && @documents.most_recent.income_collection?
             end
           end
         end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::TenancyClassification::V2::Helpers do
-  describe 'case_paused' do
-    subject { helpers.case_paused }
+  describe 'case_paused?' do
+    subject { helpers.case_paused? }
 
     let(:helpers) { described_class.new(case_priority, nil, nil) }
 
@@ -11,6 +11,14 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
 
       it 'returns true' do
         expect(subject).to eq(true)
+      end
+    end
+
+    context 'when a case was paused in the past' do
+      let(:case_priority) { build(:case_priority, is_paused_until: 7.days.ago) }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
       end
     end
   end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -1,10 +1,18 @@
 require 'rails_helper'
 
 describe Hackney::Income::TenancyClassification::V2::Helpers do
+  let(:case_priority) { build(:case_priority, is_paused_until: nil) }
+  let(:eviction_date) { nil }
+  let(:criteria) {
+    Stubs::StubCriteria.new(
+      eviction_date: eviction_date
+    )
+  }
+
+  let(:helpers) { described_class.new(case_priority, criteria, nil) }
+
   describe 'case_paused?' do
     subject { helpers.case_paused? }
-
-    let(:helpers) { described_class.new(case_priority, nil, nil) }
 
     context 'when a case is paused for seven days' do
       let(:case_priority) { build(:case_priority, is_paused_until: 7.days.from_now) }
@@ -16,6 +24,34 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
 
     context 'when a case was paused in the past' do
       let(:case_priority) { build(:case_priority, is_paused_until: 7.days.ago) }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
+  describe 'case_has_eviction_date?' do
+    subject { helpers.case_has_eviction_date? }
+
+    context 'when the criteria has a future eviction date' do
+      let(:eviction_date) { 6.days.from_now }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the criteria has a past eviction date' do
+      let(:eviction_date) { 6.days.ago }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the criteria does not have a eviction date' do
+      let(:eviction_date) { nil }
 
       it 'returns false' do
         expect(subject).to eq(false)

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 describe Hackney::Income::TenancyClassification::V2::Helpers do
   let(:case_priority) { build(:case_priority, is_paused_until: nil) }
   let(:eviction_date) { nil }
+  let(:courtdate) { nil }
   let(:criteria) {
     Stubs::StubCriteria.new(
-      eviction_date: eviction_date
+      eviction_date: eviction_date,
+      courtdate: courtdate
     )
   }
 
@@ -52,6 +54,34 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
 
     context 'when the criteria does not have a eviction date' do
       let(:eviction_date) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
+  describe 'court_date_in_future' do
+    subject { helpers.court_date_in_future? }
+
+    context 'when the criteria has a future court date' do
+      let(:courtdate) { 6.days.from_now }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the criteria has a past court date' do
+      let(:courtdate) { 6.days.ago }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the criteria does not have a court date' do
+      let(:courtdate) { nil }
 
       it 'returns false' do
         expect(subject).to eq(false)

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Hackney::Income::TenancyClassification::V2::Helpers do
+  describe 'case_paused' do
+    subject { helpers.case_paused }
+
+    let(:helpers) { described_class.new(case_priority, nil, nil) }
+
+    context 'when a case is paused for seven days' do
+      let(:case_priority) { build(:case_priority, is_paused_until: 7.days.from_now) }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -88,4 +88,42 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
       end
     end
   end
+
+  describe 'should_prevent_action?' do
+    subject { helpers.should_prevent_action? }
+
+    context 'when the case does not have a future court date, and does not have an eviction date, and is not paused' do
+      let(:courtdate) { nil }
+      let(:eviction_date) { nil }
+      let(:case_priority) { build(:case_priority, is_paused_until: nil) }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the case does have a future court date' do
+      let(:courtdate) { 7.days.from_now }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the case does have an eviction date' do
+      let(:eviction_date) { 7.days.from_now }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the case is paused' do
+      let(:case_priority) { build(:case_priority, is_paused_until: 7.days.from_now) }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe Hackney::Income::TenancyClassification::V2::Helpers do
+  class HelperClass
+    include Hackney::Income::TenancyClassification::V2::Helpers
+
+    def initialize(case_priority, criteria, documents)
+      @case_priority = case_priority
+      @criteria = criteria
+      @documents = documents
+    end
+  end
+
   let(:case_priority) { build(:case_priority, is_paused_until: nil) }
   let(:eviction_date) { nil }
   let(:courtdate) { nil }
@@ -11,7 +21,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     )
   }
 
-  let(:helpers) { described_class.new(case_priority, criteria, nil) }
+  let(:helpers) { HelperClass.new(case_priority, criteria, nil) }
 
   describe 'case_paused?' do
     subject { helpers.case_paused? }


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->

Slowly slowly refactoring out the V2 engine into separate files, with goal of making the classification extensible.

We've identified a helper pattern that you can see in the code. My vision is that the helpers will be the only methods that each of the rulesets use, instead of directly querying the three objects as they do currently.

Once we've moved all the helpers, and added any additional helpers required, the helper methods should allow us to write DSL-like methods in the rulesets

## Changes proposed in this pull request
<!-- List all the changes -->
* Introduce helpers file (TDD :tada:) to slowly migrate helpers into
* Decouple logic about whether ReviewFailedLetter is a valid action, and returning the action
* Refactor out Apply For Outright Possession Warrant into separate file
* Loop over array of classes to determine next actions


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does it feel like the ruby way of doing things?

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
[MAAP-201](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&selectedIssue=MAAP-201)
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
