### PR TITLE
Use collectable arrears for v2 helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ $ rspec path/to/spec
 
 The above is useful because you can TDD your change and manually test through the browser without having to restart anything.
 
+If you find that when running tests, UH simulator keeps dying, it might be because you need to [assign more memory to Docker](https://docs.docker.com/docker-for-mac/#preferences) (this link is specifically for macs, but other operating systems might be similar).
+
 #### Linting
 
 "Linters" run static analysis on code to ensure it meets style standards. We use [Rubocop][rubocop] on this project with a permissive configuration.

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -95,7 +95,7 @@ module Hackney
           end
 
           def balance_with_1_week_grace
-            @criteria.balance - calculated_grace_amount
+            @criteria.collectable_arrears - calculated_grace_amount
           end
 
           def calculated_grace_amount

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -20,6 +20,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
   let(:total_payment_amount_in_week) { 0 }
   let(:weekly_rent) { 0 }
   let(:balance) { 0 }
+  let(:collectable_arrears) { 0 }
   let(:criteria) {
     Stubs::StubCriteria.new(
       eviction_date: eviction_date,
@@ -29,7 +30,8 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
       most_recent_agreement: most_recent_agreement,
       total_payment_amount_in_week: total_payment_amount_in_week,
       weekly_rent: weekly_rent,
-      balance: balance
+      balance: balance,
+      collectable_arrears: collectable_arrears
     )
   }
 
@@ -392,12 +394,13 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
   describe 'balance_with_1_week_grace' do
     subject { helpers.balance_with_1_week_grace }
 
-    context 'when total payment amount not being above the weekly rent' do
-      let(:balance) { 15 }
+    context 'when balance and collectable arrears are different' do
+      let(:balance) { 635.02 }
+      let(:collectable_arrears) { 590.0 }
 
-      it 'return the difference between balance and grace amount' do
-        allow(helpers).to receive(:calculated_grace_amount).and_return(5)
-        expect(subject).to eq(10)
+      it 'returns the difference between collectable arrears and grace amount' do
+        allow(helpers).to receive(:calculated_grace_amount).and_return(45.02)
+        expect(subject).to eq(544.98)
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
There is currently a case which V1 classifies as `no_action` but V2 classifies as `apply_for_court_date`.

Found that for V2, the helper function `balance_with_1_week_grace` uses `@criteria.balance`.
But it should use `@criteria.collectable_arrears` [as V1 does](https://github.com/LBHackney-IT/lbh-income-api/blob/f957bcdddd2c90afa1f13e4d1e105fc99fb1e7a2/lib/hackney/income/tenancy_classification/v1/classifier.rb#L257).

Also for a while I had an issue where while running all tests, UH simulator kept dying.
Turns out it was because I didn't have enough memory allocated for Docker, so I thought a little info about that in the README might be good.

## Changes proposed in this pull request
<!-- List all the changes -->
- Make `balance_with_1_week_grace` use `@criteria.collectable_arrears` for V2
- Fix the test around this, using details from the case that is deviating

- Add info in readme about ensuring you have enough memory for docker

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Anything! 😄 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-361?atlOrigin=eyJpIjoiZDgzNGI0NDUzNGQ2NDFmODg1ZWIxNTdhZjkzZDkzYWQiLCJwIjoiaiJ9

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
