### PR TITLE
Classification refactor - Send Court Warning Letter

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_court_warning_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_court_warning_letter.rb
@@ -1,0 +1,38 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class SendCourtWarningLetter < BaseRuleset
+            def execute
+              return :send_court_warning_letter if action_valid
+            end
+
+            private
+
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.balance.blank?
+              return false if @criteria.weekly_gross_rent.blank?
+
+              return false if @criteria.active_agreement?
+
+              return false if @criteria.last_communication_action.in?(after_court_warning_letter_actions)
+
+              return false unless @criteria.nosp.valid?
+              return false unless @criteria.nosp.active?
+
+              balance_is_in_arrears_by_number_of_weeks?(4)
+            end
+
+            def after_court_warning_letter_actions
+              [
+                Hackney::Tenancy::ActionCodes::COURT_WARNING_LETTER_SENT
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
@@ -145,14 +145,6 @@ shared_examples 'TenancyClassification Contract' do
     let(:action_codes) { Hackney::Tenancy::ActionCodes::FOR_UH_CRITERIA_SQL }
     let(:unused_action_codes_required_for_uh_criteria_sql) { result - action_codes }
 
-    describe '#after_court_warning_letter_actions' do
-      let(:result) { assign_classification.send(:after_court_warning_letter_actions) }
-
-      it 'contains action codes within the UH Criteria Codes' do
-        expect(unused_action_codes_required_for_uh_criteria_sql).to be_empty
-      end
-    end
-
     describe '#valid_actions_for_apply_for_court_date_to_progress' do
       let(:result) { assign_classification.send(:valid_actions_for_apply_for_court_date_to_progress) }
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Refactoring out the V2 engine into separate files allowing it to be more extensible when adding new classifications.
## Changes proposed in this pull request
<!-- List all the changes -->
* Refactor out Send Court Warning Letter classification into separate file
* Remove classifier tests for after_court_warning_letter_actions

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-201

For the removed tests:
https://hackney.atlassian.net/browse/MAAP-226
## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
