### PR TITLE
Check court outcome and date for send nosp

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -23,6 +23,13 @@ module Hackney
             @criteria.courtdate.blank?
           end
 
+          def court_outcome_missing?
+            return false if court_date_in_future?
+            return false if no_court_date?
+
+            @criteria.court_outcome.blank?
+          end
+
           def last_communication_older_than?(date)
             return false if @criteria.last_communication_date.blank?
             @criteria.last_communication_date <= date.to_date

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_nosp.rb
@@ -19,6 +19,8 @@ module Hackney
 
               return false if @criteria.nosp.valid?
 
+              return false if court_outcome_missing?
+
               unless @criteria.nosp.served?
                 return false unless @criteria.last_communication_action.in?(valid_actions_for_nosp_to_progress)
                 return false if last_communication_older_than?(3.months.ago)

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -15,6 +15,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
   let(:last_communication_date) { nil }
   let(:eviction_date) { nil }
   let(:courtdate) { nil }
+  let(:court_outcome) { nil }
   let(:most_recent_agreement) { nil }
   let(:total_payment_amount_in_week) { 0 }
   let(:weekly_rent) { 0 }
@@ -23,6 +24,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     Stubs::StubCriteria.new(
       eviction_date: eviction_date,
       courtdate: courtdate,
+      court_outcome: court_outcome,
       last_communication_date: last_communication_date,
       most_recent_agreement: most_recent_agreement,
       total_payment_amount_in_week: total_payment_amount_in_week,
@@ -494,6 +496,58 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
         allow(helpers).to receive(:arrear_accumulation_by_number_weeks).and_return(15)
 
         expect(subject).to eq(false)
+      end
+    end
+  end
+
+  describe 'court_outcome_missing?' do
+    subject { helpers.court_outcome_missing? }
+
+    context 'when there is no court date' do
+      let(:courtdate) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is a court date in the past' do
+      let(:courtdate) { 2.days.ago }
+
+      context 'when the court outcome is blank' do
+        let(:court_outcome) { nil }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'when the court outcome is not blank' do
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a court date in the future' do
+      let(:courtdate) { 2.days.ago }
+
+      context 'when the court outcome is blank' do
+        let(:court_outcome) { nil }
+
+        it 'returns false' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'when the court outcome is not blank' do
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->

Continuing on with the deviation work. NOSP should not send if there's a court date in the past without a court outcome.

## Changes proposed in this pull request
<!-- List all the changes -->
* Expect a court outcome to be set if there's a court date in the past.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
