### PR TITLE
Add GET court cases API endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ serve:
 
 .PHONY: shell
 shell:
-	docker-compose run --rm -e RAILS_ENV=test app /bin/bash
+	docker-compose run --rm app /bin/bash
 
 .PHONY: test-db-destroy
 test-db-destroy:

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -1,6 +1,17 @@
 class CourtCasesController < ApplicationController
   include CourtCaseResponseHelper
 
+  def index
+    requested_cases = income_use_case_factory.view_court_cases.execute(tenancy_ref: params.fetch(:tenancy_ref))
+
+    cases = requested_cases.map do |c|
+      map_court_case_to_response(court_case: c)
+    end
+
+    response = { court_cases: cases }
+    render json: response
+  end
+
   def create
     court_case_params = {
       tenancy_ref: params.fetch(:tenancy_ref),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     post '/agreement/:tenancy_ref', to: 'agreements#create'
     post '/agreements/:agreement_id/cancel', to: 'agreements#cancel'
 
+    get '/court_cases/:tenancy_ref', to: 'court_cases#index'
     post '/court_case/:tenancy_ref', to: 'court_cases#create'
   end
 end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -216,6 +216,10 @@ module Hackney
         Hackney::Income::CreateCourtCase.new
       end
 
+      def view_court_cases
+        Hackney::Income::ViewCourtCases.new
+      end
+
       private
 
       def cloud_storage


### PR DESCRIPTION
## Context
We want to be able to view existing court cases so we can view the court case of a formal agreement

<!-- List all the changes -->
- Add get court cases API endpoint

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-332

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated