### PR TITLE
Update court case table and model

### DIFF
--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -8,7 +8,6 @@ module CourtCaseResponseHelper
       balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
       createdAt: court_case.created_at.strftime('%F'),
       strikeOutDate: court_case.strike_out_date.strftime('%F'),
-      createdBy: court_case.created_by
     }
   end
 end

--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -3,9 +3,9 @@ module CourtCaseResponseHelper
     {
       id: court_case.id,
       tenancyRef: court_case.tenancy_ref,
-      courtDecisionDate: court_case.court_decision_date,
+      dateOfCourtDecision: court_case.date_of_court_decision,
       courtOutcome: court_case.court_outcome,
-      balanceAtOutcomeDate: court_case.balance_at_outcome_date,
+      balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
       createdAt: court_case.created_at.strftime('%F'),
       strikeOutDate: court_case.strike_out_date.strftime('%F'),
       createdBy: court_case.created_by

--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -3,7 +3,7 @@ module CourtCaseResponseHelper
     {
       id: court_case.id,
       tenancyRef: court_case.tenancy_ref,
-      dateOfCourtDecision: court_case.date_of_court_decision,
+      courtDate: court_case.court_date,
       courtOutcome: court_case.court_outcome,
       balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
       createdAt: court_case.created_at.strftime('%F'),

--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -7,7 +7,7 @@ module CourtCaseResponseHelper
       courtOutcome: court_case.court_outcome,
       balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
       createdAt: court_case.created_at.strftime('%F'),
-      strikeOutDate: court_case.strike_out_date.strftime('%F'),
+      strikeOutDate: court_case.strike_out_date.strftime('%F')
     }
   end
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -15,7 +15,7 @@ class CourtCasesController < ApplicationController
   def create
     court_case_params = {
       tenancy_ref: params.fetch(:tenancy_ref),
-      date_of_court_decision: params.fetch(:date_of_court_decision),
+      court_date: params.fetch(:court_date),
       court_outcome: params.fetch(:court_outcome),
       balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
       strike_out_date: params.fetch(:strike_out_date),

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -15,9 +15,9 @@ class CourtCasesController < ApplicationController
   def create
     court_case_params = {
       tenancy_ref: params.fetch(:tenancy_ref),
-      court_decision_date: params.fetch(:court_decision_date),
+      date_of_court_decision: params.fetch(:date_of_court_decision),
       court_outcome: params.fetch(:court_outcome),
-      balance_at_outcome_date: params.fetch(:balance_at_outcome_date),
+      balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
       strike_out_date: params.fetch(:strike_out_date),
       created_by: params.fetch(:created_by)
     }

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -18,7 +18,7 @@ class CourtCasesController < ApplicationController
       court_date: params.fetch(:court_date),
       court_outcome: params.fetch(:court_outcome),
       balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
-      strike_out_date: params.fetch(:strike_out_date),
+      strike_out_date: params.fetch(:strike_out_date)
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -19,7 +19,6 @@ class CourtCasesController < ApplicationController
       court_outcome: params.fetch(:court_outcome),
       balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
       strike_out_date: params.fetch(:strike_out_date),
-      created_by: params.fetch(:created_by)
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,7 +2,7 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
-        validates_presence_of :tenancy_ref, :court_decision_date, :court_outcome, :balance_at_outcome_date, :strike_out_date, :created_by
+        validates_presence_of :tenancy_ref, :date_of_court_decision, :court_outcome, :balance_on_court_outcome_date, :strike_out_date, :created_by
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
       end
     end

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,7 +2,7 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
-        validates_presence_of :tenancy_ref, :date_of_court_decision, :court_outcome, :balance_on_court_outcome_date, :strike_out_date, :created_by
+        validates_presence_of :tenancy_ref, :court_date, :court_outcome, :balance_on_court_outcome_date, :strike_out_date, :created_by
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
       end
     end

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,7 +2,7 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
-        validates_presence_of :tenancy_ref, :court_date, :court_outcome, :balance_on_court_outcome_date, :strike_out_date, :created_by
+        validates_presence_of :tenancy_ref
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
       end
     end

--- a/db/migrate/20200803102320_update_court_case_column_names.rb
+++ b/db/migrate/20200803102320_update_court_case_column_names.rb
@@ -1,6 +1,0 @@
-class UpdateCourtCaseColumnNames < ActiveRecord::Migration[5.2]
-  def change
-    rename_column :court_cases, :court_decision_date, :date_of_court_decision
-    rename_column :court_cases, :balance_at_outcome_date, :balance_on_court_outcome_date
-  end
-end

--- a/db/migrate/20200803102320_update_court_case_column_names.rb
+++ b/db/migrate/20200803102320_update_court_case_column_names.rb
@@ -1,0 +1,6 @@
+class UpdateCourtCaseColumnNames < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :court_cases, :court_decision_date, :date_of_court_decision
+    rename_column :court_cases, :balance_at_outcome_date, :balance_on_court_outcome_date
+  end
+end

--- a/db/migrate/20200803165658_update_court_case_columns.rb
+++ b/db/migrate/20200803165658_update_court_case_columns.rb
@@ -1,0 +1,15 @@
+class UpdateCourtCaseColumns < ActiveRecord::Migration[5.2]
+  def up
+    rename_column :court_cases, :court_decision_date, :court_date
+    rename_column :court_cases, :balance_at_outcome_date, :balance_on_court_outcome_date
+    change_column_null :court_cases, :court_date, false
+    change_column_null :court_cases, :strike_out_date, true
+  end
+
+  def down
+    change_column_null :court_cases, :strike_out_date, false
+    change_column_null :court_cases, :court_date, true
+    rename_column :court_cases, :balance_on_court_outcome_date, :balance_at_outcome_date
+    rename_column :court_cases, :court_date, :court_decision_date
+  end
+end

--- a/db/migrate/20200804143043_update_nullable_court_case_columns.rb
+++ b/db/migrate/20200804143043_update_nullable_court_case_columns.rb
@@ -1,0 +1,6 @@
+class UpdateNullableCourtCaseColumns < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :court_cases, :court_date, true
+    remove_column :court_cases, :created_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_102320) do
+ActiveRecord::Schema.define(version: 2020_08_03_165658) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -104,13 +104,13 @@ ActiveRecord::Schema.define(version: 2020_08_03_102320) do
   end
 
   create_table "court_cases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "date_of_court_decision"
+    t.datetime "court_date", null: false
     t.text "court_outcome"
     t.decimal "balance_on_court_outcome_date", precision: 10, scale: 2
     t.string "tenancy_ref", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "strike_out_date", null: false
+    t.datetime "strike_out_date"
     t.string "created_by", null: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_185956) do
