### PR TITLE
Implement check data action & Fix a few rules

### DIFF
--- a/app/models/hackney/income/models/case_priority.rb
+++ b/app/models/hackney/income/models/case_priority.rb
@@ -7,7 +7,7 @@ module Hackney
           apply_for_court_date: 6, send_court_warning_letter: 7, update_court_outcome_action: 8,
           send_court_agreement_breach_letter: 9, send_informal_agreement_breach_letter: 10,
           court_breach_visit: 11, court_breach_no_payment: 12, review_failed_letter: 13,
-          apply_for_outright_possession_warrant: 14, informal_breached_after_letter: 15
+          apply_for_outright_possession_warrant: 14, informal_breached_after_letter: 15, check_data: 16
         }
 
         validates :case_id, presence: true, uniqueness: true

--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -26,7 +26,8 @@ module Hackney
               Rulesets::InformalBreachedAfterLetter,
               Rulesets::SendCourtAgreementBreachLetter, # TODO(AO): Possible missing test for this classification
               Rulesets::SendCourtWarningLetter,
-              Rulesets::ApplyForCourtDate
+              Rulesets::ApplyForCourtDate,
+              Rulesets::CheckData
             ]
 
             actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents).execute }

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
@@ -14,6 +14,9 @@ module Hackney
               # Cases should be paused if they have been to court but have no agreement
               return true if !case_paused? && court_warrant_active? && !active_agreement?
 
+              # Cases with court outcomes must have court dates recorded
+              return true if !case_paused? && no_court_date? && @criteria.court_outcome.present?
+
               false
             end
           end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
@@ -1,0 +1,24 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Rulesets
+          class CheckData < BaseRuleset
+            def execute
+              return :check_data if action_valid
+            end
+
+            private
+
+            def action_valid
+              # Cases should be paused if they have been to court but have no agreement
+              return true if !case_paused? && court_warrant_active? && !active_agreement?
+
+              false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_informal_agreement_breach_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_informal_agreement_breach_letter.rb
@@ -12,7 +12,7 @@ module Hackney
 
             def action_valid
               return false if should_prevent_action?
