### PR TITLE
Refactor SyncCasePriority 

### DIFF
--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -1,15 +1,15 @@
 module Hackney
   module Income
     class SyncCasePriority
-      def initialize(prioritisation_gateway:, stored_tenancies_gateway:, automate_sending_letters:)
+      def initialize(prioritisation_gateway:, stored_worktray_item_gateway:, automate_sending_letters:)
         @automate_sending_letters = automate_sending_letters
         @prioritisation_gateway = prioritisation_gateway
-        @stored_tenancies_gateway = stored_tenancies_gateway
+        @stored_worktray_item_gateway = stored_worktray_item_gateway
       end
 
       def execute(tenancy_ref:)
         priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
-        case_priority = @stored_tenancies_gateway.store_tenancy(
+        case_priority = @stored_worktray_item_gateway.store_worktray_item(
           tenancy_ref: tenancy_ref,
           criteria: priorities.fetch(:criteria)
         )

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -4,7 +4,7 @@ module Hackney
       def view_cases
         Hackney::Income::ViewCases.new(
           tenancy_api_gateway: tenancy_api_gateway,
-          stored_tenancies_gateway: stored_tenancies_gateway
+          stored_worktray_item_gateway: stored_worktray_item_gateway
         )
       end
 
@@ -183,7 +183,7 @@ module Hackney
         Hackney::Income::SyncCasePriority.new(
           automate_sending_letters: automate_sending_letters,
           prioritisation_gateway: prioritisation_gateway,
-          stored_tenancies_gateway: stored_tenancies_gateway
+          stored_worktray_item_gateway: stored_worktray_item_gateway
         )
       end
 
@@ -273,8 +273,8 @@ module Hackney
         Hackney::Income::SqlPauseTenancyGateway.new
       end
 
-      def stored_tenancies_gateway
-        Hackney::Income::StoredTenanciesGateway.new
+      def stored_worktray_item_gateway
+        Hackney::Income::WorktrayItemGateway.new
       end
 
       def tenancy_api_gateway

--- a/lib/hackney/income/view_cases.rb
+++ b/lib/hackney/income/view_cases.rb
@@ -3,19 +3,19 @@ module Hackney
     class ViewCases
       Response = Struct.new(:cases, :number_of_pages)
 
-      def initialize(tenancy_api_gateway:, stored_tenancies_gateway:)
+      def initialize(tenancy_api_gateway:, stored_worktray_item_gateway:)
         @tenancy_api_gateway = tenancy_api_gateway
-        @stored_tenancies_gateway = stored_tenancies_gateway
+        @stored_worktray_item_gateway = stored_worktray_item_gateway
       end
 
       def execute(page_number:, number_per_page:, filters: {})
-        number_of_pages = @stored_tenancies_gateway.number_of_pages(
+        number_of_pages = @stored_worktray_item_gateway.number_of_pages(
           number_per_page: number_per_page,
           filters: filters
         )
         return Response.new([], 0) if number_of_pages.zero?
 
-        tenancies = @stored_tenancies_gateway.get_tenancies(
+        tenancies = @stored_worktray_item_gateway.get_tenancies(
           page_number: page_number,
           number_per_page: number_per_page,
           filters: filters

--- a/lib/hackney/income/worktray_item_gateway.rb
+++ b/lib/hackney/income/worktray_item_gateway.rb
@@ -1,10 +1,10 @@
 module Hackney
   module Income
-    class StoredTenanciesGateway
+    class WorktrayItemGateway
       GatewayModel = Hackney::Income::Models::CasePriority
       DocumentModel = Hackney::Cloud::Document
 
-      def store_tenancy(tenancy_ref:, criteria:)
+      def store_worktray_item(tenancy_ref:, criteria:)
         gateway_model_instance = GatewayModel.find_or_initialize_by(tenancy_ref: tenancy_ref)
 
         documents = DocumentModel.exclude_uploaded.by_payment_ref(criteria.payment_ref)

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -7,7 +7,7 @@ describe CasesController do
     before do
       allow(Hackney::Income::ViewCases).to receive(:new).with(
         tenancy_api_gateway: instance_of(Hackney::Tenancy::Gateway::TenanciesGateway),
-        stored_tenancies_gateway: instance_of(Hackney::Income::StoredTenanciesGateway)
+        stored_worktray_item_gateway: instance_of(Hackney::Income::WorktrayItemGateway)
       ).and_return(view_my_cases_instance)
     end
 

--- a/spec/lib/hackney/income/sync_case_priority_spec.rb
+++ b/spec/lib/hackney/income/sync_case_priority_spec.rb
@@ -4,7 +4,7 @@ describe Hackney::Income::SyncCasePriority do
   subject { sync_case.execute(tenancy_ref: tenancy_ref) }
 
   let(:stub_tenancy_object) { double }
-  let(:stored_tenancies_gateway) { double(store_tenancy: stub_tenancy_object) }
+  let(:stored_worktray_item_gateway) { double(store_worktray_item: stub_tenancy_object) }
   let(:criteria) { Stubs::StubCriteria.new }
 
   let(:prioritisation_gateway) do
@@ -21,7 +21,7 @@ describe Hackney::Income::SyncCasePriority do
     described_class.new(
       automate_sending_letters: automate_sending_letters,
       prioritisation_gateway: prioritisation_gateway,
-      stored_tenancies_gateway: stored_tenancies_gateway
+      stored_worktray_item_gateway: stored_worktray_item_gateway
     )
   end
 
@@ -36,7 +36,7 @@ describe Hackney::Income::SyncCasePriority do
     }
 
     it 'calls the automate_sending_letters usecase' do
-      expect(stored_tenancies_gateway).to receive(:store_tenancy).and_return(case_priority)
+      expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
 
       expect(automate_sending_letters).to receive(:execute).with(case_priority: case_priority)
       subject
@@ -55,7 +55,7 @@ describe Hackney::Income::SyncCasePriority do
     }
 
     it 'automate_sending_letters usecase is not called' do
-      expect(stored_tenancies_gateway).to receive(:store_tenancy).and_return(case_priority)
+      expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
 
       expect(automate_sending_letters).not_to receive(:execute).with(case_priority: case_priority)
       subject

--- a/spec/lib/hackney/income/view_cases_spec.rb
+++ b/spec/lib/hackney/income/view_cases_spec.rb
@@ -6,12 +6,12 @@ describe Hackney::Income::ViewCases do
   let(:page_number) { Faker::Number.number(digits: 2).to_i }
   let(:number_per_page) { Faker::Number.number(digits: 2).to_i }
   let(:tenancy_api_gateway) { Hackney::Income::TenancyApiGatewayStub.new({}) }
-  let(:stored_tenancies_gateway) { Hackney::Income::StoredTenancyGatewayStub.new({}) }
+  let(:stored_worktray_item_gateway) { Hackney::Income::StoredTenancyGatewayStub.new({}) }
 
   let(:view_cases) do
     described_class.new(
       tenancy_api_gateway: tenancy_api_gateway,
-      stored_tenancies_gateway: stored_tenancies_gateway
+      stored_worktray_item_gateway: stored_worktray_item_gateway
     )
   end
 
@@ -22,11 +22,11 @@ describe Hackney::Income::ViewCases do
   end
 
   it 'does not do further queries if the page number returned is 0' do
-    expect(stored_tenancies_gateway)
+    expect(stored_worktray_item_gateway)
       .to receive(:number_of_pages)
       .and_call_original
 
-    expect(stored_tenancies_gateway).not_to receive(:get_tenancies)
+    expect(stored_worktray_item_gateway).not_to receive(:get_tenancies)
 
     expect(subject.cases).to eq([])
     expect(subject.number_of_pages).to eq(0)
@@ -49,10 +49,10 @@ describe Hackney::Income::ViewCases do
       }
     end
 
-    let(:stored_tenancies_gateway) { Hackney::Income::StoredTenancyGatewayStub.new(tenancy_list) }
+    let(:stored_worktray_item_gateway) { Hackney::Income::StoredTenancyGatewayStub.new(tenancy_list) }
 
     it 'passes the correct page number and number per page into the stored tenancy gateway' do
-      expect(stored_tenancies_gateway)
+      expect(stored_worktray_item_gateway)
         .to receive(:get_tenancies)
         .with(a_hash_including(page_number: page_number, number_per_page: number_per_page))
         .and_call_original
@@ -131,7 +131,7 @@ describe Hackney::Income::ViewCases do
         }
 
         it 'returns only paused cases' do
