### PR TITLE
Implement Create Agreement Validation Rules

### DIFF
--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -26,11 +26,7 @@ module Hackney
         )
       end
 
-      def cancel_active_agreements(tenancy_ref)
-        active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
-
-        return unless active_agreements.any?
-
+      def cancel_active_agreements(active_agreements)
         active_agreements.each do |agreement|
           @cancel_agreement.execute(agreement_id: agreement.id)
         end

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -25,7 +25,9 @@ module Hackney
           court_case_id: court_case.id
         }
 
-        cancel_active_agreements(tenancy_ref)
+        active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
+
+        cancel_active_agreements(active_agreements) if active_agreements.any?
 
         new_agreement = create_agreement(formal_agreement_params)
 

--- a/spec/lib/hackney/income/create_informal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_informal_agreement_spec.rb
@@ -50,4 +50,36 @@ describe Hackney::Income::CreateInformalAgreement do
       expect(agreements.second.current_state).to eq('live')
     end
   end
+
+  context 'when there is an existing formal agreement for the tenancy' do
+    let(:court_case) do
+      Hackney::Income::Models::CourtCase.create!(
+        tenancy_ref: tenancy_ref,
+        balance_at_outcome_date: Faker::Commerce.price(range: 10...1000),
+        court_decision_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
+        court_outcome: Faker::ChuckNorris.fact
+      )
+    end
+
+    before do
+      Hackney::Income::Models::CasePriority.create!(tenancy_ref: tenancy_ref, balance: 200)
+
+      existing_agreement = Hackney::Income::Models::Agreement.create!(
+        tenancy_ref: tenancy_ref,
+        amount: Faker::Commerce.price(range: 10...100),
+        start_date: Faker::Date.between(from: 4.days.ago, to: Date.today),
+        frequency: frequency,
+        created_by: created_by,
+        agreement_type: 'formal',
+        court_case_id: court_case.id,
+        notes: notes
+      )
+      Hackney::Income::Models::AgreementState.create!(agreement_id: existing_agreement.id, agreement_state: :live)
+    end
+
+    it 'does not allow create a new informal agreement' do
+      expect { subject.execute(new_agreement_params: new_agreement_params) }
+        .to raise_error Hackney::Income::CreateInformalAgreement::CreateAgreementError, 'There is an existing formal agreement for this tenancy'
+    end
+  end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As a formal agreement takes precedence over an informal agreement, when there is a active formal agreement on a tenancy, a caseworker should not be able to cancel that formal agreement by creating an informal one
## Changes proposed in this pull request
<!-- List all the changes -->

- Add validation to `create_informal_agreement` use case to not cancel an active agreement if it is formal

- Update `cancel_active_agreement` method signature to now only accept active agreements 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-332
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