-              return false if @criteria.nosp.served?
+              return false if @criteria.nosp.served? && @criteria.nosp.valid?
               return false if @criteria.last_communication_action.in?([
                 Hackney::Tenancy::ActionCodes::INFORMAL_BREACH_LETTER_SENT,
                 Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
@@ -30,9 +30,10 @@ describe 'Apply for Outright Possession Warrant Rule examples' do
     base_example.merge(
       desription: 'when the court date does not exist',
       active_agreement: false,
-      outcome: :no_action,
+      outcome: :check_data,
       courtdate: nil,
-      court_outcome: 'OUT'
+      court_outcome: 'OUT',
+      skip_v1_test: true
     ),
     base_example.merge(
       desription: 'when there is an active agreement in place after outright possession order',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
@@ -43,7 +43,8 @@ describe 'Apply for Outright Possession Warrant Rule examples' do
     ),
     base_example.merge(
       description: 'when they have already applied for a warrent of possession',
-      outcome: :no_action,
+      outcome: nil,
+      outcome_not: :apply_for_outright_possession_warrant,
       last_communication_action: Hackney::Tenancy::ActionCodes::WARRANT_OF_POSSESSION
     )
   ]

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+base_example = {
+  skip_v1_test: true
+}
+describe 'Check Data examples' do
+  examples = [
+    base_example.merge(
+      desription: 'When there is an active court warrant, without an agreement, and not paused',
+      outcome: :check_data,
+      active_agreement: false,
+      courtdate: 1.week.ago,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+    ), base_example.merge(
+      desription: 'No action when there is no court warrant',
+      outcome: :no_action,
+      active_agreement: false,
+      courtdate: nil
+    ), base_example.merge(
+      desription: 'No action when there is an active court warrant, without an agreement, but is paused',
+      outcome: :no_action,
+      is_paused_until: 1.day.from_now.to_date,
+      active_agreement: false,
+      courtdate: 1.week.ago,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+    ), base_example.merge(
+      desription: 'No action when there is an old court warrant, without an agreement, and not paused',
+      outcome: :no_action,
+      active_agreement: false,
+      courtdate: 11.years.ago,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+    ), base_example.merge(
+      desription: 'No action when there is an not an active court warrant',
+      outcome: :no_action,
+      courtdate: nil
+    )
+  ]
+  it_behaves_like 'TenancyClassification', examples
+end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
@@ -32,6 +32,12 @@ describe 'Check Data examples' do
       desription: 'No action when there is an not an active court warrant',
       outcome: :no_action,
       courtdate: nil
+    ),
+    base_example.merge(
+      description: 'Check Data when case has court outcome but no court date',
+      outcome: :check_data,
+      courtdate: nil,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
     )
   ]
   it_behaves_like 'TenancyClassification', examples

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
@@ -45,7 +45,8 @@ describe '"Court Breach - No Payment" examples' do
     ),
     base_example.deep_merge(
       description: 'when there is no courtdate',
-      outcome: :no_action,
+      outcome: :check_data,
+      skip_v1_test: true,
       courtdate: nil
     ),
     base_example.deep_merge(

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
@@ -17,9 +17,14 @@ describe 'Various "Send informal breach letter" examples (new)' do
       most_recent_agreement: { breached: false }
     ),
     base_example.deep_merge(
-      description: 'with a NOSP',
-      outcome: :no_action,
-      most_recent_agreement: { breached: false }
+      description: 'with an valid NOSP',
+      nosp_served_date: 1.months.ago,
+      outcome: :no_action
+    ),
+    base_example.deep_merge(
+      description: 'with an invalid NOSP',
+      nosp_served_date: 5.years.ago,
+      skip_v1_test: true
     ),
     base_example.deep_merge(
       description: 'with an undated agreement',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_nosp_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_nosp_spec.rb
@@ -77,8 +77,7 @@ describe 'Send NOSP Rule', type: :feature do
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
       last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
-      eviction_date: nil,
-      court_outcome: 'Trail'
+      eviction_date: nil
     },
     {
       outcome: :no_action,
@@ -90,8 +89,7 @@ describe 'Send NOSP Rule', type: :feature do
       active_agreement: false,
       last_communication_date: 2.months.ago.to_date,
       last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
-      eviction_date: nil,
-      court_outcome: 'Hail'
+      eviction_date: nil
     },
     {
       outcome: :no_action,
@@ -115,8 +113,7 @@ describe 'Send NOSP Rule', type: :feature do
       active_agreement: false,
       last_communication_date: 5.days.ago.to_date,
       last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
-      eviction_date: nil,
-      court_outcome: 'Pale'
+      eviction_date: nil
     },
     {
       outcome: :no_action,
@@ -165,8 +162,7 @@ describe 'Send NOSP Rule', type: :feature do
       active_agreement: true,
       last_communication_date: 8.days.ago.to_date,
       last_communication_action: Hackney::Tenancy::ActionCodes::INCOME_COLLECTION_LETTER_2,
-      eviction_date: nil,
-      court_outcome: 'Tail'
+      eviction_date: nil
     },
     {
       outcome: :send_NOSP,

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
@@ -54,8 +54,9 @@ describe '"Update court outcome" examples' do
     ),
     base_example.merge(
       description: 'with no court date set and a court outcome has been reached',
-      outcome: :no_action,
+      outcome: :check_data,
       court_outcome: 'Outcome reached',
+      skip_v1_test: true,
       courtdate: nil
     ),
     base_example.merge(

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -90,8 +90,16 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
       let(:days_since_last_payment) { options[:days_since_last_payment] }
       let(:total_payment_amount_in_week) { options[:total_payment_amount_in_week] }
 
-      it "returns `#{options[:outcome]}`" do
-        expect(subject).to eq(options[:outcome])
+      if options[:outcome]
+        it "returns `#{options[:outcome]}`" do
+          expect(subject).to eq(options[:outcome])
+        end
+      elsif options[:outcome_not]
+        it "does not return `#{options[:outcome_not]}`" do
+          expect(subject).not_to eq(options[:outcome_not])
+        end
+      else
+        raise 'outcome or outcome_not as an option'
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->

There are several wrong rules, and a few scenarios of bad data in UH.

V1 will start deviating significantly from this PR onwards.

This will also require an update to the frontend to display the Check Data action correctly, and probably will need an explainer somewhere to tell the officers exactly what it is they're meant to be checking, and give them an indication as to what it is that they can do to resolve.

## Changes proposed in this pull request
<!-- List all the changes -->

- Added a ‘check_data’ action in the case that:
  - A case has a court outcome but no court date
  - A case is not paused, has a court date and court outcome but no agreement
- Updated send breached informal agreement letter if unless there is a valid nosp

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Check logic seems right for the prioritisation. Might be easier to look per commit as they're atomic
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-358
