### PR TITLE
Check for breached informal agreement before sending letter 2

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
@@ -16,6 +16,7 @@ module Hackney
               return false if @criteria.weekly_gross_rent.blank?
 
               return false if @criteria.active_agreement?
+              return false if breached_agreement? && !court_breach_agreement?
               return false if @criteria.nosp.served?
 
               return false unless @criteria.last_communication_action.in?(valid_actions_for_letter_two_to_progress)

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_two_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_two_spec.rb
@@ -137,6 +137,20 @@ describe 'Send Letter Two Rule', type: :feature do
       last_communication_action: letter_1_in_arrears_sent_code,
       courtdate: nil
     },
+    {
+      description: 'with breached informal agreement',
+      outcome: :send_informal_agreement_breach_letter,
+      weekly_rent: 5,
+      collectable_arrears: 20.0,
+      balance: 20.0,
+      last_communication_date: 2.weeks.ago.to_date,
+      last_communication_action: letter_1_in_arrears_sent_code,
+      most_recent_agreement: {
+        start_date: 6.days.ago,
+        breached: true,
+        status: :breached
+      }
+    },
     # court date in past
     {
       outcome: :no_action,


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
There are deviations in the classifications from V1 and V2 of the classifier.
## Changes proposed in this pull request
<!-- List all the changes -->
Add check for breached informal agreement before `send_letter_two` action
```
Expected: send_informal_agreement_breach_letter
Actual: :send_letter_two, :send_informal_agreement_breach_letter
Examples:
[
'005772/01',
'0101191/02',
'0101890/02',
'0102360/02',
'0102663/02',
'0103186/02',
'0103435/02',
'0103573/02',
'018349/01',
'023917/01'
]
```

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-339?atlOrigin=eyJpIjoiNGM3MDczN2RjYjdkNDlhNWJhNzEzNWRhNWI1NWVkN2EiLCJwIjoiaiJ9
