### PR TITLE
move letter one and two into separate ruleset files

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -16,6 +16,8 @@ module Hackney
               Rulesets::ApplyForOutrightPossessionWarrant,
               Rulesets::ReviewFailedLetter,
               Rulesets::SendSMS,
+              Rulesets::SendLetterOne,
+              Rulesets::SendLetterTwo,
               Rulesets::UpdateCourtOutcomeAction,
               Rulesets::CourtBreachVisit
             ]
@@ -34,9 +36,6 @@ module Hackney
             actions << :informal_breached_after_letter if informal_breached_after_letter?
 
             actions << :send_NOSP if send_nosp?
-
-            actions << :send_letter_two if send_letter_two?
-            actions << :send_letter_one if send_letter_one?
 
             actions.compact!
 
@@ -118,35 +117,6 @@ module Hackney
             informal_breached_agreement?
           end
 
-          def send_letter_one?
-            return false if should_prevent_action?
-            return false if @criteria.balance.blank?
-            return false if @criteria.weekly_gross_rent.blank?
-            return false if @criteria.nosp.served?
-            return false if @criteria.active_agreement?
-
-            return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&
-                            last_communication_newer_than?(3.months.ago)
-
-            balance_is_in_arrears_by_amount?(10) && no_court_date?
-          end
-
-          def send_letter_two?
-            return false if should_prevent_action?
-            return false if @criteria.balance.blank?
-            return false if @criteria.weekly_gross_rent.blank?
-
-            return false if @criteria.active_agreement?
-            return false if @criteria.nosp.served?
-
-            return false unless @criteria.last_communication_action.in?(valid_actions_for_letter_two_to_progress)
-
-            return false if last_communication_newer_than?(14.days.ago)
-            return false if last_communication_older_than?(3.months.ago)
-
-            balance_is_in_arrears_by_amount?(10) && no_court_date?
-          end
-
           def send_nosp?
             return false if should_prevent_action?
             return false if @criteria.balance.blank?
@@ -215,22 +185,6 @@ module Hackney
             balance_with_1_week_grace >= arrear_accumulation_by_number_weeks(weeks)
           end
 
-          def balance_is_in_arrears_by_amount?(amount)
-            balance_with_1_week_grace >= amount
-          end
-
-          def balance_with_1_week_grace
-            @criteria.balance - calculated_grace_amount
-          end
-
-          def calculated_grace_amount
-            grace_amount = @criteria.weekly_gross_rent + @criteria.total_payment_amount_in_week
-
-            return 0 if grace_amount.negative?
-
-            grace_amount
-          end
-
           def arrear_accumulation_by_number_weeks(weeks)
             @criteria.weekly_gross_rent * weeks
           end
@@ -238,27 +192,6 @@ module Hackney
           def valid_actions_for_court_breach_no_payment
             [
               Hackney::Tenancy::ActionCodes::VISIT_MADE
-            ]
-          end
-
-          def after_letter_one_actions
-            [
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT_2,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT_3,
-              Hackney::Tenancy::ActionCodes::S0A_ALTERNATIVE_LETTER,
-              Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
-            ]
-          end
-
-          def valid_actions_for_letter_two_to_progress
-            [
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
-              Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH
             ]
           end
 

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -54,6 +54,22 @@ module Hackney
               Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT
             ]
           end
+
+          def balance_is_in_arrears_by_amount?(amount)
+            balance_with_1_week_grace >= amount
+          end
+
+          def balance_with_1_week_grace
+            @criteria.balance - calculated_grace_amount
+          end
+
+          def calculated_grace_amount
+            grace_amount = @criteria.weekly_gross_rent + @criteria.total_payment_amount_in_week
+
+            return 0 if grace_amount.negative?
+
+            grace_amount
+          end
         end
       end
     end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_one.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_one.rb
@@ -1,0 +1,44 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class SendLetterOne < BaseRuleset
+            def execute
+              return :send_letter_one if action_valid
+            end
+
+            private
+
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.balance.blank?
+              return false if @criteria.weekly_gross_rent.blank?
+              return false if @criteria.nosp.served?
+              return false if @criteria.active_agreement?
+
+              return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&
+                              last_communication_newer_than?(3.months.ago)
+
+              balance_is_in_arrears_by_amount?(10) && no_court_date?
+            end
+
+            def after_letter_one_actions
+              [
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT_2,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH_ALT_3,
+                Hackney::Tenancy::ActionCodes::S0A_ALTERNATIVE_LETTER,
+                Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
@@ -1,0 +1,40 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class SendLetterTwo < BaseRuleset
+            def execute
+              return :send_letter_two if action_valid
+            end
+
+            private
+
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.balance.blank?
+              return false if @criteria.weekly_gross_rent.blank?
+
+              return false if @criteria.active_agreement?
+              return false if @criteria.nosp.served?
+
+              return false unless @criteria.last_communication_action.in?(valid_actions_for_letter_two_to_progress)
+
+              return false if last_communication_newer_than?(14.days.ago)
+              return false if last_communication_older_than?(3.months.ago)
+
+              balance_is_in_arrears_by_amount?(10) && no_court_date?
+            end
+
+            def valid_actions_for_letter_two_to_progress
+              [
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1,
+                Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_1_UH
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
@@ -145,22 +145,6 @@ shared_examples 'TenancyClassification Contract' do
     let(:action_codes) { Hackney::Tenancy::ActionCodes::FOR_UH_CRITERIA_SQL }
     let(:unused_action_codes_required_for_uh_criteria_sql) { result - action_codes }
 
-    describe '#after_letter_one_actions' do
-      let(:result) { assign_classification.send(:after_letter_one_actions) }
-
-      it 'contains Letter 2 UH code that is used for an edge case in the UH Criteria SQL' do
-        expect(unused_action_codes_required_for_uh_criteria_sql).to eq([Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2_UH])
-      end
-    end
-
-    describe '#valid_actions_for_letter_two_to_progress' do
-      let(:result) { assign_classification.send(:valid_actions_for_letter_two_to_progress) }
-
-      it 'contains action codes within the UH Criteria Codes' do
-        expect(unused_action_codes_required_for_uh_criteria_sql).to be_empty
-      end
-    end
-
     describe '#valid_actions_for_nosp_to_progress' do
       let(:result) { assign_classification.send(:valid_actions_for_nosp_to_progress) }
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Slowly slowly refactoring out the V2 engine into separate files, with goal of making the classification extensible.

## Changes proposed in this pull request
<!-- List all the changes -->
- move letter one and two into separate ruleset files
- test helper methods

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-201
## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
