### PR TITLE
Update the `Agreement state` model 

### DIFF
--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -11,10 +11,6 @@ module Hackney
         enum agreement_type: { informal: 'informal', formal: 'formal' }
         enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3 }
 
-        def current_state
-          Hackney::Income::Models::AgreementState.where(agreement_id: id).last&.agreement_state
-        end
-
         def active?
           ACTIVE_STATES.include?(current_state)
         end

--- a/app/models/hackney/income/models/agreement_state.rb
+++ b/app/models/hackney/income/models/agreement_state.rb
@@ -2,9 +2,17 @@ module Hackney
   module Income
     module Models
       class AgreementState < ApplicationRecord
+        after_create :update_current_state_of_agreement
+
         validates_presence_of :agreement_state, :agreement_id
         belongs_to :agreement, class_name: 'Hackney::Income::Models::Agreement'
         enum agreement_state: { live: 'live', breached: 'breached', cancelled: 'cancelled', completed: 'completed' }
+
+        private
+
+        def update_current_state_of_agreement
+          agreement.update!(current_state: agreement_state)
+        end
       end
     end
   end

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -20,7 +20,6 @@ module Hackney
           start_date: new_agreement_params[:start_date],
           frequency: new_agreement_params[:frequency],
           created_by: new_agreement_params[:created_by],
-          current_state: 'live',
           notes: new_agreement_params[:notes],
           court_case_id: court_case.id
         }

--- a/lib/hackney/income/create_informal_agreement.rb
+++ b/lib/hackney/income/create_informal_agreement.rb
@@ -17,7 +17,6 @@ module Hackney
           start_date: new_agreement_params[:start_date],
           frequency: new_agreement_params[:frequency],
           created_by: new_agreement_params[:created_by],
-          current_state: 'live',
           notes: new_agreement_params[:notes]
         }
 

--- a/lib/hackney/income/detect_breach.rb
+++ b/lib/hackney/income/detect_breach.rb
@@ -89,7 +89,7 @@ module Hackney
                       end
 
         Hackney::Income::Models::AgreementState.create!(
-          agreement_id: agreement.id,
+          agreement: agreement,
           agreement_state: new_state,
           expected_balance: expected_balance,
           checked_balance: current_balance,

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -26,7 +26,7 @@ describe Hackney::Income::CancelAgreement do
 
   before do
     create(:agreement_state,
-           agreement_id: agreement.id,
+           agreement: agreement,
            agreement_state: active_state)
   end
 
@@ -60,7 +60,7 @@ describe Hackney::Income::CancelAgreement do
     before do
       create(:agreement_state,
              :completed,
-             agreement_id: agreement.id)
+             agreement: agreement)
     end
 
     it 'returns the initial agreement' do
@@ -79,7 +79,7 @@ describe Hackney::Income::CancelAgreement do
     before do
       create(:agreement_state,
              :cancelled,
-             agreement_id: agreement.id)
+             agreement: agreement)
     end
 
     it 'returns the initial agreement' do

--- a/spec/lib/hackney/income/create_informal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_informal_agreement_spec.rb
@@ -35,7 +35,7 @@ describe Hackney::Income::CreateInformalAgreement do
                                   current_state: 'breached',
                                   created_by: created_by,
                                   agreement_type: 'informal')
-      create(:agreement_state, :breached, agreement_id: breached_agreement.id)
+      create(:agreement_state, :breached, agreement: breached_agreement)
       create(:case_priority, tenancy_ref: tenancy_ref, balance: 200)
     end
 
@@ -64,7 +64,7 @@ describe Hackney::Income::CreateInformalAgreement do
                                   agreement_type: 'formal',
                                   court_case_id: court_case.id,
                                   notes: notes)
-      create(:agreement_state, :live, agreement_id: existing_agreement.id)
+      create(:agreement_state, :live, agreement: existing_agreement)
     end
 
     it 'does not allow create a new informal agreement' do
@@ -75,7 +75,7 @@ describe Hackney::Income::CreateInformalAgreement do
     context 'when the formal agreement is completed' do
       before do
         existing_agreement = Hackney::Income::Models::Agreement.first
-        create(:agreement_state, :completed, agreement_id: existing_agreement.id)
+        create(:agreement_state, :completed, agreement: existing_agreement)
       end
 
       it 'allows to create a new informal agreement' do

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -46,7 +46,7 @@ describe Hackney::Income::ViewAgreements do
       expect(response.first.start_date).to eq(start_date)
       expect(response.first.frequency).to eq(frequency)
       expect(response.first.created_by).to eq(created_by)
