### PR TITLE
WIP Update agreements fields in api docs

### DIFF
--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -85,7 +85,7 @@ definitions:
       frequency:
         type: string
         example: 'weekly'
-      state:
+      currentState:
         type: string
         example: 'active'
       history:

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -28,7 +28,7 @@ paths:
           description: Agreement not found
       tags:
         - agreements
-  /agreement/{tenancy_ref}:
+  /agreements/{tenancy_ref}:
     post:
       summary: 'Create an agreement for the tenancy id'
       description: Create agreement with specified tenancy id


### PR DESCRIPTION
## Context
We want to add clear documentation to the income-api so that other services can easily use it.
There were a few imperfections in the previous PR https://github.com/LBHackney-IT/lbh-income-api/pull/396, this PR is to address those. 

## Changes proposed in this pull request
- Update the POST route
- Update `state` to `currentState` to be consistent with the rails model

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Renaming the `POST` `/agreements/{tenancy_ref}` caused some issues, because it uses the same endpoint as the `GET /agreements/{tenancy_ref}`, initially I used singular because you create a single agreement at a time. Should we keep the old one? 
![image](https://user-images.githubusercontent.com/22743709/84179294-a428e980-aa7d-11ea-9d85-9c6b9929241a.png)

Let me know if you see any other issues!

