### PR TITLE
Remove old helpers from V2 classifier

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -61,18 +61,6 @@ module Hackney
             raise ArgumentError, "Tried to classify a case as #{wanted_action}, but this is not on the list of valid classifications."
           end
 
-          def case_has_eviction_date?
-            @criteria.eviction_date.present?
-          end
-
-          def court_date_in_future?
-            @criteria.courtdate&.future?
-          end
-
-          def case_paused?
-            @case_priority.paused?
-          end
-
           def active_agreement_court_outcomes
             [
               Hackney::Tenancy::ActionCodes::ADJOURNED_ON_TERMS_COURT_OUTCOME,


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Old helpers which were already moved into the helper file were left on the V2 classifier file, these have been removed to get rid of the unused code and avoid confusion. 
## Changes proposed in this pull request
<!-- List all the changes -->
* Remove case_has_eviction_date?, court_date_in_future? & case_paused? from V2 classifier file
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
