### PR TITLE
Allow updating court case

### DIFF
--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -6,7 +6,9 @@ module CourtCaseResponseHelper
       courtDate: court_case.court_date,
       courtOutcome: court_case.court_outcome,
       balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
-      strikeOutDate: court_case.strike_out_date&.strftime('%F')
+      strikeOutDate: court_case.strike_out_date,
+      terms: court_case.terms,
+      disrepairCounterClaim: court_case.disrepair_counter_claim
     }
   end
 end

--- a/app/controllers/court_case_response_helper.rb
+++ b/app/controllers/court_case_response_helper.rb
@@ -6,8 +6,7 @@ module CourtCaseResponseHelper
       courtDate: court_case.court_date,
       courtOutcome: court_case.court_outcome,
       balanceOnCourtOutcomeDate: court_case.balance_on_court_outcome_date,
-      createdAt: court_case.created_at.strftime('%F'),
-      strikeOutDate: court_case.strike_out_date.strftime('%F')
+      strikeOutDate: court_case.strike_out_date&.strftime('%F')
     }
   end
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -1,6 +1,7 @@
 class CourtCasesController < ApplicationController
   include CourtCaseResponseHelper
-
+  REQUIRED_PARAMS = %i[id tenancy_ref court_date court_outcome balance_on_court_outcome_date].freeze
+  OPTIONAL_PARAMS = %i[strike_out_date terms disrepair_counter_claim].freeze
   def index
     requested_cases = income_use_case_factory.view_court_cases.execute(tenancy_ref: params.fetch(:tenancy_ref))
 
@@ -26,11 +27,14 @@ class CourtCasesController < ApplicationController
 
   def update
     court_case_params = {
-      id: params.require(:id),
-      tenancy_ref: params.require(:tenancy_ref),
-      court_date: params.require(:court_date),
-      court_outcome: params.require(:court_outcome),
-      balance_on_court_outcome_date: params.require(:balance_on_court_outcome_date)
+      id: update_court_case_params[:id],
+      tenancy_ref: update_court_case_params[:tenancy_ref],
+      court_date: update_court_case_params[:court_date],
+      court_outcome: update_court_case_params[:court_outcome],
+      balance_on_court_outcome_date: update_court_case_params[:balance_on_court_outcome_date],
+      strike_out_date: update_court_case_params[:strike_out_date],
+      terms: update_court_case_params[:terms],
+      disrepair_counter_claim: update_court_case_params[:disrepair_counter_claim]
     }
 
     updated_court_case = income_use_case_factory.update_court_case.execute(court_case_params: court_case_params)
@@ -38,4 +42,10 @@ class CourtCasesController < ApplicationController
 
     render json: response
   end
+
+  def update_court_case_params
+    params.require(REQUIRED_PARAMS)
+    allowed_params = params.permit(REQUIRED_PARAMS + OPTIONAL_PARAMS)
+  end
+
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -1,7 +1,8 @@
 class CourtCasesController < ApplicationController
   include CourtCaseResponseHelper
-  REQUIRED_PARAMS = %i[id tenancy_ref court_date court_outcome balance_on_court_outcome_date].freeze
-  OPTIONAL_PARAMS = %i[strike_out_date terms disrepair_counter_claim].freeze
+  REQUIRED_UPDATE_PARAMS = %i[id tenancy_ref court_date court_outcome balance_on_court_outcome_date].freeze
+  OPTIONAL_UPDATE_PARAMS = %i[strike_out_date terms disrepair_counter_claim].freeze
+
   def index
     requested_cases = income_use_case_factory.view_court_cases.execute(tenancy_ref: params.fetch(:tenancy_ref))
 
@@ -38,14 +39,17 @@ class CourtCasesController < ApplicationController
     }
 
     updated_court_case = income_use_case_factory.update_court_case.execute(court_case_params: court_case_params)
-    response = map_court_case_to_response(court_case: updated_court_case)
 
-    render json: response
+    if updated_court_case
+      response = map_court_case_to_response(court_case: updated_court_case)
+      render json: response
+    else
+      render json: { error: 'court case not found' }, status: :not_found
+    end
   end
 
   def update_court_case_params