+ActiveRecord::Schema.define(version: 2020_08_03_102320) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -104,9 +104,9 @@ ActiveRecord::Schema.define(version: 2020_07_30_185956) do
   end
 
   create_table "court_cases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "court_decision_date"
+    t.datetime "date_of_court_decision"
     t.text "court_outcome"
-    t.decimal "balance_at_outcome_date", precision: 10, scale: 2
+    t.decimal "balance_on_court_outcome_date", precision: 10, scale: 2
     t.string "tenancy_ref", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_165658) do
+ActiveRecord::Schema.define(version: 2020_08_04_143043) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -104,14 +104,13 @@ ActiveRecord::Schema.define(version: 2020_08_03_165658) do
   end
 
   create_table "court_cases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "court_date", null: false
+    t.datetime "court_date"
     t.text "court_outcome"
     t.decimal "balance_on_court_outcome_date", precision: 10, scale: 2
     t.string "tenancy_ref", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "strike_out_date"
-    t.string "created_by", null: false
   end
 
   create_table "delayed_jobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -119,12 +119,12 @@ paths:
         schema:
           type: object
           required:
-            - dateOfCourtDecision
+            - courtDate
             - courtOutcome
             - balanceOnCourtOutcomeDate
             - createdBy
           properties:
-            dateOfCourtDecision:
+            courtDate:
               type: string
             courtOutcome:
               type: string
@@ -214,7 +214,7 @@ definitions:
       tenancyRef:
         type: string
         example: '1'
-      dateOfCourtDecision:
+      courtDate:
         type: string
         format: date
         example: '10/11/2020'

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -120,20 +120,24 @@ paths:
           type: object
           required:
             - courtDate
-            - courtOutcome
-            - balanceOnCourtOutcomeDate
             - createdBy
           properties:
             courtDate:
               type: string
+              example: '01/08/2020'
             courtOutcome:
               type: string
+              example: 'Stay of execution'
             balanceOnCourtOutcomeDate:
               type: number
+              example: '50'
             strikeOutDate:
               type: string