-      expect(response.first.current_state).to eq(nil)
+      expect(response.first.current_state).to eq(current_state)
     end
   end
 end

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -31,7 +31,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   it 'can have an associated agreement_state' do
-    create(:agreement_state, :live, agreement_id: agreement.id)
+    create(:agreement_state, :live, agreement: agreement)
 
     expect(described_class.first.agreement_states.first).to be_a Hackney::Income::Models::AgreementState
     expect(Hackney::Income::Models::AgreementState.first.agreement_id).to eq(agreement.id)
@@ -71,8 +71,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
     end
 
     it 'returns the latest agreement state' do
-      create(:agreement_state, :live, agreement_id: agreement.id)
-      create(:agreement_state, :breached, agreement_id: agreement.id)
+      create(:agreement_state, :live, agreement: agreement)
+      create(:agreement_state, :breached, agreement: agreement)
 
       expect(agreement.current_state).to eq('breached')
     end
@@ -85,7 +85,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
 
     it 'returns true if agreement state is an active state' do
       state = %w[live breached].sample
-      create(:agreement_state, agreement_state: state, agreement_id: agreement.id)
+      create(:agreement_state, agreement_state: state, agreement: agreement)
 
       expect(agreement.current_state).to eq(state)
       expect(agreement).to be_active
@@ -93,7 +93,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
 
     it 'returns false if agreement is inactive' do
       state = %w[cancelled completed].sample
-      create(:agreement_state, agreement_state: state, agreement_id: agreement.id)
+      create(:agreement_state, agreement_state: state, agreement: agreement)
 
       expect(agreement.current_state).to eq(state)
       expect(agreement).not_to be_active

--- a/spec/models/hackney/income/models/agreement_state_spec.rb
+++ b/spec/models/hackney/income/models/agreement_state_spec.rb
@@ -19,6 +19,16 @@ describe Hackney::Income::Models::AgreementState, type: :model do
     )
   end
 
+  it 'updates the current_state of the agreement on creation' do
+    agreement = create(:agreement, current_state: :live)
+
+    expect(agreement.current_state).to eq('live')
+
+    described_class.create(agreement: agreement, agreement_state: :completed)
+
+    expect(agreement.current_state).to eq('completed')
+  end
+
   describe 'agreement_state' do
     it 'only accepts valid agreement_states' do
       %w[live breached cancelled completed].each do |agreement_state|

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['agreements'].first['amount']).to eq(amount.to_s)
         expect(parsed_response['agreements'].first['startDate']).to include(start_date.to_s)
         expect(parsed_response['agreements'].first['frequency']).to eq(frequency)
-        expect(parsed_response['agreements'].first['currentState']).to eq(nil)
+        expect(parsed_response['agreements'].first['currentState']).to eq(current_state)
         expect(parsed_response['agreements'].first['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['agreements'].first['createdBy']).to eq(created_by)
         expect(parsed_response['agreements'].first['notes']).to eq(notes)
@@ -114,6 +114,7 @@ RSpec.describe 'Agreements', type: :request do
       let(:created_agreement) do
         create(:agreement,
                starting_balance: starting_balance,
+               current_state: :live,
                **new_agreement_params)
       end
 
@@ -135,7 +136,7 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['amount']).to eq(amount.to_s)
         expect(parsed_response['startDate']).to include(start_date.to_s)
         expect(parsed_response['frequency']).to eq(frequency)
-        expect(parsed_response['currentState']).to eq(nil)
+        expect(parsed_response['currentState']).to eq('live')
         expect(parsed_response['createdAt']).to eq(Date.today.to_s)
         expect(parsed_response['createdBy']).to eq(created_by)
         expect(parsed_response['notes']).to eq(notes)
@@ -161,7 +162,7 @@ RSpec.describe 'Agreements', type: :request do
       let(:agreement) { create(:agreement, agreement_params) }
 
       before do
-        create(:agreement_state, :cancelled, agreement_id: agreement.id)
+        create(:agreement_state, :cancelled, agreement: agreement)
 
         allow(Hackney::Income::CancelAgreement).to receive(:new).and_return(cancel_agreement_instance)
         allow(cancel_agreement_instance).to receive(:execute)

--- a/spec/support/shared_examples/create_agreement.rb
+++ b/spec/support/shared_examples/create_agreement.rb
@@ -92,7 +92,7 @@ RSpec.shared_examples 'CreateAgreement' do
       existing_agreement_params[:agreement_type] = 'informal'
 
       existing_agreement = create(:agreement, existing_agreement_params)
-      create(:agreement_state, :live, agreement_id: existing_agreement.id)
+      create(:agreement_state, :live, agreement: existing_agreement)
     end
 
     it 'creates and returns a new live agreement and cancelles the previous agreement' do


### PR DESCRIPTION
## Context
We monkey patched the `current_state` method on the `Agreement` model, to always look up and return the last agreement state, it’s not just inefficient but this can bite us later.

## Changes proposed in this pull request
- Removed the monkey patch and update the `Agreement state` model to update the current state of an `Agreement` on creation
- Update test setups where needed

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