-    params.require(REQUIRED_PARAMS)
-    allowed_params = params.permit(REQUIRED_PARAMS + OPTIONAL_PARAMS)
+    params.require(REQUIRED_UPDATE_PARAMS)
+    params.permit(REQUIRED_UPDATE_PARAMS + OPTIONAL_UPDATE_PARAMS)
   end
-
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -14,15 +14,27 @@ class CourtCasesController < ApplicationController
 
   def create
     court_case_params = {
-      tenancy_ref: params.fetch(:tenancy_ref),
-      court_date: params.fetch(:court_date),
-      court_outcome: params.fetch(:court_outcome),
-      balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
-      strike_out_date: params.fetch(:strike_out_date)
+      tenancy_ref: params.require(:tenancy_ref),
+      court_date: params.require(:court_date)
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)
     response = map_court_case_to_response(court_case: new_court_case)
+
+    render json: response
+  end
+
+  def update
+    court_case_params = {
+      id: params.require(:id),
+      tenancy_ref: params.require(:tenancy_ref),
+      court_date: params.require(:court_date),
+      court_outcome: params.require(:court_outcome),
+      balance_on_court_outcome_date: params.require(:balance_on_court_outcome_date)
+    }
+
+    updated_court_case = income_use_case_factory.update_court_case.execute(court_case_params: court_case_params)
+    response = map_court_case_to_response(court_case: updated_court_case)
 
     render json: response
   end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -1,8 +1,5 @@
 class CourtCasesController < ApplicationController
   include CourtCaseResponseHelper
-  REQUIRED_UPDATE_PARAMS = %i[id tenancy_ref court_date court_outcome balance_on_court_outcome_date].freeze
-  OPTIONAL_UPDATE_PARAMS = %i[strike_out_date terms disrepair_counter_claim].freeze
-
   def index
     requested_cases = income_use_case_factory.view_court_cases.execute(tenancy_ref: params.fetch(:tenancy_ref))
 
@@ -15,9 +12,18 @@ class CourtCasesController < ApplicationController
   end
 
   def create
+    parameters = %i[tenancy_ref court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim].freeze
+
+    create_court_case_params = params.permit(parameters)
+
     court_case_params = {
-      tenancy_ref: params.require(:tenancy_ref),
-      court_date: params.require(:court_date)
+      tenancy_ref: create_court_case_params[:tenancy_ref],
+      court_date: create_court_case_params[:court_date],
+      court_outcome: create_court_case_params[:court_outcome],
+      balance_on_court_outcome_date: create_court_case_params[:balance_on_court_outcome_date],
+      strike_out_date: create_court_case_params[:strike_out_date],
+      terms: create_court_case_params[:terms],
+      disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim]
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)
@@ -27,9 +33,12 @@ class CourtCasesController < ApplicationController
   end
 
   def update
