### PR TITLE
Add notes field to agreements table

### DIFF
--- a/app/controllers/agreement_response_helper.rb
+++ b/app/controllers/agreement_response_helper.rb
@@ -11,6 +11,7 @@ module AgreementResponseHelper
       currentState: agreement.current_state,
       createdAt: agreement.created_at.strftime('%F'),
       createdBy: agreement.created_by,
+      notes: agreement.notes,
       history: map_agreement_state_history(agreement.agreement_states)
     }
   end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -21,7 +21,8 @@ class AgreementsController < ApplicationController
       amount: params.fetch(:amount),
       start_date: params.fetch(:start_date),
       frequency: params.fetch(:frequency),
-      created_by: params.fetch(:created_by)
+      created_by: params.fetch(:created_by),
+      notes: params.fetch(:notes)
     }
 
     created_agreement = income_use_case_factory.create_agreement.execute(new_agreement_params: agreement_params)

--- a/db/migrate/20200706144853_add_notes_to_agreements_table.rb
+++ b/db/migrate/20200706144853_add_notes_to_agreements_table.rb
@@ -1,0 +1,5 @@
+class AddNotesToAgreementsTable < ActiveRecord::Migration[5.2]
+  def change
+    add_column :agreements, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_111144) do
+ActiveRecord::Schema.define(version: 2020_07_06_144853) do
 
   create_table "agreement_states", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "agreement_id"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_06_30_111144) do
     t.datetime "updated_at", null: false
     t.string "tenancy_ref", null: false
     t.string "created_by", null: false
+    t.text "notes"
   end
 
   create_table "case_priorities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -118,6 +118,9 @@ definitions:
       createdAt:
         type: string
         format: date
+      notes:
+        type: string
+        example: 'When Chuck Norris presses Ctrl+Alt+Delete, worldwide computer restart is initiated.'
       history:
         type: array
         items: 

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -1,8 +1,9 @@
 module Hackney
   module Income
     class CreateAgreement
-      def initialize(add_action_diary:)
+      def initialize(add_action_diary:, cancel_agreement:)
         @add_action_diary = add_action_diary
+        @cancel_agreement = cancel_agreement
       end
 
       def execute(new_agreement_params:)
@@ -24,10 +25,8 @@ module Hackney
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
 
         if active_agreements.any?
-          cancel_agreement = Hackney::Income::CancelAgreement.new
-
           active_agreements.each do |agreement|
-            cancel_agreement.execute(agreement_id: agreement.id)
+            @cancel_agreement.execute(agreement_id: agreement.id)
           end
         end
 

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -13,7 +13,8 @@ module Hackney
           start_date: new_agreement_params[:start_date],
           frequency: new_agreement_params[:frequency],
           created_by: new_agreement_params[:created_by],
-          current_state: 'live'
+          current_state: 'live',
+          notes: new_agreement_params[:notes]
         }
 
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -1,6 +1,10 @@
 module Hackney
   module Income
     class CreateAgreement
+      def initialize(add_action_diary:)
+        @add_action_diary = add_action_diary
+      end
+
       def execute(new_agreement_params:)
         tenancy_ref = new_agreement_params[:tenancy_ref]
         case_details = Hackney::Income::Models::CasePriority.where(tenancy_ref: tenancy_ref)
@@ -29,6 +33,13 @@ module Hackney
 
         new_agreement = Hackney::Income::Models::Agreement.create!(agreement_params)
         Hackney::Income::Models::AgreementState.create!(agreement_id: new_agreement.id, agreement_state: :live)
+
+        @add_action_diary.execute(
+          tenancy_ref: tenancy_ref,
+          action_code: 'AGR',
+          comment: "Informal Agreement created: #{new_agreement.notes}",
+          username: new_agreement.created_by
+        )
 
         new_agreement
       end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -202,7 +202,10 @@ module Hackney
       end
 
       def create_agreement
-        Hackney::Income::CreateAgreement.new(add_action_diary: add_action_diary)
+        Hackney::Income::CreateAgreement.new(
+          add_action_diary: add_action_diary,
+          cancel_agreement: cancel_agreement
+        )
       end
 
       def cancel_agreement

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -202,7 +202,7 @@ module Hackney
       end
 
       def create_agreement
-        Hackney::Income::CreateAgreement.new
+        Hackney::Income::CreateAgreement.new(add_action_diary: add_action_diary)
       end
 
       def cancel_agreement

