### PR TITLE
Expose tenancy_ref in classifier log

### DIFF
--- a/lib/hackney/income/tenancy_classification/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/classifier.rb
@@ -27,13 +27,11 @@ module Hackney
             Rails.logger.error(
               "CLASSIFIER: V1: #{version1_action} " \
                "V2: #{version2_action} " \
-               "Criteria: #{@criteria} " \
-               "CasePriority: #{@case_priority} " \
-               "Document Count: #{@documents.length}"
+               "tenancy_ref: #{@criteria.tenancy_ref}"
             )
           else
             Rails.logger.info(
-              'Classifier V1 & V2 Match'
+              "Classifier V1 & V2 Match for tenancy_ref: #{@criteria.tenancy_ref}"
             )
           end
 

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -42,9 +42,7 @@ module Hackney
                 Rails.logger.error(
                   'CLASSIFIER: Multiple recommended actions from V2' \
                   "Actions: #{actions} " \
-                  "Criteria: #{@criteria} " \
-                  "CasePriority: #{@case_priority} " \
-                  "Document Count: #{@documents.length}"
+                  "tenancy_ref: #{@criteria.tenancy_ref}"
                 )
               end
             end

--- a/lib/hackney/income/universal_housing_criteria.rb
+++ b/lib/hackney/income/universal_housing_criteria.rb
@@ -1,6 +1,8 @@
 module Hackney
   module Income
     class UniversalHousingCriteria
+      attr_reader :tenancy_ref
+
       def self.for_tenancy(universal_housing_client, tenancy_ref)
         attributes = universal_housing_client[build_sql, tenancy_ref].first
         attributes ||= {}
@@ -264,7 +266,7 @@ module Hackney
 
       private
 
-      attr_reader :tenancy_ref, :attributes
+      attr_reader :attributes
 
       def day_difference(date_a, date_b)
         (date_a.to_date - date_b.to_date).to_i

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -4,6 +4,10 @@ module Stubs
       @attributes = attributes
     end
 
+    def tenancy_ref
+      'StubCriteria'
+    end
+
     def days_since_last_payment
       attributes[:days_since_last_payment]
     end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
To aid in debugging classifier rules - at the moment the log output is not useful in identifying a tenancy.

Just a small one

## Changes proposed in this pull request
<!-- List all the changes -->
* Emit a tenancy ref rather than a set of object hashes.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-202

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