+    parameters = %i[id court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim].freeze
+
+    update_court_case_params = params.permit(parameters)
+
     court_case_params = {
       id: update_court_case_params[:id],
-      tenancy_ref: update_court_case_params[:tenancy_ref],
       court_date: update_court_case_params[:court_date],
       court_outcome: update_court_case_params[:court_outcome],
       balance_on_court_outcome_date: update_court_case_params[:balance_on_court_outcome_date],
@@ -46,10 +55,5 @@ class CourtCasesController < ApplicationController
     else
       render json: { error: 'court case not found' }, status: :not_found
     end
-  end
-
-  def update_court_case_params
-    params.require(REQUIRED_UPDATE_PARAMS)
-    params.permit(REQUIRED_UPDATE_PARAMS + OPTIONAL_UPDATE_PARAMS)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
     get '/court_cases/:tenancy_ref', to: 'court_cases#index'
     post '/court_case/:tenancy_ref', to: 'court_cases#create'
+    patch '/court_case/:court_case_id/update', to: 'court_cases#update'
 
     get 'actions', to: 'actions#index'
   end

--- a/lib/hackney/income/update_court_case.rb
+++ b/lib/hackney/income/update_court_case.rb
@@ -1,0 +1,28 @@
+module Hackney
+  module Income
+    class UpdateCourtCase
+      def execute(court_case_params:)
+        court_case_id = court_case_params[:id]
+        court_date = court_case_params[:court_date]
+        tenancy_ref = court_case_params[:tenancy_ref]
+
+        court_case = Hackney::Income::Models::CourtCase.find_by_id(court_case_id)
+
+        return if court_case.nil?
+        return if court_case.court_date != court_date
+        return if court_case.tenancy_ref != tenancy_ref
+
+        params = {
+          court_outcome: court_case_params[:court_outcome],
+          balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
+          strike_out_date: court_case_params[:strike_out_date],
+          terms: court_case_params[:terms],
+          disrepair_counter_claim: court_case_params[:disrepair_counter_claim]
+        }
+
+        court_case.update(params)
+        court_case
+      end
+    end
+  end
+end

--- a/lib/hackney/income/update_court_case.rb
+++ b/lib/hackney/income/update_court_case.rb
@@ -3,22 +3,18 @@ module Hackney
     class UpdateCourtCase
       def execute(court_case_params:)
         court_case_id = court_case_params[:id]
-        court_date = court_case_params[:court_date]
-        tenancy_ref = court_case_params[:tenancy_ref]
-
         court_case = Hackney::Income::Models::CourtCase.find_by_id(court_case_id)
 
         return if court_case.nil?
-        return if court_case.court_date != court_date
-        return if court_case.tenancy_ref != tenancy_ref
 
         params = {
+          court_date: court_case_params[:court_date],
           court_outcome: court_case_params[:court_outcome],
           balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
           strike_out_date: court_case_params[:strike_out_date],
           terms: court_case_params[:terms],
           disrepair_counter_claim: court_case_params[:disrepair_counter_claim]
-        }
+        }.reject { |_key, value| value.nil? }
 
         court_case.update(params)
         court_case

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -243,6 +243,10 @@ module Hackney
         Hackney::Income::ViewCourtCases.new
       end
 
+      def update_court_case
+        Hackney::Income::UpdateCourtCase.new
+      end
+
       private
 
       def cloud_storage

