### PR TITLE
create database before set database environment

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -12,13 +12,12 @@ then
   dockerize -wait "$DATABASE_SERVICE" -timeout 1m
 
   # Setup the database - safe if it is already configured
+  rails db:setup
 
   if [ "$RAILS_ENV" = "development" ]
   then
     rails db:environment:set RAILS_ENV=development
   fi
-
-  rails db:setup
 fi
 
 # Start app


### PR DESCRIPTION
## Context
When we tried to run 'make run-all' command from the front-end repo the Income API failed because the database didn't exist when we tried to setup the database environment

## Changes proposed in this pull request
<!-- List all the changes -->
Made changes to the Entrypoint.sh if statement file so that it would run 'rails db:setup' before the database environment is set

## Guidance to review
May need to have a go at setting up from scratch to ensure this is the right fix
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
N/A

## Things to check
- If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- Environment variables have been updated
