### PR TITLE
Add strike out date and created by to court case model

### DIFF
--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -6,7 +6,9 @@ module CourtCaseResponseHelper
       courtDecisionDate: court_case.court_decision_date,
       courtOutcome: court_case.court_outcome,
       balanceAtOutcomeDate: court_case.balance_at_outcome_date,
-      createdAt: court_case.created_at.strftime('%F')
+      createdAt: court_case.created_at.strftime('%F'),
+      strikeOutDate: court_case.strike_out_date.strftime('%F'),
+      createdBy: court_case.created_by
     }
   end
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -17,7 +17,9 @@ class CourtCasesController < ApplicationController
       tenancy_ref: params.fetch(:tenancy_ref),
       court_decision_date: params.fetch(:court_decision_date),
       court_outcome: params.fetch(:court_outcome),
-      balance_at_outcome_date: params.fetch(:balance_at_outcome_date)
+      balance_at_outcome_date: params.fetch(:balance_at_outcome_date),
+      strike_out_date: params.fetch(:strike_out_date),
+      created_by: params.fetch(:created_by)
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,7 +2,7 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
-        validates_presence_of :tenancy_ref, :court_decision_date, :court_outcome, :balance_at_outcome_date
+        validates_presence_of :tenancy_ref, :court_decision_date, :court_outcome, :balance_at_outcome_date, :strike_out_date, :created_by
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
       end
     end

--- a/db/migrate/20200729112644_update_court_case_model.rb
+++ b/db/migrate/20200729112644_update_court_case_model.rb
@@ -1,0 +1,6 @@
+class UpdateCourtCaseModel < ActiveRecord::Migration[5.2]
+  def change
+    add_column :court_cases, :strike_out_date, :datetime, null: false
+    add_column :court_cases, :created_by, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_150054) do
+ActiveRecord::Schema.define(version: 2020_07_29_112644) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -107,6 +107,8 @@ ActiveRecord::Schema.define(version: 2020_07_16_150054) do
     t.string "tenancy_ref", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "strike_out_date", null: false
+    t.string "created_by", null: false
   end
 
   create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -6,7 +6,9 @@ module Hackney
           tenancy_ref: court_case_params[:tenancy_ref],
           court_decision_date: court_case_params[:court_decision_date],
           court_outcome: court_case_params[:court_outcome],