+              format: date
+              example: '01/08/2026'
             createdBy:
               type: string
+              example: 'Tom Nook'
       responses:
         200:
           description: successful operation
@@ -217,7 +221,7 @@ definitions:
       courtDate:
         type: string
         format: date
-        example: '10/11/2020'
+        example: '01/08/2020'
       courtOutcome:
         type: string
         example: 'something'
@@ -227,13 +231,24 @@ definitions:
       strikeOutDate:
         type: string
         format: date
-        example: '27/01/2025'
-      createdAt:
+        example: '01/08/2026'
+      courtCaseHistory:
+        type: array
+        items:
+          $ref: '#/definitions/courtCaseHistory'
+  courtCaseHistory:
+    type: object
+    properties:
+      description:
+        type: string
+        example: 'court date added'
+      date:
         type: string
         format: date
+        example: '01/07/2020'
       createdBy:
         type: string
-        example: 'Tom Nooks'
+        example: 'Tom Nook'
   courtCasesList:
     type: object
     properties:

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -113,6 +113,27 @@ paths:
         required: true
         type: string
         description: Court case for tenancy
+      - in: body
+        name: court_case
+        description: Court case to create
+        schema:
+          type: object
+          required:
+            - dateOfCourtDecision
+            - courtOutcome
+            - balanceOnCourtOutcomeDate
+            - createdBy
+          properties:
+            dateOfCourtDecision:
+              type: string
+            courtOutcome:
+              type: string
+            balanceOnCourtOutcomeDate:
+              type: number
+            strikeOutDate:
+              type: string
+            createdBy:
+              type: string
       responses:
         200:
           description: successful operation
@@ -193,19 +214,26 @@ definitions:
       tenancyRef:
         type: string
         example: '1'
-      courtDecisionDate:
+      dateOfCourtDecision:
         type: string
         format: date
         example: '10/11/2020'
       courtOutcome:
         type: string
         example: 'something'
-      balanceAtOutcomeDate:
+      balanceOnCourtOutcomeDate:
         type: number
         format: '50'
+      strikeOutDate:
+        type: string
+        format: date
+        example: '27/01/2025'
       createdAt:
         type: string
         format: date
+      createdBy:
+        type: string
+        example: 'Tom Nooks'
   courtCasesList:
     type: object
     properties:

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -8,7 +8,6 @@ module Hackney
           court_outcome: court_case_params[:court_outcome],
           balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
           strike_out_date: court_case_params[:strike_out_date],
-          created_by: court_case_params[:created_by]
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -7,7 +7,7 @@ module Hackney
           court_date: court_case_params[:court_date],
           court_outcome: court_case_params[:court_outcome],
           balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