-          expect(stored_tenancies_gateway)
+          expect(stored_worktray_item_gateway)
             .to receive(:get_tenancies)
             .with(a_hash_including(
                     page_number: page_number,
@@ -142,7 +142,7 @@ describe Hackney::Income::ViewCases do
                   ))
             .and_call_original
 
-          expect(stored_tenancies_gateway)
+          expect(stored_worktray_item_gateway)
             .to receive(:number_of_pages)
             .with(a_hash_including(
                     number_per_page: number_per_page,
@@ -170,7 +170,7 @@ describe Hackney::Income::ViewCases do
           let(:pause_reason) { Faker::Lorem.word }
 
           it 'returns only paused cases filtered by pause reason' do
-            expect(stored_tenancies_gateway)
+            expect(stored_worktray_item_gateway)
               .to receive(:get_tenancies)
               .with(a_hash_including(
                       page_number: page_number,
@@ -182,7 +182,7 @@ describe Hackney::Income::ViewCases do
                     ))
               .and_call_original
 
-            expect(stored_tenancies_gateway)
+            expect(stored_worktray_item_gateway)
               .to receive(:number_of_pages)
               .with(a_hash_including(
                       number_per_page: number_per_page,
@@ -212,7 +212,7 @@ describe Hackney::Income::ViewCases do
         let(:patch) { Faker::Lorem.characters(number: 3) }
 
         it 'asks the gateway for cases filtered by patch' do
-          expect(stored_tenancies_gateway)
+          expect(stored_worktray_item_gateway)
             .to receive(:get_tenancies)
             .with(a_hash_including(
                     page_number: page_number,
@@ -222,7 +222,7 @@ describe Hackney::Income::ViewCases do
                     }
                   )).and_call_original
 
-          expect(stored_tenancies_gateway)
+          expect(stored_worktray_item_gateway)
             .to receive(:number_of_pages)
             .with(a_hash_including(
                     number_per_page: number_per_page,
@@ -241,7 +241,7 @@ describe Hackney::Income::ViewCases do
     let(:number_of_pages) { Faker::Number.number(digits: 3).to_i }
 
     it 'consults the stored tenancies gateway' do
-      expect(stored_tenancies_gateway).to receive(:number_of_pages).with(
+      expect(stored_worktray_item_gateway).to receive(:number_of_pages).with(
         number_per_page: number_per_page,
         filters: {}
       ).and_call_original
@@ -249,7 +249,7 @@ describe Hackney::Income::ViewCases do
     end
 
     it 'returns what the stored tenancies gateway does' do
-      allow(stored_tenancies_gateway).to receive(:number_of_pages).and_return(number_of_pages)
+      allow(stored_worktray_item_gateway).to receive(:number_of_pages).and_return(number_of_pages)
       expect(subject.number_of_pages).to eq(number_of_pages)
     end
   end

--- a/spec/lib/hackney/income/worktray_item_gateway_spec.rb
+++ b/spec/lib/hackney/income/worktray_item_gateway_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-describe Hackney::Income::StoredTenanciesGateway do
+describe Hackney::Income::WorktrayItemGateway do
   let(:gateway) { described_class.new }
 
   let(:tenancy_model) { Hackney::Income::Models::CasePriority }
   let(:document_model) { Hackney::Cloud::Document }
 
   context 'when storing a tenancy' do
-    subject(:store_tenancy) do
-      gateway.store_tenancy(
+    subject(:store_worktray_item) do
+      gateway.store_worktray_item(
         tenancy_ref: attributes.fetch(:tenancy_ref),
         criteria: attributes.fetch(:criteria)
       )
@@ -39,13 +39,13 @@ describe Hackney::Income::StoredTenanciesGateway do
       let(:created_tenancy) { tenancy_model.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
 
       it 'creates the tenancy' do
-        store_tenancy
+        store_worktray_item
         expect(created_tenancy).to have_attributes(expected_serialised_tenancy(attributes))
       end
 
       # FIXME: shouldn't return AR models from gateways
       it 'returns the tenancy' do
-        expect(store_tenancy).to eq(created_tenancy)
+        expect(store_worktray_item).to eq(created_tenancy)
       end
     end
 
@@ -76,18 +76,18 @@ describe Hackney::Income::StoredTenanciesGateway do
       let(:stored_tenancy) { tenancy_model.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }
 
       it 'updates the tenancy' do
-        store_tenancy
+        store_worktray_item
         expect(stored_tenancy).to have_attributes(expected_serialised_tenancy(attributes))
       end
 
       it 'does not create a new tenancy' do
-        store_tenancy
+        store_worktray_item
         expect(tenancy_model.count).to eq(1)
       end
 
       # FIXME: shouldn't return AR models from gateways
       it 'returns the tenancy' do
-        expect(store_tenancy).to eq(pre_existing_tenancy)
+        expect(store_worktray_item).to eq(pre_existing_tenancy)
       end
     end
   end


### PR DESCRIPTION
## Context
We want to use MAA agreements rather than the agreements from UH whenever we running classification, currently, the classifier called in the sync process, in `stored_tenancies_gateway` whenever a new `case_priority` is saved in the DB.

We want to refactor these responsibilities so we can update that agreement states in MAA before running the classifier and then saving a new worktray item(aka case priority) 

## Changes proposed in this pull request
-  Rename stored_tenancies_gateway to  stored_worktray_item_gateway

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-176

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
