### PR TITLE
 Add cancel endpoint to agreements API

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -29,6 +29,12 @@ class AgreementsController < ApplicationController
     render json: response
   end
 
+  def cancel
+    cancelled_agreement = income_use_case_factory.cancel_agreement.execute(agreement_id: params.fetch(:agreement_id))
+    response = map_agreement_to_response(agreement: cancelled_agreement)
+    render json: response
+  end
+
   def agreements_params
     params.permit([:tenancy_ref])
   end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -31,8 +31,12 @@ class AgreementsController < ApplicationController
 
   def cancel
     cancelled_agreement = income_use_case_factory.cancel_agreement.execute(agreement_id: params.fetch(:agreement_id))
-    response = map_agreement_to_response(agreement: cancelled_agreement)
-    render json: response
+    if cancelled_agreement
+      response = map_agreement_to_response(agreement: cancelled_agreement)
+      render json: response
+    else
+      render json: { error: 'agreement not found' }, status: :not_found
+    end
   end
 
   def agreements_params

--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -2,12 +2,18 @@ module Hackney
   module Income
     module Models
       class Agreement < ApplicationRecord
+        ACTIVE_STATES = %w[live breached].freeze
+
         has_many :agreement_states, class_name: 'Hackney::Income::Models::AgreementState'
         enum agreement_type: { informal: 'informal', formal: 'formal' }
         enum frequency: { weekly: 0, monthly: 1 }
 
         def current_state
           Hackney::Income::Models::AgreementState.where(agreement_id: id).last&.agreement_state
+        end
+
+        def active?
+          ACTIVE_STATES.include?(current_state)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,5 +29,6 @@ Rails.application.routes.draw do
 
     get '/agreements/:tenancy_ref', to: 'agreements#index'
     post '/agreement/:tenancy_ref', to: 'agreements#create'
+    post '/agreements/:agreement_id/cancel', to: 'agreements#cancel'
   end
 end

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '1.0'
+  version: "1.1"
   title: 'LBH Income API'
   description: 'The Income API is the back-end of Hackney Income Collection Service'
 paths:        
@@ -41,6 +41,30 @@ paths:
         required: true
         type: string
         description: Agreement for tenancy
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/agreement'
+        400:
+          description: Invalid search parameter
+        404:
+          description: Agreement not found
+      tags:
+        - agreements
+  /agreements/{agreement_id}/cancel:
+    post:
+      summary: 'Cancel an agreement with id'
+      description: Cancel agreement with specified id
+      operationId: cancelAgreement
+      produces:
+      - application/json
+      parameters:
+      - in: path
+        name: agreement_id
+        required: true
+        type: string
+        description: Id of an agreement
       responses:
         200:
           description: successful operation

--- a/lib/hackney/income/cancel_agreement.rb
+++ b/lib/hackney/income/cancel_agreement.rb
@@ -1,0 +1,15 @@
+module Hackney
+  module Income
+    class CancelAgreement
+      def execute(agreement_id:)
+        agreement = Hackney::Income::Models::Agreement.find(agreement_id)
+
+        return agreement if agreement.current_state == 'cancelled'
+
+        Hackney::Income::Models::AgreementState.create!(agreement_id: agreement_id, agreement_state: 'cancelled')
+
+        agreement
+      end
+    end
+  end
+end

--- a/lib/hackney/income/cancel_agreement.rb
+++ b/lib/hackney/income/cancel_agreement.rb
@@ -2,8 +2,9 @@ module Hackney
   module Income
     class CancelAgreement
       def execute(agreement_id:)
-        agreement = Hackney::Income::Models::Agreement.find(agreement_id)
+        agreement = Hackney::Income::Models::Agreement.find_by_id(agreement_id)
 
+        return if agreement.nil?
         return agreement unless agreement.active?
 
         Hackney::Income::Models::AgreementState.create!(agreement_id: agreement_id, agreement_state: :cancelled)

--- a/lib/hackney/income/cancel_agreement.rb
+++ b/lib/hackney/income/cancel_agreement.rb
@@ -4,9 +4,9 @@ module Hackney
       def execute(agreement_id:)
         agreement = Hackney::Income::Models::Agreement.find(agreement_id)
 
-        return agreement if agreement.current_state == 'cancelled'
+        return agreement unless agreement.active?
 
-        Hackney::Income::Models::AgreementState.create!(agreement_id: agreement_id, agreement_state: 'cancelled')
+        Hackney::Income::Models::AgreementState.create!(agreement_id: agreement_id, agreement_state: :cancelled)
 
         agreement
       end

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -2,10 +2,11 @@ module Hackney
   module Income
     class CreateAgreement
       def execute(new_agreement_params:)
