### PR TITLE
refactor send informal agreement breach letter classification

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_informal_agreement_breach_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_informal_agreement_breach_letter.rb
@@ -1,0 +1,33 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class SendInformalAgreementBreachLetter < BaseRuleset
+            def execute
+              return :send_informal_agreement_breach_letter if action_valid
+            end
+
+            private
+
+            def action_valid
+              return false if should_prevent_action?
+              return false if @criteria.nosp.served?
+              return false if @criteria.last_communication_action.in?([
+                Hackney::Tenancy::ActionCodes::INFORMAL_BREACH_LETTER_SENT,
+                Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
+                Hackney::Tenancy::ActionCodes::VISIT_MADE
+              ])
+
+              if @criteria.last_communication_date.present?
+                return false if last_communication_newer_than?(7.days.ago)
+              end
+
+              informal_breached_agreement?
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Slowly refactoring out the V2 engine into separate files, with goal of making the classification extensible.

## Changes proposed in this pull request
<!-- List all the changes -->
Moved out the send informal agreement breach letter classification 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-201

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
