### PR TITLE
Check agreement status before send nosp

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -57,6 +57,10 @@ module Hackney
             @criteria.last_communication_date > date.to_date
           end
 
+          def active_agreement?
+            @criteria.active_agreement? || (@criteria.most_recent_agreement.present? && @criteria.most_recent_agreement[:status].in?(%i[active breached]))
+          end
+
           def informal_breached_agreement?
             return false if should_prevent_action?
             breached_agreement? && !court_breach_agreement?

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
@@ -15,7 +15,7 @@ module Hackney
               return false if @criteria.balance.blank?
               return false if @criteria.weekly_gross_rent.blank?
 
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
 
               return false if @criteria.nosp.valid?
               return false if court_warrant_active?

--- a/lib/hackney/income/universal_housing_criteria.rb
+++ b/lib/hackney/income/universal_housing_criteria.rb
@@ -101,9 +101,19 @@ module Hackney
       end
 
       def most_recent_agreement
+        if attributes[:most_recent_agreement_status].present?
+          status = case attributes[:most_recent_agreement_status].squish
+                   when Hackney::Income::BREACHED_ARREARS_AGREEMENT_STATUS
+                     :breached
+                   when Hackney::Income::ACTIVE_ARREARS_AGREEMENT_STATUS
+                     :active
+                   end
+        end
+
         {
           breached: !active_agreement?,
-          start_date: attributes[:most_recent_agreement_date]
+          start_date: attributes[:most_recent_agreement_date],
+          status: status
         }
       end
 

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -680,4 +680,32 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
       end
     end
   end
+
+  describe 'active_agreement' do
+    subject { helpers.active_agreement? }
+
+    context 'when there is no agreement' do
+      let(:most_recent_agreement) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is an active non-breached agreement' do
+      let(:most_recent_agreement) { { start_date: 1.week.ago, breached: false, status: :active } }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when there is a breached agreement' do
+      let(:most_recent_agreement) { { start_date: 1.week.ago, breached: true, status: :breached } }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/support/stubs/stub_criteria.rb
+++ b/spec/support/stubs/stub_criteria.rb
@@ -77,7 +77,7 @@ module Stubs
     end
 
     def active_agreement?
-      attributes[:most_recent_agreement] || attributes[:active_agreement]
+      attributes[:most_recent_agreement].present? || attributes[:active_agreement].present?
     end
 
     def nosp


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Resolving another deviation for the ruleset. Tightening the rules down so that a NOSP checks if there's an active agreement.


## Changes proposed in this pull request
<!-- List all the changes -->
Use a more sophisticated check to see if an agreement is active - before this change it was only looking for agreements that had not been breached.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I'd like to refactor the existing `@criteria.active_agreement` out and make it all tidier, but I'm not sure about chasing this one down as it may have implications on the `stored_tenancies_gateway`. Maybe a q for @elena-vi 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-202

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
