### PR TITLE
Call the classifier outside stored_tenancies_gateway during the sync process

### DIFF
--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -8,10 +8,18 @@ module Hackney
       end
 
       def execute(tenancy_ref:)
-        priorities = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref)
+        criteria = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref).fetch(:criteria)
+        documents = Hackney::Cloud::Document.exclude_uploaded.by_payment_ref(criteria.payment_ref)
+        classification = Hackney::Income::TenancyClassification::Classifier.new(
+          Hackney::Income::Models::CasePriority.find_or_initialize_by(tenancy_ref: tenancy_ref),
+          criteria,
+          documents
+        ).execute
+
         case_priority = @stored_worktray_item_gateway.store_worktray_item(
           tenancy_ref: tenancy_ref,
-          criteria: priorities.fetch(:criteria)
+          criteria: criteria,
+          classification: classification
         )
 
         @automate_sending_letters.execute(case_priority: case_priority) unless case_priority.paused?

--- a/lib/hackney/income/worktray_item_gateway.rb
+++ b/lib/hackney/income/worktray_item_gateway.rb
@@ -2,18 +2,9 @@ module Hackney
   module Income
     class WorktrayItemGateway
       GatewayModel = Hackney::Income::Models::CasePriority
-      DocumentModel = Hackney::Cloud::Document
 
-      def store_worktray_item(tenancy_ref:, criteria:)
+      def store_worktray_item(tenancy_ref:, criteria:, classification:)
         gateway_model_instance = GatewayModel.find_or_initialize_by(tenancy_ref: tenancy_ref)
-
-        documents = DocumentModel.exclude_uploaded.by_payment_ref(criteria.payment_ref)
-
-        classification_usecase = Hackney::Income::TenancyClassification::Classifier.new(
-          gateway_model_instance,
-          criteria,
-          documents
-        )
 
         begin
           gateway_model_instance.tap do |tenancy|
@@ -29,7 +20,7 @@ module Hackney
               last_communication_action: criteria.last_communication_action,
               last_communication_date: criteria.last_communication_date,
               active_nosp: criteria.active_nosp?,
-              classification: classification_usecase.execute,
+              classification: classification,
               patch_code: criteria.patch_code,
               courtdate: criteria.courtdate,
               court_outcome: criteria.court_outcome,

--- a/spec/lib/hackney/income/sync_case_priority_spec.rb
+++ b/spec/lib/hackney/income/sync_case_priority_spec.rb
@@ -5,7 +5,9 @@ describe Hackney::Income::SyncCasePriority do
 
   let(:stub_tenancy_object) { double }
   let(:stored_worktray_item_gateway) { double(store_worktray_item: stub_tenancy_object) }
+  let(:document_model) { Hackney::Cloud::Document }
   let(:criteria) { Stubs::StubCriteria.new }
+  let(:tenancy_classification_stub) { double('Classifier') }
 
   let(:prioritisation_gateway) do
     PrioritisationGatewayDouble.new(
@@ -23,6 +25,16 @@ describe Hackney::Income::SyncCasePriority do
       prioritisation_gateway: prioritisation_gateway,
       stored_worktray_item_gateway: stored_worktray_item_gateway
     )
+  end
+
+  before do
+    expect(tenancy_classification_stub).to receive(:execute).once
+
+    expect(document_model).to receive(:by_payment_ref).with(criteria.payment_ref).and_return([])
+
+    expect(Hackney::Income::TenancyClassification::Classifier).to receive(:new)
+      .with(instance_of(Hackney::Income::Models::CasePriority), criteria, [])
+      .and_return(tenancy_classification_stub)
   end
 
   context 'when given a case priority' do

--- a/spec/lib/hackney/income/worktray_item_gateway_spec.rb
+++ b/spec/lib/hackney/income/worktray_item_gateway_spec.rb
@@ -4,36 +4,20 @@ describe Hackney::Income::WorktrayItemGateway do
   let(:gateway) { described_class.new }
 
   let(:tenancy_model) { Hackney::Income::Models::CasePriority }
-  let(:document_model) { Hackney::Cloud::Document }
 
   context 'when storing a tenancy' do
-    subject(:store_worktray_item) do
-      gateway.store_worktray_item(
-        tenancy_ref: attributes.fetch(:tenancy_ref),
-        criteria: attributes.fetch(:criteria)
-      )
-    end
+    subject(:store_worktray_item) { gateway.store_worktray_item(attributes) }
 
     let(:attributes) do
       {
         tenancy_ref: Faker::Internet.slug,
-        criteria: stubbed_criteria
+        criteria: stubbed_criteria,
+        classification: classification
       }
     end
 
     let(:stubbed_criteria) { Stubs::StubCriteria.new }
-    let(:tenancy_classification_stub) { double('Classifier') }
     let(:classification) { 'no_action' }
-
-    before do
-      expect(tenancy_classification_stub).to receive(:execute).and_return(classification)
-
-      expect(document_model).to receive(:by_payment_ref).with(stubbed_criteria.payment_ref).and_return([])
-
-      expect(Hackney::Income::TenancyClassification::Classifier).to receive(:new)
-        .with(instance_of(tenancy_model), stubbed_criteria, [])
-        .and_return(tenancy_classification_stub)
-    end
 
     context 'when the tenancy does not already exist' do
       let(:created_tenancy) { tenancy_model.find_by(tenancy_ref: attributes.fetch(:tenancy_ref)) }


### PR DESCRIPTION
## Context
We want to use MAA agreements rather than the agreements from UH whenever we running classification, currently, the classifier called in the sync process, in `stored_tenancies_gateway` whenever a new `case_priority` is saved in the DB.

We want to refactor these responsibilities so we can update that agreement states in MAA before running the classifier and then saving a new worktray item(aka case priority) 

This is the second slice of this refactoring, first slice: https://github.com/LBHackney-IT/lbh-income-api/pull/463

## Changes proposed in this pull request
-  Call the classifier outside stored_tenancies_gateway during the sync process

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-176

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
