### PR TITLE
Move court case related helper methods into a separate module

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -3,9 +3,12 @@ module Hackney
     module TenancyClassification
       module V2
         module Helpers
-          # Replace this with Hackney::Income::TenancyClassification::V2::MAAgreementHelpers
+          # Replace these with:
+          # include Hackney::Income::TenancyClassification::V2::Helpers::MAAgreementHelpers
+          # include Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
           # when agreements synced from UH
           include Hackney::Income::TenancyClassification::V2::Helpers::UHAgreementHelpers
+          include Hackney::Income::TenancyClassification::V2::Helpers::UHCourtCaseHelpers
 
           def case_paused?
             @case_priority.paused?
@@ -15,40 +18,8 @@ module Hackney
             @criteria.eviction_date.present?
           end
 
-          def court_warrant_active?
-            return false if @criteria.court_outcome.blank?
-
-            if @criteria.court_outcome.in?([
-              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
-              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
-              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY,
-              Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
-            ])
-              return @criteria.courtdate.blank? || @criteria.courtdate > 6.years.ago
-            end
-
-            false
-          end
-
-          def court_date_in_future?
-            @criteria.courtdate.present? && @criteria.courtdate.future?
-          end
-
           def should_prevent_action?
             case_has_eviction_date? || court_date_in_future? || case_paused?
-          end
-
-          def no_court_date?
-            @criteria.courtdate.blank?
-          end
-
-          def court_outcome_missing?
-            return false if court_date_in_future?
-            return false if no_court_date?
-
-            @criteria.court_outcome.blank?
           end
 
           def last_communication_older_than?(date)

--- a/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
@@ -1,0 +1,43 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Helpers
+          module UHCourtCaseHelpers
+            def court_warrant_active?
+              return false if @criteria.court_outcome.blank?
+
+              if @criteria.court_outcome.in?([
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY,
+                Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+              ])
+                return @criteria.courtdate.blank? || @criteria.courtdate > 6.years.ago
+              end
+
+              false
+            end
+
+            def court_date_in_future?
+              @criteria.courtdate.present? && @criteria.courtdate.future?
+            end
+
+            def no_court_date?
+              @criteria.courtdate.blank?
+            end
+
+            def court_outcome_missing?
+              return false if court_date_in_future?
+              return false if no_court_date?
+
+              @criteria.court_outcome.blank?
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We want to use MAA agreements rather than the agreements from UH whenever we running classification

## Changes proposed in this pull request
- Move court_case helper methods to `UHCourtCaseHelpers` from `TenancyClassification::V2::Helper`, Once we synced agreements and court_cases from UH, we can swap these easily with a new module that uses the court cases in MA


## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-176

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
