### PR TITLE
Promote V2 secure tenancy classifier

### DIFF
--- a/lib/hackney/income/tenancy_classification/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/classifier.rb
@@ -7,12 +7,7 @@ module Hackney
           @criteria = criteria
           @documents = documents
 
-          @version1_classifier = Hackney::Income::TenancyClassification::V1::Classifier.new(
-            case_priority,
-            criteria,
-            documents
-          )
-          @version2_classifier = Hackney::Income::TenancyClassification::V2::Classifier.new(
+          @classifier = Hackney::Income::TenancyClassification::V2::Classifier.new(
             case_priority,
             criteria,
             documents
@@ -20,22 +15,9 @@ module Hackney
         end
 
         def execute
-          version1_action = @version1_classifier.execute
-          version2_action = @version2_classifier.execute
+          action = @classifier.execute
 
-          if version1_action != version2_action
-            Rails.logger.error(
-              "CLASSIFIER: V1: #{version1_action} " \
-               "V2: #{version2_action} " \
-               "tenancy_ref: #{@criteria.tenancy_ref}"
-            )
-          else
-            Rails.logger.info(
-              "Classifier V1 & V2 Match for tenancy_ref: #{@criteria.tenancy_ref}"
-            )
-          end
-
-          version1_action
+          action
         end
       end
     end

--- a/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
@@ -1,42 +1,5 @@
 require 'rails_helper'
 
-describe Hackney::Income::TenancyClassification::Classifier do
-  subject { assign_classification.execute }
-
-  let(:case_priority) { build(:case_priority) }
-  let(:criteria) { Stubs::StubCriteria.new }
-  let(:documents_related_to_case) { [] }
-
-  let(:assign_classification) { described_class.new(case_priority, criteria, documents_related_to_case) }
-
-  context 'when v1 does not match v2' do
-    let(:v1_classifier) { instance_double(Hackney::Income::TenancyClassification::V1::Classifier) }
-    let(:v2_classifier) { instance_double(Hackney::Income::TenancyClassification::V2::Classifier) }
-
-    before do
-      allow(Rails.logger).to receive(:error)
-
-      allow(Hackney::Income::TenancyClassification::V1::Classifier)
-        .to receive(:new)
-        .and_return(v1_classifier)
-      allow(Hackney::Income::TenancyClassification::V2::Classifier)
-        .to receive(:new)
-        .and_return(v2_classifier)
-
-      allow(v1_classifier)
-        .to receive(:execute)
-        .and_return(:send_first_SMS)
-      allow(v2_classifier)
-        .to receive(:execute)
-        .and_return(:no_action)
-    end
-
-    it 'returns the v1 response' do
-      expect(subject).to eq(:send_first_SMS)
-    end
-  end
-end
-
 shared_examples 'TenancyClassification Contract' do
   subject { assign_classification.execute }
 

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -24,12 +24,6 @@ end
 # Alternatively, see any file that uses the Shared Example and see what they are supplying.
 #
 shared_examples 'TenancyClassification' do |condition_matrix|
-  describe Hackney::Income::TenancyClassification::V1::Classifier do
-    v1_conditions = condition_matrix.reject { |matrix| matrix[:skip_v1_test] == true }
-
-    it_behaves_like 'TenancyClassification Internal', v1_conditions
-  end
-
   describe Hackney::Income::TenancyClassification::V2::Classifier do
     it_behaves_like 'TenancyClassification Internal', condition_matrix
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As the ruleset have been refactored, it's time phase out the old prioritiser/classifier 

## Changes proposed in this pull request
<!-- List all the changes -->
phased out classification v1

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&selectedIssue=MAAP-202

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