-        case_details = Hackney::Income::Models::CasePriority.where(tenancy_ref: new_agreement_params[:tenancy_ref])
+        tenancy_ref = new_agreement_params[:tenancy_ref]
+        case_details = Hackney::Income::Models::CasePriority.where(tenancy_ref: tenancy_ref)
 
         agreement_params = {
-          tenancy_ref: new_agreement_params[:tenancy_ref],
+          tenancy_ref: tenancy_ref,
           agreement_type: new_agreement_params[:agreement_type],
           starting_balance: case_details.first[:balance],
           amount: new_agreement_params[:amount],
@@ -15,16 +16,16 @@ module Hackney
           current_state: 'live'
         }
 
-        live_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: new_agreement_params[:tenancy_ref]).where(current_state: 'live')
+        active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
 
-        if live_agreements.any?
-          live_agreements.each do |agreement|
-            Hackney::Income::Models::AgreementState.create!(agreement_id: agreement.id, agreement_state: 'cancelled')
+        if active_agreements.any?
+          active_agreements.each do |agreement|
+            Hackney::Income::Models::AgreementState.create!(agreement_id: agreement.id, agreement_state: :cancelled)
           end
         end
 
         new_agreement = Hackney::Income::Models::Agreement.create!(agreement_params)
-        Hackney::Income::Models::AgreementState.create!(agreement_id: new_agreement.id, agreement_state: agreement_params[:current_state])
+        Hackney::Income::Models::AgreementState.create!(agreement_id: new_agreement.id, agreement_state: :live)
 
         new_agreement
       end

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -19,8 +19,10 @@ module Hackney
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
 
         if active_agreements.any?
+          cancel_agreement = Hackney::Income::CancelAgreement.new
+
           active_agreements.each do |agreement|
-            Hackney::Income::Models::AgreementState.create!(agreement_id: agreement.id, agreement_state: :cancelled)
+            cancel_agreement.execute(agreement_id: agreement.id)
           end
         end
 

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -205,6 +205,10 @@ module Hackney
         Hackney::Income::CreateAgreement.new
       end
 
+      def cancel_agreement
+        Hackney::Income::CancelAgreement.new
+      end
+
       private
 
       def cloud_storage

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -35,6 +35,14 @@ describe Hackney::Income::CancelAgreement do
     expect(cancelled_agreement.current_state).to eq('cancelled')
   end
 
+  context 'when the agreement does not exist' do
+    it 'returns nil' do
+      non_existent_agreement_id = Faker::Number.number(digits: 10)
+
+      expect(subject.execute(agreement_id: non_existent_agreement_id)).to be_nil
+    end
+  end
+
   context 'when an agreement is completed' do
     before do
       Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'completed')

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -22,12 +22,16 @@ describe Hackney::Income::CancelAgreement do
   end
 
   let!(:agreement) { Hackney::Income::Models::Agreement.create!(agreement_params) }
+  let(:active_state) { %w[live breached].sample }
 
   before do
-    Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'live')
+    Hackney::Income::Models::AgreementState.create(
+      agreement_id: agreement.id,
+      agreement_state: active_state
+    )
   end
 
-  it 'cancelles a given agreement' do
+  it 'cancelles an active agreement' do
     cancelled_agreement = subject.execute(agreement_id: agreement.id)
 
     expect(cancelled_agreement.id).to eq(agreement.id)

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe Hackney::Income::CancelAgreement do
+  subject { described_class.new }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:agreement_type) { 'informal' }
+  let(:amount) { Faker::Commerce.price(range: 10...100) }
+  let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
+  let(:frequency) { 'weekly' }
+  let(:created_by) { Faker::Number.number(digits: 8).to_s }
+
+  let(:agreement_params) do
+    {
+      tenancy_ref: tenancy_ref,
+      agreement_type: agreement_type,
+      amount: amount,
+      start_date: start_date,
+      frequency: frequency,
+      created_by: created_by
+    }
+  end
+
+  let!(:agreement) { Hackney::Income::Models::Agreement.create!(agreement_params) }
+
+  it 'cancelles a given agreement' do
+    cancelled_agreement = subject.execute(agreement_id: agreement.id)
+
+    expect(cancelled_agreement.id).to eq(agreement.id)
+    expect(cancelled_agreement.tenancy_ref).to eq(tenancy_ref)
+    expect(cancelled_agreement.current_state).to eq('cancelled')
+  end
+
+  context 'when an agreement already cancelled' do
+    before do
+      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'cancelled')
+    end
+
+    it 'returns the initial agreement' do
+      expect(agreement.current_state).to eq('cancelled')
+      expect(agreement.agreement_states.length).to eq(1)
+
+      cancelled_agreement = subject.execute(agreement_id: agreement.id)
+
+      expect(cancelled_agreement.id).to eq(agreement.id)
+      expect(cancelled_agreement.current_state).to eq('cancelled')
+      expect(cancelled_agreement.agreement_states.length).to eq(1)
+    end
+  end
+end

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -69,4 +69,28 @@ describe Hackney::Income::Models::Agreement, type: :model do
       expect(agreement.current_state).to eq('breached')
     end
   end
