### PR TITLE
add upper limit of £10 to sms rule

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
@@ -18,6 +18,7 @@ module Hackney
               return false if @criteria.nosp.served?
               return false if @criteria.active_agreement?
               return false if breached_agreement? && !court_breach_agreement?
+              return false if @criteria.collectable_arrears >= 10
 
               if @criteria.last_communication_action.present?
                 return false if @criteria.last_communication_action.in?(blocking_communication_actions) &&

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
@@ -24,6 +24,12 @@ describe 'Send First SMS Rule examples' do
       balance: 1
     ),
     base_example.merge(
+      description: 'when the collectable_arrears is more than £10',
+      outcome: :send_letter_one,
+      collectable_arrears: 11,
+      balance: 11
+    ),
+    base_example.merge(
       description: 'when the collectable_arrears is more than £5, but there is no phone number on the case',
       outcome: :no_action,
       phone_numbers: [],


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
to avoid classifying cases as both send letter one and send sms we needed an upper limit

## Changes proposed in this pull request
<!-- List all the changes -->
don't send sms if collectable arrears are more than £10

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-359

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
