### PR TITLE
check if there is a court date before checking how log ago the court …

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -22,7 +22,7 @@ module Hackney
               Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
               Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
             ])
-              return @criteria.courtdate > 6.years.ago
+              return @criteria.courtdate.blank? || @criteria.courtdate > 6.years.ago
             end
 
             false

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -529,6 +529,14 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
           expect(subject).to eq(false)
         end
       end
+
+      context 'with a court date is nil' do
+        let(:courtdate) { nil }
+
+        it 'returns false' do
+          expect(subject).to eq(true)
+        end
+      end
     end
 
     context 'when there is a adjourned on terms outcome' do


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
A sentry error came in, this issue was caused 32 errors when the sync ran 

## Changes proposed in this pull request
<!-- List all the changes -->
Assume that if there is no court date the court warrant is still active (this is an edge case where the court outcome was entered but the court date was missed off)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://sentry.io/organizations/london-borough-of-hackney/issues/1786816962/?project=1276456&query=is%3Aunresolved

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