+
+  describe 'active?' do
+    let(:agreement) { described_class.create(tenancy_ref: '123', created_by: user_name) }
+
+    it 'returns false if there are no associated agreement states' do
+      expect(agreement.current_state).to be_falsey
+    end
+
+    it 'returns true if agreement state is an active state' do
+      state = %w[live breached].sample
+      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: state)
+
+      expect(agreement.current_state).to eq(state)
+      expect(agreement).to be_active
+    end
+
+    it 'returns false if agreement is inactive' do
+      state = %w[cancelled completed].sample
+      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: state)
+
+      expect(agreement.current_state).to eq(state)
+      expect(agreement).not_to be_active
+    end
+  end
 end

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -125,4 +125,48 @@ RSpec.describe 'Agreements', type: :request do
       end
     end
   end
+
+  describe 'POST /api/v1/agreements/{agreement_id}/cancel' do
+    path '/agreements/{agreement_id}/cancel' do
+      let(:cancel_agreement_instance) { instance_double(Hackney::Income::CancelAgreement) }
+      let(:agreement_params) do
+        {
+          tenancy_ref: tenancy_ref,
+          agreement_type: agreement_type,
+          amount: amount.to_s,
+          start_date: start_date.to_s,
+          frequency: frequency,
+          created_by: created_by,
+          starting_balance: starting_balance
+        }
+      end
+      let(:agreement) { Hackney::Income::Models::Agreement.create(agreement_params) }
+
+      before do
+        Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'cancelled')
+
+        allow(Hackney::Income::CancelAgreement).to receive(:new).and_return(cancel_agreement_instance)
+        allow(cancel_agreement_instance).to receive(:execute)
+          .with(agreement_id: agreement.id.to_s)
+          .and_return(agreement)
+      end
+
+      it 'calls the cancel agreement use-case and returns the cancelled agreement' do
+        post "/api/v1/agreements/#{agreement.id}/cancel"
+
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
+        expect(parsed_response['agreementType']).to eq(agreement_type)
+        expect(parsed_response['startingBalance']).to eq(starting_balance)
+        expect(parsed_response['amount']).to eq(amount)
+        expect(parsed_response['startDate']).to include(start_date.to_s)
+        expect(parsed_response['frequency']).to eq(frequency)
+        expect(parsed_response['currentState']).to eq('cancelled')
+        expect(parsed_response['createdAt']).to eq(Date.today.to_s)
+        expect(parsed_response['createdBy']).to eq(created_by)
+        expect(parsed_response['history'].last['state']).to eq('cancelled')
+      end
+    end
+  end
 end

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -167,6 +167,24 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['createdBy']).to eq(created_by)
         expect(parsed_response['history'].last['state']).to eq('cancelled')
       end
+
+      context 'when the agreement does not exist it returns 404' do
+        let(:cancel_agreement_instance) { instance_double(Hackney::Income::CancelAgreement) }
+
+        before do
+          allow(Hackney::Income::CancelAgreement).to receive(:new).and_return(cancel_agreement_instance)
+          allow(cancel_agreement_instance).to receive(:execute)
+            .with(agreement_id: 'N0PE')
+            .and_return(nil)
+        end
+
+        it 'returns 404' do
+          post '/api/v1/agreements/N0PE/cancel'
+
+          expect(response).to have_http_status(:not_found)
+          expect(JSON.parse(response.body)['error']).to eq('agreement not found')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow caseworkers to cancel a live agreement

## Changes proposed in this pull request
<!-- List all the changes -->
- Update API docs to add the new endpoint
- Add the `agreements/{id}/cancel` endpoint
- Refactor Agreements to check for any active state
- Update `create agreement` implementation so that we cancel all active agreements when creating a new agreement

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Please before reviewing this have a look at this smaller PR https://github.com/LBHackney-IT/lbh-income-api/pull/418 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-173

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
