### PR TITLE
Rollback Ruby for Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1
+FROM ruby:2.5.3
 
 ARG RAILS_ENV=development
 WORKDIR /app
@@ -6,7 +6,7 @@ WORKDIR /app
 # 50 MB stack needed in sync worker thread
 ENV RUBY_THREAD_VM_STACK_SIZE=50000000
 
-RUN wget https://web.archive.org/web/20191028054637/http://www.freetds.org/files/stable/freetds-1.00.27.tar.gz && \
+RUN wget -q https://www.freetds.org/files/stable/freetds-1.00.27.tar.gz && \
   tar -xzf freetds-1.00.27.tar.gz && \
   cd freetds-1.00.27 && \
   ./configure --prefix=/usr/local --with-tdsver=7.3 && \

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'aws-sdk-s3'
 gem 'loofah', '>= 2.2.3'
 gem 'rack', '>= 2.0.6'
 
-ruby '2.7.1'
+ruby '2.5.3'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2'
 # Use sqlite3 as the database for Active Record


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We have a fairly significant issue in that we are unable to connect to Universal Housing from the income api.

I believe this is due to TLS cipher changes between the underlying base operating system provided by `ruby:2.5.3` and `ruby:2.7.1` in that the OS has changed from `stretch` to `buster`. 

The connection error that we have been witnessing has been described in this github issue https://github.com/rails-sqlserver/tiny_tds/issues/441 and I have been able to confirm locally that with stretch we are able to connect to UH.

## Changes proposed in this pull request
<!-- List all the changes -->
* Temporary rollback of the ruby version upgrade from #388 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
* I want to see the tests pass on this, as I'm not sure we've used any new syntax that would not be valid in 2.5.3.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
