### PR TITLE
Check phone number before recommending sms

### DIFF
--- a/lib/hackney/income/stored_tenancies_gateway.rb
+++ b/lib/hackney/income/stored_tenancies_gateway.rb
@@ -4,15 +4,22 @@ module Hackney
       GatewayModel = Hackney::Income::Models::CasePriority
       DocumentModel = Hackney::Cloud::Document
 
+      def initialize(contacts_gateway:)
+        @contacts_gateway = contacts_gateway
+      end
+
       def store_tenancy(tenancy_ref:, criteria:)
         gateway_model_instance = GatewayModel.find_or_initialize_by(tenancy_ref: tenancy_ref)
+
+        contact_numbers = @contacts_gateway.get_responsible_contacts(tenancy_ref: criteria.tenancy_ref).map(&:phone_numbers).flatten.uniq.compact
 
         documents = DocumentModel.exclude_uploaded.by_payment_ref(criteria.payment_ref)
 
         classification_usecase = Hackney::Income::TenancyClassification::Classifier.new(
           gateway_model_instance,
           criteria,
-          documents
+          documents,
+          contact_numbers
         )
 
         begin

--- a/lib/hackney/income/tenancy_classification/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/classifier.rb
@@ -2,10 +2,11 @@ module Hackney
   module Income
     module TenancyClassification
       class Classifier
-        def initialize(case_priority, criteria, documents)
+        def initialize(case_priority, criteria, documents, contact_numbers)
           @case_priority = case_priority
           @criteria = criteria
           @documents = documents
+          @contact_numbers = contact_numbers
 
           @version1_classifier = Hackney::Income::TenancyClassification::V1::Classifier.new(
             case_priority,
@@ -15,7 +16,8 @@ module Hackney
           @version2_classifier = Hackney::Income::TenancyClassification::V2::Classifier.new(
             case_priority,
             criteria,
-            documents
+            documents,
+            contact_numbers
           )
         end
 

--- a/lib/hackney/income/tenancy_classification/v1/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v1/classifier.rb
@@ -3,7 +3,7 @@ module Hackney
     module TenancyClassification
       module V1
         class Classifier
-          def initialize(case_priority, criteria, documents)
+          def initialize(case_priority, criteria, documents, phone_number = nil)
             @criteria = criteria
             @case_priority = case_priority
             @documents = documents

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -5,10 +5,11 @@ module Hackney
         class Classifier
           include Helpers
 
-          def initialize(case_priority, criteria, documents)
+          def initialize(case_priority, criteria, documents, contact_numbers)
             @criteria = criteria
             @case_priority = case_priority
             @documents = documents
+            @contact_numbers = contact_numbers
           end
 
           def execute
@@ -29,22 +30,18 @@ module Hackney
               Rulesets::ApplyForCourtDate
             ]
 
-            actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents).execute }
+            actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents, @contact_numbers).execute }
 
             actions.compact!
 
             actions << :no_action if actions.none?
 
             if actions.length > 1
-              if actions == %i[send_first_SMS send_letter_one]
-                actions = %i[send_letter_one]
-              else
-                Rails.logger.error(
-                  'CLASSIFIER: Multiple recommended actions from V2' \
-                  "Actions: #{actions} " \
-                  "tenancy_ref: #{@criteria.tenancy_ref}"
-                )
-              end
+              Rails.logger.error(
+                'CLASSIFIER: Multiple recommended actions from V2' \
+                "Actions: #{actions} " \
+                "tenancy_ref: #{@criteria.tenancy_ref}"
+              )
             end
 
             validate_wanted_action(actions.first)

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
@@ -6,10 +6,11 @@ module Hackney
           class BaseRuleset
             include V2::Helpers
 
-            def initialize(case_priority, criteria, documents)
+            def initialize(case_priority, criteria, documents, contact_numbers)
               @case_priority = case_priority
               @criteria = criteria
               @documents = documents
+              @contact_numbers = contact_numbers
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
@@ -41,12 +41,14 @@ module Hackney
             end
 
             def invalid_phone_number?
+              return true if @contact_numbers.empty?
+
               phone_number_valid = @contact_numbers.map do |phone_number|
                 phone = Phonelib.parse(phone_number)
-                phone.valid?
+                phone.invalid? || phone.types.include?(:fixed_line)
               end
 
-              return if phone_number_valid.include?(false)
+              return true if phone_number_valid.include?(true)
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
@@ -13,6 +13,7 @@ module Hackney
             def action_valid
               return false if should_prevent_action?
               return false if @criteria.collectable_arrears.blank?
+              return false if invalid_phone_number?
               return false if @criteria.courtdate.present?
               return false if @criteria.nosp.served?
               return false if @criteria.active_agreement?
@@ -37,6 +38,15 @@ module Hackney
                 Hackney::Tenancy::ActionCodes::MANUAL_AMBER_SMS_ACTION_CODE,
                 Hackney::Tenancy::ActionCodes::TEXT_MESSAGE_SENT
               ]
