### PR TITLE
Move out UpdateCourtOutcomeAction logic from classifier

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -29,7 +29,6 @@ module Hackney
 
             actions << :send_court_warning_letter if send_court_warning_letter?
             actions << :apply_for_court_date if apply_for_court_date?
-            # actions << :update_court_outcome_action if update_court_outcome_action?
 
             actions << :send_informal_agreement_breach_letter if informal_agreement_breach_letter?
             actions << :informal_breached_after_letter if informal_breached_after_letter?

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -15,7 +15,8 @@ module Hackney
             rulesets = [
               Rulesets::ApplyForOutrightPossessionWarrant,
               Rulesets::ReviewFailedLetter,
-              Rulesets::SendSMS
+              Rulesets::SendSMS,
+              Rulesets::UpdateCourtOutcomeAction
             ]
 
             actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents).execute }
@@ -28,7 +29,7 @@ module Hackney
 
             actions << :send_court_warning_letter if send_court_warning_letter?
             actions << :apply_for_court_date if apply_for_court_date?
-            actions << :update_court_outcome_action if update_court_outcome_action?
+            # actions << :update_court_outcome_action if update_court_outcome_action?
 
             actions << :send_informal_agreement_breach_letter if informal_agreement_breach_letter?
             actions << :informal_breached_after_letter if informal_breached_after_letter?
@@ -86,14 +87,6 @@ module Hackney
 
             @criteria.last_communication_action.in?(valid_actions_for_court_breach_no_payment) &&
               last_communication_older_than?(1.week.ago)
-          end
-
-          def update_court_outcome_action?
-            return false if should_prevent_action?
-            return false if @criteria.courtdate.blank?
-            return false if @criteria.courtdate.future?
-
-            @criteria.court_outcome.blank?
           end
 
           def court_agreement_letter_action?

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/update_court_outcome_action.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/update_court_outcome_action.rb
@@ -1,0 +1,25 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class UpdateCourtOutcomeAction < BaseRuleset
+            def execute
+              return :update_court_outcome_action if action_valid
+            end
+
+            private
+
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.courtdate.blank?
+              return false if @criteria.courtdate.future?
+
+              @criteria.court_outcome.blank?
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
"_Slowly slowly refactoring out the V2 engine into separate files, with goal of making the classification extensible_." - @antonyoneill 

## Changes proposed in this pull request
- Refactor out **Update Court Outcome Action** into separate file

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
[MAAP-201](https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&selectedIssue=MAAP-201)
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated