### PR TITLE
Set db env var to prevent environment mismatch

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -12,6 +12,12 @@ then
   dockerize -wait "$DATABASE_SERVICE" -timeout 1m
 
   # Setup the database - safe if it is already configured
+
+  if [ "$RAILS_ENV" = "development" ]
+  then
+    rails db:environment:set RAILS_ENV=development
+  fi
+
   rails db:setup
 fi
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Few of us were receiveing an error when setting up the project:
```
ActiveRecord::EnvironmentMismatchError: 
You are attempting to modify a database that was last run in `test` environment.
You are running in `development` environment. 
If you are sure you want to continue, first set the environment using:
        bin/rails db:environment:set RAILS_ENV=development
```

Thank you @antonyoneill for helping by sending this:
`docker-compose run --entrypoint='bin/rails db:environment:set RAILS_ENV=development' app`
## Changes proposed in this pull request
<!-- List all the changes -->
The change sets the db environment to `development` which makes everything happy.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
This fixes the issue I was having, but I still don't fully understand why this popped up - so if anyone could explain it like I'm 5, that might be good 😬 

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
