### PR TITLE
Update get agreements response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.3

--- a/app/controllers/agreement_response_helper.rb
+++ b/app/controllers/agreement_response_helper.rb
@@ -9,6 +9,7 @@ module AgreementResponseHelper
       startDate: agreement.start_date,
       frequency: agreement.frequency,
       currentState: agreement.current_state,
+      createdAt: agreement.created_at.strftime('%F'),
       history: map_agreement_state_history(agreement.agreement_states)
     }
   end

--- a/app/controllers/agreement_response_helper.rb
+++ b/app/controllers/agreement_response_helper.rb
@@ -10,6 +10,7 @@ module AgreementResponseHelper
       frequency: agreement.frequency,
       currentState: agreement.current_state,
       createdAt: agreement.created_at.strftime('%F'),
+      createdBy: agreement.created_by,
       history: map_agreement_state_history(agreement.agreement_states)
     }
   end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -21,6 +21,7 @@ class AgreementsController < ApplicationController
       amount: params.fetch(:amount),
       start_date: params.fetch(:start_date),
       frequency: params.fetch(:frequency)
+      # created_by: params.fetch(:created_by)
     }
 
     created_agreement = income_use_case_factory.create_agreement.execute(new_agreement_params: agreement_params)

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -20,8 +20,8 @@ class AgreementsController < ApplicationController
       agreement_type: params.fetch(:agreement_type),
       amount: params.fetch(:amount),
       start_date: params.fetch(:start_date),
-      frequency: params.fetch(:frequency)
-      # created_by: params.fetch(:created_by)
+      frequency: params.fetch(:frequency),
+      created_by: params.fetch(:created_by)
     }
 
     created_agreement = income_use_case_factory.create_agreement.execute(new_agreement_params: agreement_params)

--- a/db/migrate/20200630111144_add_created_by_to_agreements_table.rb
+++ b/db/migrate/20200630111144_add_created_by_to_agreements_table.rb
@@ -1,0 +1,5 @@
+class AddCreatedByToAgreementsTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :agreements, :created_by, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_09_111305) do
+ActiveRecord::Schema.define(version: 2020_06_30_111144) do
 
   create_table "agreement_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "agreement_id"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2020_06_09_111305) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "tenancy_ref", null: false
+    t.string "created_by", null: false
   end
 
   create_table "case_priorities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -88,6 +88,12 @@ definitions:
       currentState:
         type: string
         example: 'live'
+      createdBy:
+        type: string
+        example: 'Joe Bloggs'
+      createdAt:
+        type: string
+        format: date
       history:
         type: array
         items: 

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -11,6 +11,7 @@ module Hackney
           amount: new_agreement_params[:amount],
           start_date: new_agreement_params[:start_date],
           frequency: new_agreement_params[:frequency],
+          created_by: new_agreement_params[:created_by],
           current_state: 'live'
         }
 

--- a/spec/lib/hackney/income/create_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_agreement_spec.rb
@@ -8,6 +8,7 @@ describe Hackney::Income::CreateAgreement do
   let(:amount) { Faker::Commerce.price(range: 10...100) }
   let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
   let(:frequency) { 'weekly' }
+  let(:created_by) { Faker::Name.name }
 
   let(:existing_agreement_params) do
     {
@@ -15,7 +16,8 @@ describe Hackney::Income::CreateAgreement do
       agreement_type: 'formal',
       amount: Faker::Commerce.price(range: 10...100),
       start_date: Faker::Date.between(from: 4.days.ago, to: Date.today),
-      frequency: frequency
+      frequency: frequency,
+      created_by: created_by
     }
   end
 
@@ -25,7 +27,8 @@ describe Hackney::Income::CreateAgreement do
       agreement_type: agreement_type,
       amount: amount,
       start_date: start_date,
-      frequency: frequency
+      frequency: frequency,
+      created_by: created_by
     }
   end
 
@@ -45,6 +48,7 @@ describe Hackney::Income::CreateAgreement do
       expect(created_agreement.frequency).to eq(frequency)
       expect(created_agreement.current_state).to eq('live')
       expect(created_agreement.starting_balance).to eq(100)
+      expect(created_agreement.created_by).to eq(created_by)
     end
   end
 

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -18,6 +18,7 @@ describe Hackney::Income::ViewAgreements do
     let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     let(:frequency) { 'weekly' }
     let(:current_state) { 'live' }
+    let(:created_by) { Faker::Name.name }
     let(:agreement_params) do
       {
         tenancy_ref: tenancy_ref,
@@ -26,7 +27,8 @@ describe Hackney::Income::ViewAgreements do
         amount: amount,
         start_date: start_date,
         frequency: frequency,
-        current_state: current_state
+        current_state: current_state,
+        created_by: created_by
       }
     end
 
@@ -43,6 +45,7 @@ describe Hackney::Income::ViewAgreements do
       expect(response.first.amount).to eq(amount)
       expect(response.first.start_date).to eq(start_date)
       expect(response.first.frequency).to eq(frequency)
+      expect(response.first.created_by).to eq(created_by)
       expect(response.first.current_state).to eq(nil)
     end
   end

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::Models::Agreement, type: :model do
+  let(:user_name) { Faker::Name.name }
+
   it 'includes the fields for a formal/informal agreement' do
     agreement = described_class.new
 
@@ -11,6 +13,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
       'frequency',
       'current_state',
       'start_date',
+      'created_by',
       'created_at',
       'updated_at',
       'tenancy_ref',
