### PR TITLE
Classification Refactor - Move action code helpers

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -138,12 +138,6 @@ module Hackney
             @case_priority.paused?
           end
 
-          def valid_actions_for_court_breach_no_payment
-            [
-              Hackney::Tenancy::ActionCodes::VISIT_MADE
-            ]
-          end
-
           def after_court_warning_letter_actions
             [
               Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -57,18 +57,6 @@ module Hackney
             @criteria.weekly_gross_rent * weeks
           end
 
-          def court_breach_letter_actions
-            [
-              Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT
-            ]
-          end
-
-          def valid_actions_for_court_breach_no_payment
-            [
-              Hackney::Tenancy::ActionCodes::VISIT_MADE
-            ]
-          end
-
           def balance_is_in_arrears_by_amount?(amount)
             balance_with_1_week_grace >= amount
           end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_no_payment.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_no_payment.rb
@@ -19,6 +19,12 @@ module Hackney
               @criteria.last_communication_action.in?(valid_actions_for_court_breach_no_payment) &&
                 last_communication_older_than?(1.week.ago)
             end
+
+            def valid_actions_for_court_breach_no_payment
+              [
+                Hackney::Tenancy::ActionCodes::VISIT_MADE
+              ]
+            end
           end
         end
       end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_visit.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_visit.rb
@@ -19,6 +19,12 @@ module Hackney
                 last_communication_older_than?(7.days.ago) &&
                 last_communication_newer_than?(3.months.ago)
             end
+
+            def court_breach_letter_actions
+              [
+                Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT
+              ]
+            end
           end
         end
       end

--- a/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
@@ -153,22 +153,6 @@ shared_examples 'TenancyClassification Contract' do
       end
     end
 
-    describe '#court_breach_letter_actions' do
-      let(:result) { assign_classification.send(:court_breach_letter_actions) }
-
-      it 'contains action codes within the UH Criteria Codes' do
-        expect(result - action_codes).to be_empty
-      end
-    end
-
-    describe '#valid_actions_for_court_breach_no_payment' do
-      let(:result) { assign_classification.send(:valid_actions_for_court_breach_no_payment) }
-
-      it 'contains action codes within the UH Criteria Codes' do
-        expect(result - action_codes).to be_empty
-      end
-    end
-
     describe '#valid_actions_for_apply_for_court_date_to_progress' do
       let(:result) { assign_classification.send(:valid_actions_for_apply_for_court_date_to_progress) }
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Due to uncertainty on how to test private action code helpers and to ensure consistency with other classification action code helpers, for now we have decided to remove the tests which test these helpers until we can find a better way to test these now private helpers.
## Changes proposed in this pull request
<!-- List all the changes -->
* Refactor out valid_actions_for_court_breach_no_payment from helpers file into its associated classification file
* Refactor out court_breach_letter_actions from helpers file into its associated classification file
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-226
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