--- a/spec/lib/hackney/income/update_court_case_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe Hackney::Income::UpdateCourtCase do
+  subject { described_class.new }
+
+  let(:id) { Faker::Number.number(digits: 2) }
+  let(:tenancy_ref) { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
+  let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:court_outcome) { nil }
+  let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:strike_out_date) { nil }
+  let(:terms) { nil }
+  let(:disrepair_counter_claim) { nil }
+
+  let(:court_case_params) do
+    {
+      id: id,
+      tenancy_ref: tenancy_ref,
+      court_date: court_date,
+      court_outcome: court_outcome,
+      balance_on_court_outcome_date: balance_on_court_outcome_date,
+      strike_out_date: strike_out_date,
+      terms: terms,
+      disrepair_counter_claim: disrepair_counter_claim
+    }
+  end
+
+  before do
+    create(:court_case, id: id, tenancy_ref: tenancy_ref, court_date: court_date)
+  end
+
+  context 'when adding an (not adjourned) court outcome to an existing court case' do
+    let(:court_outcome) { 'SOT' }
+
+    it 'updates and returns the court case' do
+      court_case = subject.execute(court_case_params: court_case_params)
+
+      expect(court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
+      expect(court_case.id).to eq(id)
+      expect(court_case.tenancy_ref).to eq(tenancy_ref)
+      expect(court_case.court_date).to eq(court_date)
+      expect(court_case.court_outcome).to eq(court_outcome)
+      expect(court_case.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
+    end
+  end
+
+  context 'when adding an adjourned court outcome to an existing court case' do
+    let(:court_outcome) { 'AAH' }
+    let(:strike_out_date) { Faker::Date.forward(days: 30) }
+    let(:terms) { false }
+    let(:disrepair_counter_claim) { false }
+
+    it 'updates and returns the court case' do
+      court_case = subject.execute(court_case_params: court_case_params)
+
+      expect(court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
+      expect(court_case.id).to eq(id)
+      expect(court_case.strike_out_date).to eq(strike_out_date)
+      expect(court_case.terms).to eq(terms)
+      expect(court_case.disrepair_counter_claim).to eq(disrepair_counter_claim)
+    end
+  end
+
+  context 'when the court case does not exist' do
+    it 'returns nil' do
+      court_case_params[:id] = Faker::Number.number(digits: 6)
+
+      expect(subject.execute(court_case_params: court_case_params)).to be_nil
+    end
+  end
+
+  context 'when the court date of the existing court case does not match' do
+    it 'returns nil' do
+      court_case_params[:court_date] = Faker::Date.between(from: 20.days.ago, to: 11.days.ago)
+
+      expect(subject.execute(court_case_params: court_case_params)).to be_nil
+    end
+  end
+
+  context 'when the tenancy ref of the existing court case does not match' do
+    it 'returns nil' do
+      court_case_params[:tenancy_ref] = Faker::Number.number(digits: 2).to_s
+
+      expect(subject.execute(court_case_params: court_case_params)).to be_nil
+    end
+  end
+end

--- a/spec/lib/hackney/income/update_court_case_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_spec.rb
@@ -61,6 +61,17 @@ describe Hackney::Income::UpdateCourtCase do
     end
   end
 
+  context 'when the court date of the existing court case does not match' do
+    it 'updates the court date of the existing court case and returns it' do
+      new_court_date = Faker::Date.between(from: 20.days.ago, to: 11.days.ago)
+      court_case_params[:court_date] = new_court_date
+      court_case = subject.execute(court_case_params: court_case_params)
+
+      expect(court_case.id).to eq(id)
+      expect(court_case.court_date).to eq(new_court_date)
+    end
+  end
+
   context 'when the court case does not exist' do
     it 'returns nil' do
       court_case_params[:id] = Faker::Number.number(digits: 6)
@@ -69,19 +80,13 @@ describe Hackney::Income::UpdateCourtCase do
     end
   end
 
-  context 'when the court date of the existing court case does not match' do
-    it 'returns nil' do
-      court_case_params[:court_date] = Faker::Date.between(from: 20.days.ago, to: 11.days.ago)
+  context 'when adding a court outcome without a court date to an existing court case' do
+    it 'updates and returns the court case' do
+      court_case = subject.execute(court_case_params: { id: id, court_date: nil, court_outcome: 'SOT' })
 
-      expect(subject.execute(court_case_params: court_case_params)).to be_nil
-    end
-  end
-
-  context 'when the tenancy ref of the existing court case does not match' do
-    it 'returns nil' do
-      court_case_params[:tenancy_ref] = Faker::Number.number(digits: 2).to_s
-
-      expect(subject.execute(court_case_params: court_case_params)).to be_nil
+      expect(court_case.id).to eq(id)
+      expect(court_case.court_date).not_to be_nil
+      expect(court_case.court_outcome).to eq('SOT')
     end
   end
 end

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe 'CourtCases', type: :request do
       let(:new_court_case_params) do
         {
           tenancy_ref: tenancy_ref,
-          court_date: court_date
+          court_date: court_date,
+          court_outcome: nil,
+          balance_on_court_outcome_date: nil,
+          strike_out_date: nil,
+          terms: nil,
+          disrepair_counter_claim: nil
         }
       end
 
@@ -77,7 +82,6 @@ RSpec.describe 'CourtCases', type: :request do
         let(:update_court_case_params) do
           {
             id: id,
-            tenancy_ref: tenancy_ref,
             court_date: court_date,
             court_outcome: court_outcome,
             balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
@@ -101,7 +105,6 @@ RSpec.describe 'CourtCases', type: :request do
 
           parsed_response = JSON.parse(response.body)
 
-          expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
           expect(parsed_response['courtDate']).to include(court_date)
           expect(parsed_response['courtOutcome']).to eq(court_outcome)
           expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
@@ -113,7 +116,6 @@ RSpec.describe 'CourtCases', type: :request do
         let(:update_court_case_params) do
           {
             id: id,
-            tenancy_ref: tenancy_ref,
             court_date: court_date,
             court_outcome: court_outcome,
             balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
@@ -137,7 +139,6 @@ RSpec.describe 'CourtCases', type: :request do
 
           parsed_response = JSON.parse(response.body)
 
-          expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
           expect(parsed_response['courtDate']).to include(court_date)
           expect(parsed_response['courtOutcome']).to eq(court_outcome)
           expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
@@ -152,7 +153,6 @@ RSpec.describe 'CourtCases', type: :request do
         let(:update_court_case_params) do
           {
             id: non_existent_id,
-            tenancy_ref: tenancy_ref,
             court_date: court_date,
             court_outcome: court_outcome,
             balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -68,38 +68,39 @@ RSpec.describe 'CourtCases', type: :request do
 
   describe 'PATCH /api/v1/court_case/{tenancy_ref}' do
     path '/court_case/{court_case_id}/update' do
-      context 'when adding a (not adjourned) court outcome'
-      let(:update_court_case_instance) { instance_double(Hackney::Income::UpdateCourtCase) }
+      context 'when adding a (not adjourned) court outcome' do
+        let(:update_court_case_instance) { instance_double(Hackney::Income::UpdateCourtCase) }
 
-      let(:update_court_case_params) do
-        {
-          id: id,
-          tenancy_ref: tenancy_ref,
-          court_date: court_date,
-          court_outcome: court_outcome,
-          balance_on_court_outcome_date: balance_on_court_outcome_date.to_s
-        }
-      end
+        let(:update_court_case_params) do
+          {
+            id: id,
+            tenancy_ref: tenancy_ref,
+            court_date: court_date,
+            court_outcome: court_outcome,
+            balance_on_court_outcome_date: balance_on_court_outcome_date.to_s
+          }
+        end
 
-      let(:existing_court_case) { create(:court_case, id: id, tenancy_ref: tenancy_ref, court_date: court_date) }
-      let(:updated_court_case) { create(:court_case, update_court_case_params) }
+        let(:existing_court_case) { create(:court_case, id: id, tenancy_ref: tenancy_ref, court_date: court_date) }
+        let(:updated_court_case) { create(:court_case, update_court_case_params) }
 
-      before do
-        allow(Hackney::Income::UpdateCourtCase).to receive(:new).and_return(update_court_case_instance)
-        allow(update_court_case_instance).to receive(:execute)
-          .with(court_case_params: update_court_case_params)
-          .and_return(updated_court_case)
-      end
+        before do
+          allow(Hackney::Income::UpdateCourtCase).to receive(:new).and_return(update_court_case_instance)
+          allow(update_court_case_instance).to receive(:execute)
+            .with(court_case_params: update_court_case_params)
+            .and_return(updated_court_case)
+        end
 
-      it 'updates the court case' do
-        patch "/api/v1/court_case/#{id}/update", params: update_court_case_params
+        it 'updates the court case' do
+          patch "/api/v1/court_case/#{id}/update", params: update_court_case_params
 
-        parsed_response = JSON.parse(response.body)
+          parsed_response = JSON.parse(response.body)
 
-        expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
-        expect(parsed_response['courtDate']).to include(court_date)
-        expect(parsed_response['courtOutcome']).to eq(court_outcome)
-        expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
+          expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
+          expect(parsed_response['courtDate']).to include(court_date)
+          expect(parsed_response['courtOutcome']).to eq(court_outcome)
+          expect(parsed_response['balanceOnCourtOutcomeDate']).to eq(balance_on_court_outcome_date.to_s)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
For an officer, adding a court case is a 2 process step in the design, they:

1.  Add the court date (most likely before the court case takes place)
2. Add the outcome once the court case had taken place

## Changes proposed in this pull request
<!-- List all the changes -->
I'm sorry it's so big 😭 - definitely could and should have sliced it into use case then endpoint... 😞 
- Adds an `update_court_case` use case that takes outcome information and updates an existing court case
- Adds a PATCH endpoint for updating an existing court case

To do:
- Update documentation for the endpoint (will do as I wait for this PR to be reviewed)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- In the controller, I separated required and optional parameters
  - Is that unecessary or is having required params making things worse, since we will also check for required fields in the frontend
- I made the `update_court_case` use case return `nil` if the `court case id`, `court date` and `tenancy ref` doesn't match an those of an existing court case
   - Same question as above really, is this unecessary or does it make sense?
   - `court case id` makes sense
   - But as I type this, I am unsure about the others, since in the designs, when adding the court outcomes you don't even enter those
  - I guess I was trying to be extra safe but maybe it's _too much_
```
       return if court_case.nil?
       return if court_case.court_date != court_date
       return if court_case.tenancy_ref != tenancy_ref
```
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-411?atlOrigin=eyJpIjoiYzU4Yjk3ZjMxOTY0NGUwOWFhM2U1NGNjZmM5N2I5OWIiLCJwIjoiaiJ9
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