--- a/spec/lib/hackney/income/create_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_agreement_spec.rb
@@ -9,6 +9,7 @@ describe Hackney::Income::CreateAgreement do
   let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
   let(:frequency) { 'weekly' }
   let(:created_by) { Faker::Name.name }
+  let(:notes) { Faker::ChuckNorris.fact }
 
   let(:existing_agreement_params) do
     {
@@ -17,7 +18,8 @@ describe Hackney::Income::CreateAgreement do
       amount: Faker::Commerce.price(range: 10...100),
       start_date: Faker::Date.between(from: 4.days.ago, to: Date.today),
       frequency: frequency,
-      created_by: created_by
+      created_by: created_by,
+      notes: notes
     }
   end
 
@@ -28,7 +30,8 @@ describe Hackney::Income::CreateAgreement do
       amount: amount,
       start_date: start_date,
       frequency: frequency,
-      created_by: created_by
+      created_by: created_by,
+      notes: notes
     }
   end
 
@@ -49,6 +52,7 @@ describe Hackney::Income::CreateAgreement do
       expect(created_agreement.current_state).to eq('live')
       expect(created_agreement.starting_balance).to eq(100)
       expect(created_agreement.created_by).to eq(created_by)
+      expect(created_agreement.notes).to eq(notes)
     end
   end
 

--- a/spec/lib/hackney/income/create_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_agreement_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Hackney::Income::CreateAgreement do
-  subject { described_class.new }
+  subject { described_class.new(add_action_diary: add_action_diary) }
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:agreement_type) { 'informal' }
@@ -33,6 +33,20 @@ describe Hackney::Income::CreateAgreement do
       created_by: created_by,
       notes: notes
     }
+  end
+
+  let(:add_action_diary) { spy }
+
+  it 'calls the add_action_diary when a new agreement is created' do
+    Hackney::Income::Models::CasePriority.create!(tenancy_ref: tenancy_ref, balance: 100)
+    subject.execute(new_agreement_params: new_agreement_params)
+
+    expect(add_action_diary).to have_received(:execute).with(
+      tenancy_ref: tenancy_ref,
+      comment: "Informal Agreement created: #{notes}",
+      username: created_by,
+      action_code: 'AGR'
+    )
   end
 
   context 'when there are no previous agreements for the tenancy' do

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -17,6 +17,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
       'created_at',
       'updated_at',
       'tenancy_ref',
+      'notes',
       'id'
     )
   end

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Agreements', type: :request do
   let(:current_state) { 'live' }
   let(:starting_balance) { Faker::Commerce.price(range: 100...1000) }
   let(:created_by) { Faker::Name.name }
+  let(:notes) { Faker::ChuckNorris.fact }
 
   describe 'GET /api/v1/agreements/{tenancy_ref}' do
     path '/agreements/{tenancy_ref}' do
@@ -23,7 +24,8 @@ RSpec.describe 'Agreements', type: :request do
             start_date: start_date,
             frequency: frequency,
             current_state: current_state,
-            created_by: created_by
+            created_by: created_by,
+            notes: notes
           )
         ]
       end
@@ -52,6 +54,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['agreements'].first['currentState']).to eq(nil)
         expect(parsed_response['agreements'].first['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['agreements'].first['createdBy']).to eq(created_by)
+        expect(parsed_response['agreements'].first['notes']).to eq(notes)
         expect(parsed_response['agreements'].first['history']).to eq([])
       end
 
@@ -89,7 +92,8 @@ RSpec.describe 'Agreements', type: :request do
           amount: amount.to_s,
           start_date: start_date.to_s,
           frequency: frequency,
-          created_by: created_by
+          created_by: created_by,
+          notes: notes
         }
       end
 
@@ -121,6 +125,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['currentState']).to eq(nil)
         expect(parsed_response['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['createdBy']).to eq(created_by)
+        expect(parsed_response['notes']).to eq(notes)
         expect(parsed_response['history']).to eq([])
       end
     end


### PR DESCRIPTION
## Context
We want to be able to save notes and create a new action diary entry when a new agreement is created

## Changes proposed in this pull request
- Add migration to add `notes` field to agreements table
- Update API docs
- Update agreement use-cases and request to return these fields 
- Refactor `create agreements` use case to use dependency injection for `cancel agreements`

![image](https://user-images.githubusercontent.com/22743709/86773356-7bc8e680-c04d-11ea-8eee-2ee357bc46eb.png)


## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-173

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated

