### PR TITLE
Add use-case to detect breaches in informal agreements

### DIFF
--- a/lib/hackney/income/detect_breach.rb
+++ b/lib/hackney/income/detect_breach.rb
@@ -1,0 +1,62 @@
+module Hackney
+  module Income
+    class DetectBreach
+      def initialize(tolerance_days:)
+        @tolerance_days = tolerance_days
+      end
+
+      def execute(agreement:)
+        return false unless agreement.active?
+        return false unless breached?(agreement)
+
+        Hackney::Income::Models::AgreementState.create!(agreement_id: agreement.id, agreement_state: :breached)
+      end
+
+      private
+
+      def breached?(agreement)
+        date_of_first_check = agreement.start_date + @tolerance_days.days
+
+        return false if date_of_first_check.future?
+
+        number_of_instalments = number_of_instalments(date_of_first_check, agreement.frequency)
+        expected_balance = agreement.starting_balance - (number_of_instalments * agreement.amount)
+        current_balance = Hackney::Income::Models::CasePriority.where(tenancy_ref: agreement.tenancy_ref).first.balance.to_f
+
+        expected_balance < current_balance
+      end
+
+      def number_of_instalments(date, frequency)
+        instalments = if frequency == 'weekly'
+                        payment_cycles_since(date, 7)
+                      elsif frequency == 'fortnightly'
+                        payment_cycles_since(date, 14)
+                      elsif frequency == '4 weekly'
+                        payment_cycles_since(date, 28)
+                      else
+                        full_months_since(date)
+                      end
+        instalments + 1
+      end
+
+      def full_months_since(date, number = 0)
+        date += 1.month
+        return number if date > Time.now.beginning_of_day
+        return number + 1 if date == Time.now.beginning_of_day
+
+        full_months_since(date, number + 1)
+      end
+
+      def payment_cycles_since(date, days)
+        time_difference = Time.now.beginning_of_day - date
+        number_cycles = (time_difference / days.days).to_i
+
+        prevent_negative(number_cycles)
+      end
+
+      def prevent_negative(number)
+        [number, 0].max
+      end
+    end
+  end
+end

--- a/spec/factories/agreement.rb
+++ b/spec/factories/agreement.rb
@@ -1,0 +1,32 @@
+FactoryBot.define do
+  factory :agreement, class: Hackney::Income::Models::Agreement do
+    tenancy_ref { Faker::Lorem.characters(number: 5) }
+    agreement_type { :informal }
+    notes { Faker::ChuckNorris.fact }
+    created_by { Faker::Name.name }
+    frequency { [:weekly, :monthly, :fortnightly, '4 weekly'].sample }
+    start_date { Faker::Date.between(from: 2.days.ago, to: Date.today) }
+    amount { Faker::Commerce.price(range: 10...100) }
+  end
+
+  factory :agreement_state, class: Hackney::Income::Models::AgreementState do
+    agreement
+    agreement_state { :live }
+
+    trait :live do
+      agreement_state { :live }
+    end
+
+    trait :breached do
+      agreement_state { :breached }
+    end
+
+    trait :cancelled do
+      agreement_state { :cancelled }
+    end
+
+    trait :completed do
+      agreement_state { :completed }
+    end
+  end
+end

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -21,14 +21,13 @@ describe Hackney::Income::CancelAgreement do
     }
   end
 
-  let!(:agreement) { Hackney::Income::Models::Agreement.create!(agreement_params) }
+  let!(:agreement) { create(:agreement, agreement_params) }
   let(:active_state) { %w[live breached].sample }
 
   before do
-    Hackney::Income::Models::AgreementState.create(
-      agreement_id: agreement.id,
-      agreement_state: active_state
-    )
+    create(:agreement_state,
+           agreement_id: agreement.id,
+           agreement_state: active_state)
   end
 
   it 'cancelles an active agreement' do
@@ -49,7 +48,9 @@ describe Hackney::Income::CancelAgreement do
 
   context 'when an agreement is completed' do
     before do
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'completed')
+      create(:agreement_state,
+             :completed,
+             agreement_id: agreement.id)
     end
 
     it 'returns the initial agreement' do
@@ -66,7 +67,9 @@ describe Hackney::Income::CancelAgreement do
 
   context 'when an agreement is already cancelled' do
     before do
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'cancelled')
+      create(:agreement_state,
+             :cancelled,
+             agreement_id: agreement.id)
     end
 
     it 'returns the initial agreement' do

--- a/spec/lib/hackney/income/create_informal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_informal_agreement_spec.rb
@@ -30,14 +30,13 @@ describe Hackney::Income::CreateInformalAgreement do
 
   context 'when there is a previous breached agreement for the tenancy' do
     before do
-      breached_agreement = Hackney::Income::Models::Agreement.create(
-        tenancy_ref: tenancy_ref,
-        current_state: 'breached',
-        created_by: created_by,
-        agreement_type: 'informal'
-      )
-      Hackney::Income::Models::AgreementState.create(agreement_id: breached_agreement.id, agreement_state: 'breached')
-      Hackney::Income::Models::CasePriority.create!(tenancy_ref: tenancy_ref, balance: 200)
+      breached_agreement = create(:agreement,
+                                  tenancy_ref: tenancy_ref,
+                                  current_state: 'breached',
+                                  created_by: created_by,
+                                  agreement_type: 'informal')
+      create(:agreement_state, :breached, agreement_id: breached_agreement.id)
+      create(:case_priority, tenancy_ref: tenancy_ref, balance: 200)
     end
 
     it 'cancelles the existing breached agreement and creates a new live agreement' do
@@ -54,19 +53,18 @@ describe Hackney::Income::CreateInformalAgreement do
 
   context 'when there is an existing formal agreement for the tenancy' do
     before do
-      Hackney::Income::Models::CasePriority.create!(tenancy_ref: tenancy_ref, balance: 200)
+      create(:case_priority, tenancy_ref: tenancy_ref, balance: 200)
 
-      existing_agreement = Hackney::Income::Models::Agreement.create!(
-        tenancy_ref: tenancy_ref,
-        amount: Faker::Commerce.price(range: 10...100),
-        start_date: Faker::Date.between(from: 4.days.ago, to: Date.today),
-        frequency: frequency,
-        created_by: created_by,
-        agreement_type: 'formal',
-        court_case_id: court_case.id,
-        notes: notes
-      )
-      Hackney::Income::Models::AgreementState.create!(agreement_id: existing_agreement.id, agreement_state: :live)
+      existing_agreement = create(:agreement,
+                                  tenancy_ref: tenancy_ref,
+                                  amount: Faker::Commerce.price(range: 10...100),
+                                  start_date: Faker::Date.between(from: 4.days.ago, to: Date.today),
+                                  frequency: frequency,
+                                  created_by: created_by,
+                                  agreement_type: 'formal',
+                                  court_case_id: court_case.id,
+                                  notes: notes)
+      create(:agreement_state, :live, agreement_id: existing_agreement.id)
     end
 
     it 'does not allow create a new informal agreement' do
@@ -77,7 +75,7 @@ describe Hackney::Income::CreateInformalAgreement do
     context 'when the formal agreement is completed' do
       before do
         existing_agreement = Hackney::Income::Models::Agreement.first
-        Hackney::Income::Models::AgreementState.create!(agreement_id: existing_agreement.id, agreement_state: :completed)
+        create(:agreement_state, :completed, agreement_id: existing_agreement.id)
       end
 
       it 'allows to create a new informal agreement' do

--- a/spec/lib/hackney/income/detect_breach_spec.rb
+++ b/spec/lib/hackney/income/detect_breach_spec.rb
@@ -34,17 +34,7 @@ describe Hackney::Income::DetectBreach do
   end
 
   context 'when the agreement has an inactive state' do
-    let(:agreement) do
-      Hackney::Income::Models::Agreement.new(
-        tenancy_ref: tenancy_ref,
-        agreement_type: :informal,
-        start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-        frequency: :weekly,
-        amount: Faker::Commerce.price(range: 10...100),
-        current_state: %i[completed cancelled].sample,
-        created_by: Faker::Name.name
-      )
-    end
+    let(:agreement) { build_stubbed(:agreement) }
 
     it 'returns false' do
       expect(subject.execute(agreement: agreement)).to be_falsy
@@ -211,24 +201,21 @@ describe Hackney::Income::DetectBreach do
   end
 
   def stub_informal_agreement(start_date:, frequency:, amount:, starting_balance:)
-    Hackney::Income::Models::CasePriority.create!(
-      tenancy_ref: tenancy_ref,
-      balance: starting_balance
-    )
+    create(:case_priority,
+           tenancy_ref: tenancy_ref,
+           balance: starting_balance)
 
-    agreement = Hackney::Income::Models::Agreement.create!(
-      tenancy_ref: tenancy_ref,
-      agreement_type: :informal,
-      start_date: start_date,
-      frequency: frequency,
-      amount: amount,
-      created_by: Faker::Name.name,
-      starting_balance: starting_balance
-    )
-    Hackney::Income::Models::AgreementState.create(
-      agreement_id: agreement.id,
-      agreement_state: :live
-    )
+    agreement = create(:agreement,
+                       tenancy_ref: tenancy_ref,
+                       start_date: start_date,
+                       frequency: frequency,
+                       amount: amount,
+                       starting_balance: starting_balance)
+
+    create(:agreement_state,
+           :live,
+           agreement: agreement)
+
     agreement
   end
 

--- a/spec/lib/hackney/income/detect_breach_spec.rb
+++ b/spec/lib/hackney/income/detect_breach_spec.rb
@@ -1,0 +1,241 @@
+require 'rails_helper'
+
+describe Hackney::Income::DetectBreach do
+  subject { described_class.new(tolerance_days: days_before_check) }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:days_before_check) { 5 }
+  let(:start_date) { Time.zone.local(2019, 11, 1) }
+
+  it 'allows a number of days before checking for breach' do
+    start_date = Time.zone.local(2019, 11, 1)
+    agreement = stub_informal_agreement(
+      start_date: start_date,
+      frequency: :monthly,
+      amount: 500,
+      starting_balance: 1000
+    )
+
+    date_within_tolerance = start_date + (days_before_check - 1).days
+
+    Timecop.freeze(date_within_tolerance) do
+      subject.execute(agreement: agreement)
+
+      expect(agreement.current_state).to eq('live')
+    end
+
+    date_beyond_tolerance = start_date + days_before_check.days
+
+    Timecop.freeze(date_beyond_tolerance) do
+      subject.execute(agreement: agreement)
+
+      expect(agreement.current_state).to eq('breached')
+    end
+  end
+
+  context 'when the agreement has an inactive state' do
+    let(:agreement) do
+      Hackney::Income::Models::Agreement.new(
+        tenancy_ref: tenancy_ref,
+        agreement_type: :informal,
+        start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
+        frequency: :weekly,
+        amount: Faker::Commerce.price(range: 10...100),
+        current_state: %i[completed cancelled].sample,
+        created_by: Faker::Name.name
+      )
+    end
+
+    it 'returns false' do
+      expect(subject.execute(agreement: agreement)).to be_falsy
+    end
+  end
+
+  context 'when the agreement is not breached' do
+    it 'returns false' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: :monthly,
+        amount: 500,
+        starting_balance: 1000
+      )
+
+      Timecop.freeze(start_date) do
+        expect(subject.execute(agreement: agreement)).to be_falsy
+        expect(agreement.current_state).to eq('live')
+      end
+    end
+  end
+
+  context 'when the frequency of payment is :monthly' do
+    it 'updates the state of the agreement when its breached' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: :monthly,
+        amount: 20,
+        starting_balance: 100
+      )
+
+      set_current_balance(80)
+
+      one_month_later = start_date + days_before_check.days + 1.month
+      one_day_before_next_cycle = one_month_later - 1.day
+
+      Timecop.freeze(one_day_before_next_cycle) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('live')
+      end
+
+      Timecop.freeze(one_month_later) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('breached')
+      end
+    end
+  end
+
+  context 'when the frequency of payment is :weekly' do
+    it 'updates the state of the agreement when its breached' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: :weekly,
+        amount: 20,
+        starting_balance: 100
+      )
+
+      three_weeks_later = start_date + days_before_check.days + 3.weeks
+      one_day_before_next_cycle = three_weeks_later - 1.day
+
+      set_current_balance(40)
+
+      Timecop.freeze(one_day_before_next_cycle) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('live')
+      end
+
+      Timecop.freeze(three_weeks_later) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('breached')
+      end
+    end
+  end
+
+  context 'when the frequency of payment is :fortnightly' do
+    it 'updates the state of the agreement when its breached' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: :fortnightly,
+        amount: 20,
+        starting_balance: 100
+      )
+
+      set_current_balance(80)
+
+      two_weeks_later = start_date + days_before_check.days + 2.weeks
+      one_day_before_next_cycle = two_weeks_later - 1.day
+
+      Timecop.freeze(one_day_before_next_cycle) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('live')
+      end
+
+      Timecop.freeze(two_weeks_later) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('breached')
+      end
+    end
+  end
+
+  context "when the frequency of payment is '4 weekly'" do
+    it 'updates the state of the agreement when its breached' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: '4 weekly',
+        amount: 20,
+        starting_balance: 100
+      )
+
+      set_current_balance(60)
+
+      eight_weeks_later = start_date + days_before_check.days + 8.weeks
+      one_day_before_next_cycle = eight_weeks_later - 1.day
+
+      Timecop.freeze(one_day_before_next_cycle) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('live')
+      end
+
+      Timecop.freeze(eight_weeks_later) do
+        subject.execute(agreement: agreement)
+
+        expect(agreement.current_state).to eq('breached')
+      end
+    end
+  end
+
+  describe '#full_months_since' do
+    it 'can calculate the exact number of months since start date' do
+      [
+        {
+          start_date: Time.zone.local(2019, 11, 1),
+          current_date: Time.zone.local(2019, 11, 1) + 1.month,
+          expected: 1
+        },
+        {
+          start_date: Time.zone.local(2019, 11, 1),
+          current_date: Time.zone.local(2019, 11, 1) + 27.days,
+          expected: 0
+        },
+        {
+          start_date: Time.zone.local(2019, 11, 1),
+          current_date: Time.zone.local(2019, 11, 1) + 2.months + 27.days,
+          expected: 2
+        },
+        {
+          start_date: Time.zone.local(2019, 2, 1),
+          current_date: Time.zone.local(2019, 2, 1) + 29.days,
+          expected: 1
+        }
+      ].each do |example|
+        Timecop.freeze(example[:current_date]) do
+          expect(subject.send(:full_months_since, example[:start_date])).to eq(example[:expected])
+        end
+      end
+    end
+  end
+
+  def stub_informal_agreement(start_date:, frequency:, amount:, starting_balance:)
+    Hackney::Income::Models::CasePriority.create!(
+      tenancy_ref: tenancy_ref,
+      balance: starting_balance
+    )
+
+    agreement = Hackney::Income::Models::Agreement.create!(
+      tenancy_ref: tenancy_ref,
+      agreement_type: :informal,
+      start_date: start_date,
+      frequency: frequency,
+      amount: amount,
+      created_by: Faker::Name.name,
+      starting_balance: starting_balance
+    )
+    Hackney::Income::Models::AgreementState.create(
+      agreement_id: agreement.id,
+      agreement_state: :live
+    )
+    agreement
+  end
+
+  def set_current_balance(balance)
+    Hackney::Income::Models::CasePriority.where(tenancy_ref: tenancy_ref).first.update(
+      tenancy_ref: tenancy_ref,
+      balance: balance
+    )
+  end
+end

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -32,7 +32,7 @@ describe Hackney::Income::ViewAgreements do
       }
     end
 
-    let!(:expected_agreement) { Hackney::Income::Models::Agreement.create!(agreement_params) }
+    let!(:expected_agreement) { create(:agreement, agreement_params) }
 
     it 'returns all agreements with the given tenancy_ref' do
       response = subject

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -52,7 +52,7 @@ describe Hackney::Income::ViewCourtCases do
           created_by: Faker::Name.name,
           court_case_id: expected_court_case.id
         }
-      agreement = Hackney::Income::Models::Agreement.create!(agreement_params)
+      agreement = create(:agreement, agreement_params)
       response = subject
 
       expect(response.first.agreements).to eq([agreement])

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -31,7 +31,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   it 'can have an associated agreement_state' do
-    Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'live')
+    create(:agreement_state, :live, agreement_id: agreement.id)
 
     expect(described_class.first.agreement_states.first).to be_a Hackney::Income::Models::AgreementState
     expect(Hackney::Income::Models::AgreementState.first.agreement_id).to eq(agreement.id)
@@ -71,8 +71,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
     end
 
     it 'returns the latest agreement state' do
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'live')
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'breached')
+      create(:agreement_state, :live, agreement_id: agreement.id)
+      create(:agreement_state, :breached, agreement_id: agreement.id)
 
       expect(agreement.current_state).to eq('breached')
     end
@@ -85,7 +85,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
 
     it 'returns true if agreement state is an active state' do
       state = %w[live breached].sample
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: state)
+      create(:agreement_state, agreement_state: state, agreement_id: agreement.id)
 
       expect(agreement.current_state).to eq(state)
       expect(agreement).to be_active
@@ -93,7 +93,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
 
     it 'returns false if agreement is inactive' do
       state = %w[cancelled completed].sample
-      Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: state)
+      create(:agreement_state, agreement_state: state, agreement_id: agreement.id)
 
       expect(agreement.current_state).to eq(state)
       expect(agreement).not_to be_active

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -31,13 +31,12 @@ describe Hackney::Income::Models::CourtCase, type: :model do
       created_by: Faker::Name.name
     )
 
-    Hackney::Income::Models::Agreement.create!(
-      tenancy_ref: tenancy_ref,
-      current_state: :live,
-      created_by: Faker::Name.name,
-      agreement_type: :formal,
-      court_case_id: court_case.id
-    )
+    create(:agreement,
+           tenancy_ref: tenancy_ref,
+           current_state: :live,
+           created_by: Faker::Name.name,
+           agreement_type: :formal,
+           court_case_id: court_case.id)
 
     expect(described_class.first.agreements.first).to be_a Hackney::Income::Models::Agreement
     expect(Hackney::Income::Models::Agreement.first.court_case).to eq(court_case)

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -16,17 +16,16 @@ RSpec.describe 'Agreements', type: :request do
       let(:view_agreements_instance) { instance_double(Hackney::Income::ViewAgreements) }
       let(:agreements_array) do
         [
-          Hackney::Income::Models::Agreement.create!(
-            tenancy_ref: tenancy_ref,
-            agreement_type: agreement_type,
-            starting_balance: starting_balance,
-            amount: amount,
-            start_date: start_date,
-            frequency: frequency,
-            current_state: current_state,
-            created_by: created_by,
-            notes: notes
-          )
+          create(:agreement,
+                 tenancy_ref: tenancy_ref,
+                 agreement_type: agreement_type,
+                 starting_balance: starting_balance,
+                 amount: amount,
+                 start_date: start_date,
+                 frequency: frequency,
+                 current_state: current_state,
+                 created_by: created_by,
+                 notes: notes)
         ]
       end
 
@@ -59,8 +58,8 @@ RSpec.describe 'Agreements', type: :request do
       end
 
       it 'correctly maps all agreement_states in history' do
-        first_state = Hackney::Income::Models::AgreementState.create!(agreement_id: agreements_array.first.id, agreement_state: 'live')
-        second_state = Hackney::Income::Models::AgreementState.create!(agreement_id: agreements_array.first.id, agreement_state: 'breached')
+        first_state = create(:agreement_state, :live, agreement_id: agreements_array.first.id)
+        second_state = create(:agreement_state, :breached, agreement_id: agreements_array.first.id)
 
         get "/api/v1/agreements/#{tenancy_ref}"
 
@@ -98,10 +97,9 @@ RSpec.describe 'Agreements', type: :request do
       end
 
       let(:created_agreement) do
-        Hackney::Income::Models::Agreement.create(
-          starting_balance: starting_balance,
-          **new_agreement_params
-        )
+        create(:agreement,
+               starting_balance: starting_balance,
+               **new_agreement_params)
       end
 
       before do
@@ -145,10 +143,10 @@ RSpec.describe 'Agreements', type: :request do
           starting_balance: starting_balance
         }
       end
-      let(:agreement) { Hackney::Income::Models::Agreement.create(agreement_params) }
+      let(:agreement) { create(:agreement, agreement_params) }
 
       before do
-        Hackney::Income::Models::AgreementState.create(agreement_id: agreement.id, agreement_state: 'cancelled')
+        create(:agreement_state, :cancelled, agreement_id: agreement.id)
 
         allow(Hackney::Income::CancelAgreement).to receive(:new).and_return(cancel_agreement_instance)
         allow(cancel_agreement_instance).to receive(:execute)


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to be able to detect whenever an informal agreement is breached. 
This is the first slice of tackling this problem and is not covering all the edge cases, simply just updates the agreement status to breached.
Next things to implement:
- Reset the agreement status to `live` when an agreement is no longer breached
- Add some info on why the breach is detected, e.g the UI design expects to show expected balance and actual balance and date of the last check, we should record these somewhere
- Add a corn job to run the process daily

## Changes proposed in this pull request
<!-- List all the changes -->
- Add a use-case that can take an agreement and determine whenever its breached or not, based on its first instalment date(`start_date`), frequency of payment, the days of tolerance for completing the payment. 

## Guidance to review
When we discussed detecting breaches previously, there was an expectation to check for breaches according to the payment cycle. Why is this hard to achieve? 
- The payment cycle can start any date
- We have multiple frequencies
- The status can change from one day to another(e.g payment being made on a day, the agreement is no longer in breach the next day)
It is better if we run batch processing nighly on all live agreements so we can see whether on that day it's breached or not.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-175

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
