### PR TITLE
sql to identify what cases need to be synced

### DIFF
--- a/lib/hackney/service_charge/universal_housing_lease_gateway.rb
+++ b/lib/hackney/service_charge/universal_housing_lease_gateway.rb
@@ -1,0 +1,27 @@
+module Hackney
+  module ServiceCharge
+    class UniversalHousingLeaseGateway
+      def self.lease_in_arrears
+        Hackney::UniversalHousing::Client.with_connection do |database|
+          database.extension :identifier_mangling
+          database.identifier_input_method = database.identifier_output_method = nil
+
+          query = database[:tenagree]
+
+          query
+            .select(:tag_ref)
+            .exclude(tenure: FREEHOLD_TENURE_TYPE)
+            .where { cur_bal > 0 }
+            .where(rentgrp_ref: LEASE_RENT_GROUP)
+            .where(terminated: 0)
+            .where(agr_type: MASTER_ACCOUNT_TYPE)
+            .map { |item| item[:tag_ref].strip }
+        end
+      end
+
+      LEASE_RENT_GROUP = 'LSC'.freeze
+      FREEHOLD_TENURE_TYPE = 'FRE'.freeze
+      MASTER_ACCOUNT_TYPE = 'M'.freeze
+    end
+  end
+end

--- a/spec/lib/hackney/service_charge/universal_housing_lease_gateway_spec.rb
+++ b/spec/lib/hackney/service_charge/universal_housing_lease_gateway_spec.rb
@@ -27,7 +27,7 @@ describe Hackney::ServiceCharge::UniversalHousingLeaseGateway, universal: true d
         create_uh_tenancy_agreement(tenancy_ref: '000003/01', current_balance: 50.00)
       end
 
-      it 'returns only the master account tenancy' do
+      it 'returns only the one in lease rent group' do
         expect(subject).to eq(['000001/01'])
       end
     end

--- a/spec/lib/hackney/service_charge/universal_housing_lease_gateway_spec.rb
+++ b/spec/lib/hackney/service_charge/universal_housing_lease_gateway_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe Hackney::ServiceCharge::UniversalHousingLeaseGateway, universal: true do
+  context 'when retrieving tenancy refs for cases in arrears' do
+    subject { described_class.lease_in_arrears }
+
+    let(:lease_rent_group) { 'LSC' }
+
+    context 'when there are no tenancies' do
+      it 'returns none' do
+        expect(subject).to be_empty
+      end
+    end
+
+    context 'when there is one tenancy in arrears and in the leasehold rent group' do
+      before { create_uh_tenancy_agreement(tenancy_ref: '000001/01   ', current_balance: 50.00, rentgrp_ref: lease_rent_group) }
+
+      it 'returns that tenancy with stripped whitespace' do
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'when there are three tenancies in arrears, but only one is in the leasehold rent group' do
+      before do
+        create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 50.00, rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000002/01', current_balance: 50.00)
+        create_uh_tenancy_agreement(tenancy_ref: '000003/01', current_balance: 50.00)
+      end
+
+      it 'returns only the master account tenancy' do
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'when there is one tenancy in the leasehold rent group and in credit' do
+      before { create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: -50.00, rentgrp_ref: lease_rent_group) }
+
+      it 'returns nothing' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when there are two tenancies in arrears and two in credit and all are in the rent group' do
+      before do
+        create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: -100.00, rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000002/01', current_balance: 50.00, rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000003/01', current_balance: -75.00, rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000004/01', current_balance: 100.00, rentgrp_ref: lease_rent_group)
+      end
+
+      it 'returns the two in arrears' do
+        expect(subject).to eq(%w[000002/01 000004/01])
+      end
+    end
+
+    context 'when there is a tenancy in arrears which has been terminated in the rent group' do
+      before { create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 100.00, terminated: true, rentgrp_ref: lease_rent_group) }
+
+      it 'returns nothing' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when there are three tenancies in arrears, but only one is a master account' do
+      before do
+        create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 50.00, agreement_type: 'M', rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000002/01', current_balance: 50.00, agreement_type: 'R', rentgrp_ref: lease_rent_group)
+        create_uh_tenancy_agreement(tenancy_ref: '000003/01', current_balance: 50.00, agreement_type: 'X', rentgrp_ref: lease_rent_group)
+      end
+
+      it 'returns only the master account tenancy' do
+        expect(subject).to eq(['000001/01'])
+      end
+    end
+
+    context 'when there is a tenancy in arrears which is a freehold tenure tenancy' do
+      before { create_uh_tenancy_agreement(tenancy_ref: '000001/01', current_balance: 100.00, tenure_type: 'FRE', rentgrp_ref: lease_rent_group) }
+
+      it 'does not return the tenancy' do
+        expect(subject).to eq([])
+      end
+    end
+  end
+end

--- a/spec/support/universal_housing_helper.rb
+++ b/spec/support/universal_housing_helper.rb
@@ -5,7 +5,7 @@ module UniversalHousingHelper
                                   nosp_notice_served_date: '1900-01-01 00:00:00 +0000', nosp_notice_expiry_date: '1900-01-01 00:00:00 +0000',
                                   money_judgement: 0.0, charging_order: 0.0, bal_dispute: 0.0, courtdate: '1900-01-01 00:00:00 +0000',
                                   court_outcome: nil, eviction_date: '1900-01-01 00:00:00 +0000', agreement_type: 'M',
-                                  service: 0.0, other_charge: 0.0)
+                                  service: 0.0, other_charge: 0.0, rentgrp_ref: 'HRA')
     Hackney::UniversalHousing::Client.connection[:tenagree].insert(
       tag_ref: tenancy_ref,
       cur_bal: current_balance,
@@ -16,6 +16,7 @@ module UniversalHousingHelper
       terminated: terminated ? 1 : 0,
       tenure: tenure_type,
       high_action: high_action,
+      rentgrp_ref: rentgrp_ref,
       spec_terms: true,
       other_accounts: false,
       active: true,


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Adding a service charge sync query to sync over one case (pt 2 of several)

## Changes proposed in this pull request
<!-- List all the changes -->
- Added sql query that will identify what cases need to be queued up and processed by the _new_ service charge universal housing criteria (implemented in https://github.com/LBHackney-IT/lbh-income-api/pull/417)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- The main sql that identifies the cases is here: `lib/hackney/service_charge/universal_housing_lease_gateway.rb` 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