@@ -19,7 +22,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   it 'can have an associated agreement_state' do
-    agreement = described_class.create(tenancy_ref: '123')
+    agreement = described_class.create(tenancy_ref: '123', created_by: user_name)
     Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'live')
 
     expect(described_class.first.agreement_states.first).to be_a Hackney::Income::Models::AgreementState
@@ -53,14 +56,13 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   describe 'current_state' do
-    it 'returns nil if there are no associated agreement states' do
-      agreement = described_class.create(tenancy_ref: '123')
+    let(:agreement) { described_class.create(tenancy_ref: '123', created_by: user_name) }
 
+    it 'returns nil if there are no associated agreement states' do
       expect(agreement.current_state).to be_nil
     end
 
     it 'returns the latest agreement state' do
-      agreement = described_class.create(tenancy_ref: '123')
       Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'live')
       Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'breached')
 

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['agreements'].first['startDate']).to include(start_date.to_s)
         expect(parsed_response['agreements'].first['frequency']).to eq(frequency)
         expect(parsed_response['agreements'].first['currentState']).to eq(nil)
+        expect(parsed_response['agreements'].first['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['agreements'].first['history']).to eq([])
       end
 
@@ -96,7 +97,7 @@ RSpec.describe 'Agreements', type: :request do
       end
 
       let(:created_agreement) do
-        Hackney::Income::Models::Agreement.new(
+        Hackney::Income::Models::Agreement.create(
           tenancy_ref: tenancy_ref,
           agreement_type: agreement_type,
           starting_balance: starting_balance,
@@ -126,6 +127,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['startDate']).to include(start_date.to_s)
         expect(parsed_response['frequency']).to eq(frequency)
         expect(parsed_response['currentState']).to eq(nil)
+        expect(parsed_response['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['history']).to eq([])
       end
     end

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -1,16 +1,18 @@
 require 'swagger_helper'
 
 RSpec.describe 'Agreements', type: :request do
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:agreement_type) { 'informal' }
+  let(:amount) { Faker::Commerce.price(range: 10...100) }
+  let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
+  let(:frequency) { 'weekly' }
+  let(:current_state) { 'live' }
+  let(:starting_balance) { Faker::Commerce.price(range: 100...1000) }
+  let(:created_by) { Faker::Name.name }
+
   describe 'GET /api/v1/agreements/{tenancy_ref}' do
     path '/agreements/{tenancy_ref}' do
       let(:view_agreements_instance) { instance_double(Hackney::Income::ViewAgreements) }
-      let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-      let(:agreement_type) { 'formal' }
-      let(:starting_balance) { Faker::Commerce.price(range: 10...1000) }
-      let(:amount) { Faker::Commerce.price(range: 10...100) }
-      let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
-      let(:frequency) { 'weekly' }
-      let(:current_state) { 'active' }
       let(:agreements_array) do
         [
           Hackney::Income::Models::Agreement.create!(
@@ -20,7 +22,8 @@ RSpec.describe 'Agreements', type: :request do
             amount: amount,
             start_date: start_date,
             frequency: frequency,
-            current_state: current_state
+            current_state: current_state,
+            created_by: created_by
           )
         ]
       end
@@ -48,6 +51,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['agreements'].first['frequency']).to eq(frequency)
         expect(parsed_response['agreements'].first['currentState']).to eq(nil)
         expect(parsed_response['agreements'].first['createdAt']).to eq(Date.today.to_s)
+        expect(parsed_response['agreements'].first['createdBy']).to eq(created_by)
         expect(parsed_response['agreements'].first['history']).to eq([])
       end
 
@@ -78,33 +82,21 @@ RSpec.describe 'Agreements', type: :request do
   describe 'POST /api/v1/agreement/{tenancy_ref}' do
     path '/agreement/{tenancy_ref}' do
       let(:create_agreement_instance) { instance_double(Hackney::Income::CreateAgreement) }
-      let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-      let(:agreement_type) { 'informal' }
-      let(:amount) { Faker::Commerce.price(range: 10...100) }
-      let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
-      let(:frequency) { 'weekly' }
-      let(:current_state) { 'live' }
-      let(:starting_balance) { Faker::Commerce.price(range: 100...1000) }
-
       let(:new_agreement_params) do
         {
           tenancy_ref: tenancy_ref,
           agreement_type: agreement_type,
           amount: amount.to_s,
           start_date: start_date.to_s,
-          frequency: frequency
+          frequency: frequency,
+          created_by: created_by
         }
       end
 
       let(:created_agreement) do
         Hackney::Income::Models::Agreement.create(
-          tenancy_ref: tenancy_ref,
-          agreement_type: agreement_type,
           starting_balance: starting_balance,
-          amount: amount,
-          start_date: start_date,
-          frequency: frequency,
-          current_state: current_state
+          **new_agreement_params
         )
       end
 
@@ -128,6 +120,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['frequency']).to eq(frequency)
         expect(parsed_response['currentState']).to eq(nil)
         expect(parsed_response['createdAt']).to eq(Date.today.to_s)
+        expect(parsed_response['createdBy']).to eq(created_by)
         expect(parsed_response['history']).to eq([])
       end
     end


### PR DESCRIPTION
## Context
Agreements details page show information about an agreement `created_by` and `created_at`, currently the API endpoints does not take or return these.

## Changes proposed in this pull request
- Add migration to add `created_by` field to agreements table
- Update agreement use-cases and request to return these fields 

## Link to Jira card
maybe?
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-173

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