-          strike_out_date: court_case_params[:strike_out_date],
+          strike_out_date: court_case_params[:strike_out_date]
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -4,7 +4,7 @@ module Hackney
       def execute(court_case_params:)
         params = {
           tenancy_ref: court_case_params[:tenancy_ref],
-          date_of_court_decision: court_case_params[:date_of_court_decision],
+          court_date: court_case_params[:court_date],
           court_outcome: court_case_params[:court_outcome],
           balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
           strike_out_date: court_case_params[:strike_out_date],

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -4,9 +4,9 @@ module Hackney
       def execute(court_case_params:)
         params = {
           tenancy_ref: court_case_params[:tenancy_ref],
-          court_decision_date: court_case_params[:court_decision_date],
+          date_of_court_decision: court_case_params[:date_of_court_decision],
           court_outcome: court_case_params[:court_outcome],
-          balance_at_outcome_date: court_case_params[:balance_at_outcome_date],
+          balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
           strike_out_date: court_case_params[:strike_out_date],
           created_by: court_case_params[:created_by]
         }

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     court_outcome { Faker::ChuckNorris.fact }
     balance_on_court_outcome_date { Faker::Commerce.price(range: 10...100) }
     strike_out_date { Faker::Date.forward(days: 365) }
-    created_by { Faker::Name.name }
   end
 end

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :court_case, class: Hackney::Income::Models::CourtCase do
     tenancy_ref { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
-    date_of_court_decision { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+    court_date { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
     court_outcome { Faker::ChuckNorris.fact }
     balance_on_court_outcome_date { Faker::Commerce.price(range: 10...100) }
     strike_out_date { Faker::Date.forward(days: 365) }

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :court_case, class: Hackney::Income::Models::CourtCase do
     tenancy_ref { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
-    court_decision_date { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+    date_of_court_decision { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
     court_outcome { Faker::ChuckNorris.fact }
-    balance_at_outcome_date { Faker::Commerce.price(range: 10...100) }
+    balance_on_court_outcome_date { Faker::Commerce.price(range: 10...100) }
     strike_out_date { Faker::Date.forward(days: 365) }
     created_by { Faker::Name.name }
   end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -4,7 +4,7 @@ describe Hackney::Income::CreateCourtCase do
   subject { described_class.new }
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:date_of_court_decision) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
   let(:court_outcome) { Faker::ChuckNorris.fact }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
@@ -13,7 +13,7 @@ describe Hackney::Income::CreateCourtCase do
   let(:new_court_case_params) do
     {
       tenancy_ref: tenancy_ref,
-      date_of_court_decision: date_of_court_decision,
+      court_date: court_date,
       court_outcome: court_outcome,
       balance_on_court_outcome_date: balance_on_court_outcome_date,
       strike_out_date: strike_out_date,
@@ -28,7 +28,7 @@ describe Hackney::Income::CreateCourtCase do
     expect(court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
     expect(court_case.id).to eq(latest_court_case_id)
     expect(court_case.tenancy_ref).to eq(tenancy_ref)
-    expect(court_case.date_of_court_decision).to eq(date_of_court_decision)
+    expect(court_case.court_date).to eq(court_date)
     expect(court_case.court_outcome).to eq(court_outcome)
     expect(court_case.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
     expect(court_case.strike_out_date).to eq(strike_out_date)

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -15,7 +15,7 @@ describe Hackney::Income::CreateCourtCase do
       court_date: court_date,
       court_outcome: court_outcome,
       balance_on_court_outcome_date: balance_on_court_outcome_date,
-      strike_out_date: strike_out_date,
+      strike_out_date: strike_out_date
     }
   end
 

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -8,7 +8,6 @@ describe Hackney::Income::CreateCourtCase do
   let(:court_outcome) { Faker::ChuckNorris.fact }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
-  let(:created_by) { Faker::Name.name }
 
   let(:new_court_case_params) do
     {
@@ -17,7 +16,6 @@ describe Hackney::Income::CreateCourtCase do
       court_outcome: court_outcome,
       balance_on_court_outcome_date: balance_on_court_outcome_date,
       strike_out_date: strike_out_date,
-      created_by: created_by
     }
   end
 
@@ -32,6 +30,5 @@ describe Hackney::Income::CreateCourtCase do
     expect(court_case.court_outcome).to eq(court_outcome)
     expect(court_case.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
     expect(court_case.strike_out_date).to eq(strike_out_date)
-    expect(court_case.created_by).to eq(created_by)
   end
 end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -4,18 +4,18 @@ describe Hackney::Income::CreateCourtCase do
   subject { described_class.new }
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:court_decision_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:date_of_court_decision) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
   let(:court_outcome) { Faker::ChuckNorris.fact }
-  let(:balance_at_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
   let(:created_by) { Faker::Name.name }
 
   let(:new_court_case_params) do
     {
       tenancy_ref: tenancy_ref,
-      court_decision_date: court_decision_date,
+      date_of_court_decision: date_of_court_decision,
       court_outcome: court_outcome,
-      balance_at_outcome_date: balance_at_outcome_date,
+      balance_on_court_outcome_date: balance_on_court_outcome_date,
       strike_out_date: strike_out_date,
       created_by: created_by
     }
@@ -28,9 +28,9 @@ describe Hackney::Income::CreateCourtCase do
     expect(court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
     expect(court_case.id).to eq(latest_court_case_id)
     expect(court_case.tenancy_ref).to eq(tenancy_ref)
-    expect(court_case.court_decision_date).to eq(court_decision_date)
+    expect(court_case.date_of_court_decision).to eq(date_of_court_decision)
     expect(court_case.court_outcome).to eq(court_outcome)
-    expect(court_case.balance_at_outcome_date).to eq(balance_at_outcome_date)
+    expect(court_case.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
     expect(court_case.strike_out_date).to eq(strike_out_date)
     expect(court_case.created_by).to eq(created_by)
   end

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -20,8 +20,8 @@ describe Hackney::Income::CreateFormalAgreement do
   let(:court_case) do
     Hackney::Income::Models::CourtCase.create!(
       tenancy_ref: tenancy_ref,
-      balance_at_outcome_date: Faker::Commerce.price(range: 10...1000),
-      court_decision_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
+      balance_on_court_outcome_date: Faker::Commerce.price(range: 10...1000),
+      date_of_court_decision: Faker::Date.between(from: 2.days.ago, to: Date.today),
       court_outcome: Faker::ChuckNorris.fact,
       strike_out_date: Faker::Date.forward(days: 365),
       created_by: Faker::Name.name

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -23,7 +23,7 @@ describe Hackney::Income::CreateFormalAgreement do
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...1000),
       court_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
       court_outcome: Faker::ChuckNorris.fact,
-      strike_out_date: Faker::Date.forward(days: 365),
+      strike_out_date: Faker::Date.forward(days: 365)
     )
   end
   let(:expected_action_diray_note) { "Formal agreement created: #{notes}" }

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -24,7 +24,6 @@ describe Hackney::Income::CreateFormalAgreement do
       court_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
       court_outcome: Faker::ChuckNorris.fact,
       strike_out_date: Faker::Date.forward(days: 365),
-      created_by: Faker::Name.name
     )
   end
   let(:expected_action_diray_note) { "Formal agreement created: #{notes}" }

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -21,7 +21,7 @@ describe Hackney::Income::CreateFormalAgreement do
     Hackney::Income::Models::CourtCase.create!(
       tenancy_ref: tenancy_ref,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...1000),
-      date_of_court_decision: Faker::Date.between(from: 2.days.ago, to: Date.today),
+      court_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
       court_outcome: Faker::ChuckNorris.fact,
       strike_out_date: Faker::Date.forward(days: 365),
       created_by: Faker::Name.name

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -13,7 +13,7 @@ describe Hackney::Income::ViewCourtCases do
 
   context 'when there is a court case for the tenancy' do
     let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...1000) }
-    let(:date_of_court_decision) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
+    let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     let(:court_outcome) { Faker::ChuckNorris.fact }
     let(:strike_out_date) { Faker::Date.forward(days: 365) }
     let(:created_by) { Faker::Name.name }
@@ -21,7 +21,7 @@ describe Hackney::Income::ViewCourtCases do
       {
         tenancy_ref: tenancy_ref,
         balance_on_court_outcome_date: balance_on_court_outcome_date,
-        date_of_court_decision: date_of_court_decision,
+        court_date: court_date,
         court_outcome: court_outcome,
         strike_out_date: strike_out_date,
         created_by: created_by
@@ -37,7 +37,7 @@ describe Hackney::Income::ViewCourtCases do
       expect(response.first.id).to eq(expected_court_case.id)
       expect(response.first.tenancy_ref).to eq(tenancy_ref)
       expect(response.first.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
-      expect(response.first.date_of_court_decision).to eq(date_of_court_decision)
+      expect(response.first.court_date).to eq(court_date)
       expect(response.first.court_outcome).to eq(court_outcome)
       expect(response.first.strike_out_date).to eq(strike_out_date)
       expect(response.first.created_by).to eq(created_by)

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -22,7 +22,7 @@ describe Hackney::Income::ViewCourtCases do
         balance_on_court_outcome_date: balance_on_court_outcome_date,
         court_date: court_date,
         court_outcome: court_outcome,
-        strike_out_date: strike_out_date,
+        strike_out_date: strike_out_date
       }
     end
 

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -16,7 +16,6 @@ describe Hackney::Income::ViewCourtCases do
     let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     let(:court_outcome) { Faker::ChuckNorris.fact }
     let(:strike_out_date) { Faker::Date.forward(days: 365) }
-    let(:created_by) { Faker::Name.name }
     let(:court_cases_param) do
       {
         tenancy_ref: tenancy_ref,
@@ -24,7 +23,6 @@ describe Hackney::Income::ViewCourtCases do
         court_date: court_date,
         court_outcome: court_outcome,
         strike_out_date: strike_out_date,
-        created_by: created_by
       }
     end
 
@@ -40,7 +38,6 @@ describe Hackney::Income::ViewCourtCases do
       expect(response.first.court_date).to eq(court_date)
       expect(response.first.court_outcome).to eq(court_outcome)
       expect(response.first.strike_out_date).to eq(strike_out_date)
-      expect(response.first.created_by).to eq(created_by)
       expect(response.first.agreements).to eq([])
     end
 

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -12,16 +12,16 @@ describe Hackney::Income::ViewCourtCases do
   end
 
   context 'when there is a court case for the tenancy' do
-    let(:balance_at_outcome_date) { Faker::Commerce.price(range: 10...1000) }
-    let(:court_decision_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
+    let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...1000) }
+    let(:date_of_court_decision) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     let(:court_outcome) { Faker::ChuckNorris.fact }
     let(:strike_out_date) { Faker::Date.forward(days: 365) }
     let(:created_by) { Faker::Name.name }
     let(:court_cases_param) do
       {
         tenancy_ref: tenancy_ref,
-        balance_at_outcome_date: balance_at_outcome_date,
-        court_decision_date: court_decision_date,
+        balance_on_court_outcome_date: balance_on_court_outcome_date,
+        date_of_court_decision: date_of_court_decision,
         court_outcome: court_outcome,
         strike_out_date: strike_out_date,
         created_by: created_by
@@ -36,8 +36,8 @@ describe Hackney::Income::ViewCourtCases do
       expect(response.count).to eq(1)
       expect(response.first.id).to eq(expected_court_case.id)
       expect(response.first.tenancy_ref).to eq(tenancy_ref)
-      expect(response.first.balance_at_outcome_date).to eq(balance_at_outcome_date)
-      expect(response.first.court_decision_date).to eq(court_decision_date)
+      expect(response.first.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
+      expect(response.first.date_of_court_decision).to eq(date_of_court_decision)
       expect(response.first.court_outcome).to eq(court_outcome)
       expect(response.first.strike_out_date).to eq(strike_out_date)
       expect(response.first.created_by).to eq(created_by)

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -5,16 +5,16 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     court_details = described_class.new
     expect(court_details.attributes).to include(
       'tenancy_ref',
-      'court_decision_date',
+      'date_of_court_decision',
       'court_outcome',
-      'balance_at_outcome_date'
+      'balance_on_court_outcome_date'
     )
   end
 
   it { is_expected.to validate_presence_of(:tenancy_ref) }
-  it { is_expected.to validate_presence_of(:court_decision_date) }
+  it { is_expected.to validate_presence_of(:date_of_court_decision) }
   it { is_expected.to validate_presence_of(:court_outcome) }
-  it { is_expected.to validate_presence_of(:balance_at_outcome_date) }
+  it { is_expected.to validate_presence_of(:balance_on_court_outcome_date) }
   it { is_expected.to validate_presence_of(:strike_out_date) }
   it { is_expected.to validate_presence_of(:created_by) }
   it { is_expected.to have_many(:agreements) }
@@ -24,9 +24,9 @@ describe Hackney::Income::Models::CourtCase, type: :model do
 
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
-      court_decision_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
+      date_of_court_decision: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
       court_outcome: Faker::ChuckNorris.fact,
-      balance_at_outcome_date: Faker::Commerce.price(range: 10...100),
+      balance_on_court_outcome_date: Faker::Commerce.price(range: 10...100),
       strike_out_date: Faker::Date.forward(days: 365),
       created_by: Faker::Name.name
     )

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -18,7 +18,6 @@ describe Hackney::Income::Models::CourtCase, type: :model do
   tenancy_ref = Faker::Number.number(digits: 2).to_s
 
   it 'can have associated formal agreements' do
-
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
       court_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
@@ -42,7 +41,7 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     it 'is still a valid court case' do
       court_case = described_class.create!(
         tenancy_ref: tenancy_ref,
-        court_date: Faker::Date.forward(days: 30),
+        court_date: Faker::Date.forward(days: 30)
       )
 
       expect(court_case).to be_a Hackney::Income::Models::CourtCase

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -2,33 +2,29 @@ require 'rails_helper'
 
 describe Hackney::Income::Models::CourtCase, type: :model do
   it 'includes the fields for a court ordered agreement' do
-    court_details = described_class.new
-    expect(court_details.attributes).to include(
+    court_case = described_class.new
+    expect(court_case.attributes).to include(
       'tenancy_ref',
       'court_date',
       'court_outcome',
-      'balance_on_court_outcome_date'
+      'balance_on_court_outcome_date',
+      'strike_out_date'
     )
   end
 
   it { is_expected.to validate_presence_of(:tenancy_ref) }
-  it { is_expected.to validate_presence_of(:court_date) }
-  it { is_expected.to validate_presence_of(:court_outcome) }
-  it { is_expected.to validate_presence_of(:balance_on_court_outcome_date) }
-  it { is_expected.to validate_presence_of(:strike_out_date) }
-  it { is_expected.to validate_presence_of(:created_by) }
   it { is_expected.to have_many(:agreements) }
 
+  tenancy_ref = Faker::Number.number(digits: 2).to_s
+
   it 'can have associated formal agreements' do
-    tenancy_ref = Faker::Number.number(digits: 2).to_s
 
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
       court_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
       court_outcome: Faker::ChuckNorris.fact,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...100),
-      strike_out_date: Faker::Date.forward(days: 365),
-      created_by: Faker::Name.name
+      strike_out_date: Faker::Date.forward(days: 365)
     )
 
     create(:agreement,
@@ -40,5 +36,27 @@ describe Hackney::Income::Models::CourtCase, type: :model do
 
     expect(described_class.first.agreements.first).to be_a Hackney::Income::Models::Agreement
     expect(Hackney::Income::Models::Agreement.first.court_case).to eq(court_case)
+  end
+
+  context 'when there is only a court date (e.g. adding a court date before the case takes place)' do
+    it 'is still a valid court case' do
+      court_case = described_class.create!(
+        tenancy_ref: tenancy_ref,
+        court_date: Faker::Date.forward(days: 30),
+      )
+
+      expect(court_case).to be_a Hackney::Income::Models::CourtCase
+    end
+  end
+
+  context 'when there is only a court outcome (e.g. court outcomes in UH)' do
+    it 'is still a valid court case' do
+      court_case = described_class.create!(
+        tenancy_ref: tenancy_ref,
+        court_outcome: Faker::ChuckNorris.fact
+      )
+
+      expect(court_case).to be_a Hackney::Income::Models::CourtCase
+    end
   end
 end

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -5,14 +5,14 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     court_details = described_class.new
     expect(court_details.attributes).to include(
       'tenancy_ref',
-      'date_of_court_decision',
+      'court_date',
       'court_outcome',
       'balance_on_court_outcome_date'
     )
   end
 
   it { is_expected.to validate_presence_of(:tenancy_ref) }
-  it { is_expected.to validate_presence_of(:date_of_court_decision) }
+  it { is_expected.to validate_presence_of(:court_date) }
   it { is_expected.to validate_presence_of(:court_outcome) }
   it { is_expected.to validate_presence_of(:balance_on_court_outcome_date) }
   it { is_expected.to validate_presence_of(:strike_out_date) }
@@ -24,7 +24,7 @@ describe Hackney::Income::Models::CourtCase, type: :model do
 
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
-      date_of_court_decision: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
+      court_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
       court_outcome: Faker::ChuckNorris.fact,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...100),
       strike_out_date: Faker::Date.forward(days: 365),

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -2,9 +2,9 @@ require 'swagger_helper'
 
 RSpec.describe 'CourtCases', type: :request do
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:court_decision_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
+  let(:date_of_court_decision) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
   let(:court_outcome) { Faker::ChuckNorris.fact }
-  let(:balance_at_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365).to_s }
   let(:created_by) { Faker::Name.name }
 
@@ -14,9 +14,9 @@ RSpec.describe 'CourtCases', type: :request do
       let(:new_court_case_params) do
         {
           tenancy_ref: tenancy_ref,
-          court_decision_date: court_decision_date,
+          date_of_court_decision: date_of_court_decision,
           court_outcome: court_outcome,
-          balance_at_outcome_date: balance_at_outcome_date.to_s,
+          balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
           strike_out_date: strike_out_date,
           created_by: created_by
         }
@@ -37,9 +37,9 @@ RSpec.describe 'CourtCases', type: :request do
         parsed_response = JSON.parse(response.body)
 
         expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
-        expect(parsed_response['courtDecisionDate']).to include(court_decision_date)
+        expect(parsed_response['dateOfCourtDecision']).to include(date_of_court_decision)
         expect(parsed_response['courtOutcome']).to eq(court_outcome)
-        expect(parsed_response['balanceAtOutcomeDate']).to eq(balance_at_outcome_date.to_s)
+        expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
         expect(parsed_response['createdAt']).to include(Date.today.to_s)
         expect(parsed_response['strikeOutDate']).to include(strike_out_date)
         expect(parsed_response['createdBy']).to include(created_by)

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -2,7 +2,7 @@ require 'swagger_helper'
 
 RSpec.describe 'CourtCases', type: :request do
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:date_of_court_decision) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
+  let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
   let(:court_outcome) { Faker::ChuckNorris.fact }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365).to_s }
@@ -14,7 +14,7 @@ RSpec.describe 'CourtCases', type: :request do
       let(:new_court_case_params) do
         {
           tenancy_ref: tenancy_ref,
-          date_of_court_decision: date_of_court_decision,
+          court_date: court_date,
           court_outcome: court_outcome,
           balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
           strike_out_date: strike_out_date,
@@ -37,7 +37,7 @@ RSpec.describe 'CourtCases', type: :request do
         parsed_response = JSON.parse(response.body)
 
         expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
-        expect(parsed_response['dateOfCourtDecision']).to include(date_of_court_decision)
+        expect(parsed_response['courtDate']).to include(court_date)
         expect(parsed_response['courtOutcome']).to eq(court_outcome)
         expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
         expect(parsed_response['createdAt']).to include(Date.today.to_s)

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'CourtCases', type: :request do
   let(:court_outcome) { Faker::ChuckNorris.fact }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365).to_s }
-  let(:created_by) { Faker::Name.name }
 
   describe 'POST /api/v1/court_case/{tenancy_ref}' do
     path '/court_case/{tenancy_ref}' do
@@ -18,7 +17,6 @@ RSpec.describe 'CourtCases', type: :request do
           court_outcome: court_outcome,
           balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
           strike_out_date: strike_out_date,
-          created_by: created_by
         }
       end
 
@@ -42,7 +40,6 @@ RSpec.describe 'CourtCases', type: :request do
         expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
         expect(parsed_response['createdAt']).to include(Date.today.to_s)
         expect(parsed_response['strikeOutDate']).to include(strike_out_date)
-        expect(parsed_response['createdBy']).to include(created_by)
       end
     end
   end

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'CourtCases', type: :request do
           court_date: court_date,
           court_outcome: court_outcome,
           balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
-          strike_out_date: strike_out_date,
+          strike_out_date: strike_out_date
         }
       end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow officers in MA to be able to:
- Add a court case with _just_ the court date for a case/tenancy, before the actual court case takes place
- Add an outcome (and other details) for a court case that has taken place

We also want to allow for syncing of court outcomes in UH
- Some outcomes may not have a court date
- Some existing outcomes in UH won't map to our new list of court outcomes

## Changes proposed in this pull request
<!-- List all the changes -->
- Updated documentation for court case end point:
  - Added request body guidance
  - Changed structure of court cases, removed `createdBy` and added `courtCaseHistory` to let us record the history of a court case, for example:
```
{
  "id": 12,
  "tenancyRef": "1",
  "courtDate": "01/08/2020",
  "courtOutcome": "Stay of execution",
  "balanceOnCourtOutcomeDate": 1000,
  "strikeOutDate": "01/08/2026",
  "courtCaseHistory": [
       {
      "description": "court outcome added",
      "date": "04/08/2020",
      "createdBy": "Isabelle"
     },
    {
      "description": "court date added",
      "date": "04/07/2020",
      "createdBy": "Tom Nook"
    }
  ]
}
```
- Updated court cases table:
  - Changed column names to match design: `court_decision_date` -> `court_date`, `balance_at_outcome_date` -> `balance_on_court_outcome_date`
  - Allow `strike_out_date` to be null - since outcomes won't always have one (e.g. adjourned ones)
  - Remove `created_by` column, since we will record these in a court case history table (mainly since one officer might create a court case with a date and another officer will add the outcome after the court case has taken place)

- Updated CourtCase model:
   - Only validate the presence of `tenancy_ref` - since other attributes (properties? fields? sorry, not 100% sure what the correct term is) might not exist
   - `courtDecisionDate` -> `courtDate`
   - `balanceAtOutcomeDate` -> `balanceOnCourtOutcomeDate`

To do:
- Add column in court cases table for `counter claim for disrepair` - in Jenny's designs, came from discussions with Ian
- Add court case history table
- Update use case and frontend accordingly
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
My brain feels pretty fried right now 😅 so please let me know if anything seems silly.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-349?atlOrigin=eyJpIjoiMzZhYmNkNmY1YzJhNDUzMGE0MGYwN2NmYmZjNGQ4NzYiLCJwIjoiaiJ9

https://hackney.atlassian.net/browse/MAAP-224?focusedCommentId=15817

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