-          balance_at_outcome_date: court_case_params[:balance_at_outcome_date]
+          balance_at_outcome_date: court_case_params[:balance_at_outcome_date],
+          strike_out_date: court_case_params[:strike_out_date],
+          created_by: court_case_params[:created_by]
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :court_case, class: Hackney::Income::Models::CourtCase do
+    tenancy_ref { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
+    court_decision_date { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+    court_outcome { Faker::ChuckNorris.fact }
+    balance_at_outcome_date { Faker::Commerce.price(range: 10...100) }
+    strike_out_date { Faker::Date.forward(days: 365) }
+    created_by { Faker::Name.name }
+  end
+end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -7,13 +7,17 @@ describe Hackney::Income::CreateCourtCase do
   let(:court_decision_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
   let(:court_outcome) { Faker::ChuckNorris.fact }
   let(:balance_at_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:strike_out_date) { Faker::Date.forward(days: 365) }
+  let(:created_by) { Faker::Name.name }
 
   let(:new_court_case_params) do
     {
       tenancy_ref: tenancy_ref,
       court_decision_date: court_decision_date,
       court_outcome: court_outcome,
-      balance_at_outcome_date: balance_at_outcome_date
+      balance_at_outcome_date: balance_at_outcome_date,
+      strike_out_date: strike_out_date,
+      created_by: created_by
     }
   end
 
@@ -27,5 +31,7 @@ describe Hackney::Income::CreateCourtCase do
     expect(court_case.court_decision_date).to eq(court_decision_date)
     expect(court_case.court_outcome).to eq(court_outcome)
     expect(court_case.balance_at_outcome_date).to eq(balance_at_outcome_date)
+    expect(court_case.strike_out_date).to eq(strike_out_date)
+    expect(court_case.created_by).to eq(created_by)
   end
 end

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -22,7 +22,9 @@ describe Hackney::Income::CreateFormalAgreement do
       tenancy_ref: tenancy_ref,
       balance_at_outcome_date: Faker::Commerce.price(range: 10...1000),
       court_decision_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-      court_outcome: Faker::ChuckNorris.fact
+      court_outcome: Faker::ChuckNorris.fact,
+      strike_out_date: Faker::Date.forward(days: 365),
+      created_by: Faker::Name.name
     )
   end
   let(:expected_action_diray_note) { "Formal agreement created: #{notes}" }

--- a/spec/lib/hackney/income/create_informal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_informal_agreement_spec.rb
@@ -24,14 +24,7 @@ describe Hackney::Income::CreateInformalAgreement do
   let(:amount) { Faker::Commerce.price(range: 10...100) }
   let(:agreement_type) { 'informal' }
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:court_case) do
-    Hackney::Income::Models::CourtCase.create!(
-      tenancy_ref: tenancy_ref,
-      balance_at_outcome_date: Faker::Commerce.price(range: 10...1000),
-      court_decision_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-      court_outcome: Faker::ChuckNorris.fact
-    )
-  end
+  let(:court_case) { create(:court_case) }
 
   it_behaves_like 'CreateAgreement'
 

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -15,16 +15,20 @@ describe Hackney::Income::ViewCourtCases do
     let(:balance_at_outcome_date) { Faker::Commerce.price(range: 10...1000) }
     let(:court_decision_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     let(:court_outcome) { Faker::ChuckNorris.fact }
+    let(:strike_out_date) { Faker::Date.forward(days: 365) }
+    let(:created_by) { Faker::Name.name }
     let(:court_cases_param) do
       {
         tenancy_ref: tenancy_ref,
         balance_at_outcome_date: balance_at_outcome_date,
         court_decision_date: court_decision_date,
-        court_outcome: court_outcome
+        court_outcome: court_outcome,
+        strike_out_date: strike_out_date,
+        created_by: created_by
       }
     end
 
-    let!(:expected_court_case) { Hackney::Income::Models::CourtCase.create!(court_cases_param) }
+    let!(:expected_court_case) { create(:court_case, court_cases_param) }
 
     it 'returns an array of court cases for the given tenancy_ref' do
       response = subject
@@ -35,6 +39,8 @@ describe Hackney::Income::ViewCourtCases do
       expect(response.first.balance_at_outcome_date).to eq(balance_at_outcome_date)
       expect(response.first.court_decision_date).to eq(court_decision_date)
       expect(response.first.court_outcome).to eq(court_outcome)
+      expect(response.first.strike_out_date).to eq(strike_out_date)
+      expect(response.first.created_by).to eq(created_by)
       expect(response.first.agreements).to eq([])
     end
 

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -15,6 +15,8 @@ describe Hackney::Income::Models::CourtCase, type: :model do
   it { is_expected.to validate_presence_of(:court_decision_date) }
   it { is_expected.to validate_presence_of(:court_outcome) }
   it { is_expected.to validate_presence_of(:balance_at_outcome_date) }
+  it { is_expected.to validate_presence_of(:strike_out_date) }
+  it { is_expected.to validate_presence_of(:created_by) }
   it { is_expected.to have_many(:agreements) }
 
   it 'can have associated formal agreements' do
@@ -24,7 +26,9 @@ describe Hackney::Income::Models::CourtCase, type: :model do
       tenancy_ref: tenancy_ref,
       court_decision_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
       court_outcome: Faker::ChuckNorris.fact,
-      balance_at_outcome_date: Faker::Commerce.price(range: 10...100)
+      balance_at_outcome_date: Faker::Commerce.price(range: 10...100),
+      strike_out_date: Faker::Date.forward(days: 365),
+      created_by: Faker::Name.name
     )
 
     Hackney::Income::Models::Agreement.create!(

--- a/spec/support/shared_examples/create_agreement.rb
+++ b/spec/support/shared_examples/create_agreement.rb
@@ -12,7 +12,9 @@ RSpec.shared_examples 'CreateAgreement' do
       tenancy_ref: tenancy_ref,
       balance_at_outcome_date: Faker::Commerce.price(range: 10...1000),
       court_decision_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-      court_outcome: Faker::ChuckNorris.fact
+      court_outcome: Faker::ChuckNorris.fact,
+      strike_out_date: Faker::Date.forward(days: 365),
+      created_by: Faker::Name.name
     )
   end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
After the discussion around  and formal agreements, we realised we need to include `strike out date` and `created by` for court cases in the system.
## Changes proposed in this pull request
<!-- List all the changes -->
- Add `strike out date` and `created by` to the CourtCase model
- Update usecases, controller and tests to work with this

