### PR TITLE
Check if active court warrant before sending nosp

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -11,6 +11,23 @@ module Hackney
             @criteria.eviction_date.present?
           end
 
+          def court_warrant_active?
+            return false if @criteria.court_outcome.blank?
+
+            if @criteria.court_outcome.in?([
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY,
+              Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+            ])
+              return @criteria.courtdate > 6.years.ago
+            end
+
+            false
+          end
+
           def court_date_in_future?
             @criteria.courtdate.present? && @criteria.courtdate.future?
           end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
@@ -18,6 +18,7 @@ module Hackney
               return false if @criteria.active_agreement?
 
               return false if @criteria.nosp.valid?
+              return false if court_warrant_active?
 
               return false if court_outcome_missing?
 

--- a/lib/hackney/tenancy/court_outcome_codes.rb
+++ b/lib/hackney/tenancy/court_outcome_codes.rb
@@ -3,6 +3,12 @@ module Hackney
     module CourtOutcomeCodes
       OUTRIGHT_POSSESSION_WITH_DATE = 'OPD'.freeze
       OUTRIGHT_POSSESSION_FORTHWITH = 'OPF'.freeze
+
+      ADJOURNED_GENERALLY = 'AGE'.freeze
+      ADJOURNED_ON_TERMS = 'ADT'.freeze
+      ADJOURNED_ON_TERMS_SECONDARY = 'AOT'.freeze
+
+      SUSPENDED_POSSESSION = 'SUP'.freeze
     end
   end
 end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -500,6 +500,135 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
   end
 
+  describe 'court_warrant_active' do
+    subject { helpers.court_warrant_active? }
+
+    context 'when there is no court outcome' do
+      let(:court_outcome) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is a adjourned on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:courtdate) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a adjourned on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:courtdate) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a adjourned (secondary) on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:courtdate) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a suspended possession outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:courtdate) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when there is a outright possession with date outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:courtdate) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when there is a outright possession forthwith outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH }
+
+      context 'with a court date 2 years ago' do
+        let(:courtdate) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:courtdate) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
   describe 'court_outcome_missing?' do
     subject { helpers.court_outcome_missing? }
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The old classification engine had very loose rules. As a result we can trigger several actions for a given case, even though it should not.

## Changes proposed in this pull request
<!-- List all the changes -->
Tighten the rules for sending NOSPs. In the this PR I have prevented a NOSP being sent if one of 6 court outcomes occurred within the last 6 years.

Technically some of them would have custom dates, but they are edge cases, and the dates are currently not stored in a normalised form in UH. Once we start modelling court outcomes and strike out dates then we can revisit.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check if the send_nosp ruleset seems sensible to you, given the knowledge of the escalation process.

Incidentally, this resolves 19/21 deviations in this scenario. 1 of them is a potential out-of-date sync, and the other is a missing court outcome from the model "CDG". If you know what CDG means, please let me know.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-202

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
