### PR TITLE
Update payment frequenies on agreement model

### DIFF
--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -6,7 +6,7 @@ module Hackney
 
         has_many :agreement_states, class_name: 'Hackney::Income::Models::AgreementState'
         enum agreement_type: { informal: 'informal', formal: 'formal' }
-        enum frequency: { weekly: 0, monthly: 1 }
+        enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3 }
 
         def current_state
           Hackney::Income::Models::AgreementState.where(agreement_id: id).last&.agreement_state

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -45,7 +45,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
 
   describe 'frequency' do
     it 'only accepts :weekly/:monthly as frequency' do
-      %i[weekly monthly].each do |frequency|
+      ['weekly', 'monthly', 'fortnightly', '4 weekly'].each do |frequency|
         expect { described_class.new(frequency: frequency) }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As per design there are 4 possible payment frequencies when creating agreement:
![image](https://user-images.githubusercontent.com/22743709/87420095-8f83c800-c5cc-11ea-975f-b4bc8363b257.png)

## Changes proposed in this pull request
- Add `4 weekly` and `fortnightly` frequencies to agreement model 

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
