### PR TITLE
Remove court_outcome check for send NOSP

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
@@ -18,7 +18,6 @@ module Hackney
               return false if @criteria.active_agreement?
 
               return false if @criteria.nosp.valid?
-              return false if @criteria.court_outcome.blank?
 
               unless @criteria.nosp.served?
                 return false unless @criteria.last_communication_action.in?(valid_actions_for_nosp_to_progress)


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->

We have a deviation on the new classifier whereby when a case has an empty court outcome, it prevents a NOSP being served.

The original ruleset did not reference the court outcome, and as such I do not believe the new ruleset should.

See
https://github.com/LBHackney-IT/lbh-income-api/commit/9c2811ec66186a54b35213a4918f1ea4b4cbdaa8#diff-2275c89af8d6aabdc8ee48871a213555L190-L202
for the original


## Changes proposed in this pull request
<!-- List all the changes -->

* Remove court_outcome.blank? check from send_nosp

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Hard to validate yourself, I've rerun the sync locally and it now matches the outcome matches the original MAA classification engine

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-202

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