+            end
+
+            def invalid_phone_number?
+              phone_number_valid = @contact_numbers.map do |phone_number|
+                phone = Phonelib.parse(phone_number)
+                phone.valid?
+              end
+
+              return if phone_number_valid.include?(false)
             end
           end
         end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -252,7 +252,9 @@ module Hackney
       end
 
       def stored_tenancies_gateway
-        Hackney::Income::StoredTenanciesGateway.new
+        Hackney::Income::StoredTenanciesGateway.new(
+          contacts_gateway: contacts_gateway
+        )
       end
 
       def tenancy_api_gateway

--- a/spec/features/letter_automation/failing_validation_blocks_sending_letters_spec.rb
+++ b/spec/features/letter_automation/failing_validation_blocks_sending_letters_spec.rb
@@ -66,6 +66,9 @@ describe 'syncing triggers automatic sending of letters', type: :feature do
   end
 
   def when_the_sync_runs(document_count_changes_by:, case_priority_count_changes_by:)
+    allow_any_instance_of(Hackney::Tenancy::Gateway::ContactsGateway)
+      .to receive(:get_responsible_contacts)
+      .and_return([])
     expect {
       expect {
         perform_enqueued_jobs(only: allowed_jobs) do

--- a/spec/features/letter_automation/syncing_spec.rb
+++ b/spec/features/letter_automation/syncing_spec.rb
@@ -28,6 +28,10 @@ describe 'syncing triggers automatic sending of letters', type: :feature do
     )
     mock_gov_notify_client
 
+    allow_any_instance_of(Hackney::Tenancy::Gateway::ContactsGateway)
+      .to receive(:get_responsible_contacts)
+      .and_return([])
+
     ENV['CAN_AUTOMATE_LETTERS'] = 'true'
     ENV['AUTOMATE_INCOME_COLLECTION_LETTER_ONE'] = 'true'
     ENV['PATCH_CODES_FOR_LETTER_AUTOMATION'] = 'W02'

--- a/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/stored_tenancies_gateway_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe Hackney::Income::StoredTenanciesGateway do
-  let(:gateway) { described_class.new }
+  let(:contacts_gateway) { double(Hackney::Tenancy::Gateway::ContactsGateway) }
+  let(:gateway) { described_class.new(contacts_gateway: contacts_gateway) }
 
   let(:tenancy_model) { Hackney::Income::Models::CasePriority }
   let(:document_model) { Hackney::Cloud::Document }
@@ -30,8 +31,10 @@ describe Hackney::Income::StoredTenanciesGateway do
 
       expect(document_model).to receive(:by_payment_ref).with(stubbed_criteria.payment_ref).and_return([])
 
+      allow(contacts_gateway).to receive(:get_responsible_contacts).and_return([])
+
       expect(Hackney::Income::TenancyClassification::Classifier).to receive(:new)
-        .with(instance_of(tenancy_model), stubbed_criteria, [])
+        .with(instance_of(tenancy_model), stubbed_criteria, [], [])
         .and_return(tenancy_classification_stub)
     end
 

--- a/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/classifier_spec.rb
@@ -6,8 +6,9 @@ describe Hackney::Income::TenancyClassification::Classifier do
   let(:case_priority) { build(:case_priority) }
   let(:criteria) { Stubs::StubCriteria.new }
   let(:documents_related_to_case) { [] }
+  let(:contact_numbers) { [] }
 
-  let(:assign_classification) { described_class.new(case_priority, criteria, documents_related_to_case) }
+  let(:assign_classification) { described_class.new(case_priority, criteria, documents_related_to_case, contact_numbers) }
 
   context 'when v1 does not match v2' do
     let(:v1_classifier) { instance_double(Hackney::Income::TenancyClassification::V1::Classifier) }
@@ -42,7 +43,9 @@ shared_examples 'TenancyClassification Contract' do
 
   let(:criteria) { Stubs::StubCriteria.new(attributes) }
   let(:documents_related_to_case) { [] }
-  let(:assign_classification) { described_class.new(case_priority, criteria, documents_related_to_case) }
+  let(:contact_numbers) { [] }
+
+  let(:assign_classification) { described_class.new(case_priority, criteria, documents_related_to_case, contact_numbers) }
 
   let(:attributes) do
     {

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_one_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_one_spec.rb
@@ -134,7 +134,8 @@ describe 'Send Letter One Rule', type: :feature do
       last_communication_date: 2.weeks.ago.to_date,
       last_communication_action: '',
       eviction_date: '',
-      courtdate: nil
+      courtdate: nil,
+      phone_numbers: ['07654321098']
     },
     # last action was send letter two, falls back into send letter one and no action is carried out for  over 3 months
     {

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
@@ -24,23 +24,22 @@ describe 'Send First SMS Rule examples' do
       balance: 1
     ),
     base_example.merge(
-        description: 'when the collectable_arrears is more than £5, but there is no phone number on the case',
-        outcome: :no_action,
-        phone_numbers: [],
-        skip_v1_test: true
+      description: 'when the collectable_arrears is more than £5, but there is no phone number on the case',
+      outcome: :no_action,
+      phone_numbers: [],
+      skip_v1_test: true
     ),
     base_example.merge(
-        description: 'when the collectable_arrears is more than £5, but phone number on case is not valid',
-        outcome: :no_action,
-        phone_numbers: ['not a real number'],
-        skip_v1_test: true
+      description: 'when the collectable_arrears is more than £5, but phone number on case is not valid',
+      outcome: :no_action,
+      phone_numbers: ['not a real number'],
+      skip_v1_test: true
     ),
     base_example.merge(
-        description: 'when the collectable_arrears is more than £5, but phone number on case is to a not mobile',
-        outcome: :no_action,
-        phone_numbers: ['02083563000'],
-        skip_v1_test: true
-
+      description: 'when the collectable_arrears is more than £5, but phone number on case is to a not mobile',
+      outcome: :no_action,
+      phone_numbers: ['02083563000'],
+      skip_v1_test: true
     ),
     base_example.merge(
       description: 'with breached informal agreement',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
@@ -4,7 +4,8 @@ describe 'Send First SMS Rule examples' do
   base_example = {
     outcome: :send_first_SMS,
     collectable_arrears: 5,
-    balance: 5
+    balance: 5,
+    phone_numbers: ['07654321098']
   }
   examples = [
     base_example,
@@ -21,6 +22,25 @@ describe 'Send First SMS Rule examples' do
       outcome: :no_action,
       collectable_arrears: 1,
       balance: 1
+    ),
+    base_example.merge(
+        description: 'when the collectable_arrears is more than £5, but there is no phone number on the case',
+        outcome: :no_action,
+        phone_numbers: [],
+        skip_v1_test: true
+    ),
+    base_example.merge(
+        description: 'when the collectable_arrears is more than £5, but phone number on case is not valid',
+        outcome: :no_action,
+        phone_numbers: ['not a real number'],
+        skip_v1_test: true
+    ),
+    base_example.merge(
+        description: 'when the collectable_arrears is more than £5, but phone number on case is to a not mobile',
+        outcome: :no_action,
+        phone_numbers: ['02083563000'],
+        skip_v1_test: true
+
     ),
     base_example.merge(
       description: 'with breached informal agreement',

--- a/spec/requests/manually_sending_a_letter_syncs_spec.rb
+++ b/spec/requests/manually_sending_a_letter_syncs_spec.rb
@@ -75,6 +75,10 @@ describe 'manually sending a letter causes case priority to sync', type: :reques
       }
 
       before do
+        allow_any_instance_of(Hackney::Tenancy::Gateway::ContactsGateway)
+          .to receive(:get_responsible_contacts)
+          .and_return([])
+
         generate_and_store_income_collection_letter
         income_use_case_factory.sync_case_priority.execute(tenancy_ref: tenancy_ref)
 

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -25,7 +25,9 @@ end
 #
 shared_examples 'TenancyClassification' do |condition_matrix|
   describe Hackney::Income::TenancyClassification::V1::Classifier do
-    it_behaves_like 'TenancyClassification Internal', condition_matrix
+    v1_conditions = condition_matrix.select {|matrix| matrix[:skip_v1_test] != true }
+
+    it_behaves_like 'TenancyClassification Internal', v1_conditions
   end
 
   describe Hackney::Income::TenancyClassification::V2::Classifier do
@@ -38,9 +40,10 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
 
   let(:assign_classification) {
     described_class.new(
-      case_priority, criteria, [], []
+      case_priority, criteria, [], phone_numbers
     )
   }
+
   let(:criteria) { Stubs::StubCriteria.new(attributes) }
   let(:case_priority) { build(:case_priority, is_paused_until: is_paused_until) }
 
@@ -86,6 +89,8 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
       let(:most_recent_agreement) { options[:most_recent_agreement] }
       let(:days_since_last_payment) { options[:days_since_last_payment] }
       let(:total_payment_amount_in_week) { options[:total_payment_amount_in_week] }
+
+      let(:phone_numbers) { options[:phone_numbers] || [] }
 
       it "returns `#{options[:outcome]}`" do
         expect(subject).to eq(options[:outcome])

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -25,7 +25,7 @@ end
 #
 shared_examples 'TenancyClassification' do |condition_matrix|
   describe Hackney::Income::TenancyClassification::V1::Classifier do
-    v1_conditions = condition_matrix.select {|matrix| matrix[:skip_v1_test] != true }
+    v1_conditions = condition_matrix.reject { |matrix| matrix[:skip_v1_test] == true }
 
     it_behaves_like 'TenancyClassification Internal', v1_conditions
   end

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -38,7 +38,7 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
 
   let(:assign_classification) {
     described_class.new(
-      case_priority, criteria, []
+      case_priority, criteria, [], []
     )
   }
   let(:criteria) { Stubs::StubCriteria.new(attributes) }


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
we need to check if a case has a valid phone number before recommending the system to send sms

## Changes proposed in this pull request
<!-- List all the changes -->
- check if there is a valid phone number in the sms ruleset
- allow the test suite to skip v1 classifier on some tests

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
