### PR TITLE
Add ma court case helper

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers/helpers_base.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/helpers_base.rb
@@ -1,0 +1,19 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Helpers
+          module HelpersBase
+            def most_recent_agreement
+              @most_recent_agreement ||= Hackney::Income::Models::Agreement.where(tenancy_ref: @criteria.tenancy_ref).last
+            end
+
+            def most_recent_court_case
+              @most_recent_court_case ||= Hackney::Income::Models::CourtCase.where(tenancy_ref: @criteria.tenancy_ref).last
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
@@ -4,6 +4,8 @@ module Hackney
       module V2
         module Helpers
           module MAAgreementHelpers
+            include HelpersBase
+
             def active_agreement?
               most_recent_agreement.present? && most_recent_agreement.active?
             end
@@ -23,14 +25,6 @@ module Hackney
               return false unless most_recent_agreement.formal?
 
               most_recent_agreement.start_date > most_recent_court_case.court_date
-            end
-
-            def most_recent_agreement
-              @most_recent_agreement ||= Hackney::Income::Models::Agreement.where(tenancy_ref: @criteria.tenancy_ref).last
-            end
-
-            def most_recent_court_case
-              @most_recent_court_case ||= Hackney::Income::Models::CourtCase.where(tenancy_ref: @criteria.tenancy_ref).last
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
@@ -8,6 +8,7 @@ module Hackney
 
             def court_warrant_active?
               return false if most_recent_court_case.blank?
+              return false if most_recent_court_case.court_date.blank?
               return false if most_recent_court_case.court_outcome.blank?
 
               if most_recent_court_case.court_outcome.in?([
@@ -18,7 +19,7 @@ module Hackney
                 Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
                 Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
               ])
-                return most_recent_court_case.court_date.blank? || most_recent_court_case.court_date > 6.years.ago
+                return most_recent_court_case.court_date > 6.years.ago
               end
 
               false

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
@@ -11,12 +11,12 @@ module Hackney
               return false if most_recent_court_case.court_outcome.blank?
 
               if most_recent_court_case.court_outcome.in?([
-                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
-                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
-                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY,
-                Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
-                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+                Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
               ])
                 return most_recent_court_case.court_date.blank? || most_recent_court_case.court_date > 6.years.ago
               end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
@@ -4,6 +4,8 @@ module Hackney
       module V2
         module Helpers
           module MACourtCaseHelpers
+            include HelpersBase
+
             def court_warrant_active?
               return false if most_recent_court_case.blank?
               return false if most_recent_court_case.court_outcome.blank?
@@ -36,10 +38,6 @@ module Hackney
               return false if no_court_date?
 
               most_recent_court_case.court_outcome.blank?
-            end
-
-            def most_recent_court_case
-              @most_recent_court_case ||= Hackney::Income::Models::CourtCase.where(tenancy_ref: @criteria.tenancy_ref).last
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
@@ -1,0 +1,49 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Helpers
+          module MACourtCaseHelpers
+            def court_warrant_active?
+              return false if most_recent_court_case.blank?
+              return false if most_recent_court_case.court_outcome.blank?
+
+              if most_recent_court_case.court_outcome.in?([
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+                Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY,
+                Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+                Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+              ])
+                return most_recent_court_case.court_date.blank? || most_recent_court_case.court_date > 6.years.ago
+              end
+
+              false
+            end
+
+            def court_date_in_future?
+              return false unless most_recent_court_case.present? && most_recent_court_case.court_date.present?
+              most_recent_court_case.court_date.future?
+            end
+
+            def no_court_date?
+              most_recent_court_case.blank? || most_recent_court_case.court_date.blank?
+            end
+
+            def court_outcome_missing?
+              return false if court_date_in_future?
+              return false if no_court_date?
+
+              most_recent_court_case.court_outcome.blank?
+            end
+
+            def most_recent_court_case
+              @most_recent_court_case ||= Hackney::Income::Models::CourtCase.where(tenancy_ref: @criteria.tenancy_ref).last
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
@@ -5,6 +5,7 @@ module Hackney
         module Helpers
           module UHCourtCaseHelpers
             def court_warrant_active?
+              return false if @criteria.courtdate.blank?
               return false if @criteria.court_outcome.blank?
 
               if @criteria.court_outcome.in?([
@@ -15,7 +16,7 @@ module Hackney
                 Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
                 Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
               ])
-                return @criteria.courtdate.blank? || @criteria.courtdate > 6.years.ago
+                return @criteria.courtdate > 6.years.ago
               end
 
               false

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -312,7 +312,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
   end
 
-# Remove these tests when enabling MA agreements
+  # Remove these tests when enabling MA agreements
   describe 'court_date_in_future' do
     subject { helpers.court_date_in_future? }
 

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -517,6 +517,14 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
       end
     end
 
+    context 'when the court date is in future' do
+      let(:courtdate) { 2.weeks.from_now }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
     context 'when there is a court date in the past' do
       let(:courtdate) { 2.days.ago }
 
@@ -538,13 +546,13 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
 
     context 'when there is a court date in the future' do
-      let(:courtdate) { 2.days.ago }
+      let(:courtdate) { 2.days.from_now }
 
       context 'when the court outcome is blank' do
         let(:court_outcome) { nil }
 
         it 'returns false' do
-          expect(subject).to eq(true)
+          expect(subject).to eq(false)
         end
       end
 

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -403,7 +403,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
         let(:courtdate) { nil }
 
         it 'returns false' do
-          expect(subject).to eq(true)
+          expect(subject).to eq(false)
         end
       end
     end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/helpers_spec.rb
@@ -85,34 +85,6 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
   end
 
-  describe 'court_date_in_future' do
-    subject { helpers.court_date_in_future? }
-
-    context 'when the criteria has a future court date' do
-      let(:courtdate) { 6.days.from_now }
-
-      it 'returns true' do
-        expect(subject).to eq(true)
-      end
-    end
-
-    context 'when the criteria has a past court date' do
-      let(:courtdate) { 6.days.ago }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context 'when the criteria does not have a court date' do
-      let(:courtdate) { nil }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-  end
-
   describe 'should_prevent_action?' do
     subject { helpers.should_prevent_action? }
 
@@ -144,34 +116,6 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
 
     context 'when the case is paused' do
       let(:case_priority) { build(:case_priority, is_paused_until: 7.days.from_now) }
-
-      it 'returns true' do
-        expect(subject).to eq(true)
-      end
-    end
-  end
-
-  describe 'no_court_date?' do
-    subject { helpers.no_court_date? }
-
-    context 'when the criteria has a future court date' do
-      let(:courtdate) { 6.days.from_now }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context 'when the criteria has a past court date' do
-      let(:courtdate) { 6.days.ago }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context 'when the criteria does not have a court date' do
-      let(:courtdate) { nil }
 
       it 'returns true' do
         expect(subject).to eq(true)
@@ -368,6 +312,63 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
   end
 
+# Remove these tests when enabling MA agreements
+  describe 'court_date_in_future' do
+    subject { helpers.court_date_in_future? }
+
+    context 'when the criteria has a future court date' do
+      let(:courtdate) { 6.days.from_now }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the criteria has a past court date' do
+      let(:courtdate) { 6.days.ago }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the criteria does not have a court date' do
+      let(:courtdate) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
+  describe 'no_court_date?' do
+    subject { helpers.no_court_date? }
+
+    context 'when the criteria has a future court date' do
+      let(:courtdate) { 6.days.from_now }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the criteria has a past court date' do
+      let(:courtdate) { 6.days.ago }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the criteria does not have a court date' do
+      let(:courtdate) { nil }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
   describe 'court_warrant_active' do
     subject { helpers.court_warrant_active? }
 
@@ -557,7 +558,6 @@ describe Hackney::Income::TenancyClassification::V2::Helpers do
     end
   end
 
-  # Remove these tests when enabling MA agreements
   describe 'breached_agreement?' do
     subject { helpers.breached_agreement? }
 

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
@@ -160,7 +160,17 @@ describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
     end
 
     context 'when there is no court date' do
-      let(:most_recent_court_case) { { court_date: nil } }
+      let(:most_recent_court_case) { { court_date: court_date } }
+      let(:court_date) { nil }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the court date is in future' do
+      let(:most_recent_court_case) { { court_date: court_date } }
+      let(:court_date) { 2.weeks.from_now }
 
       it 'returns false' do
         expect(subject).to eq(false)
@@ -190,13 +200,13 @@ describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
 
     context 'when there is a court date in the future' do
       let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-      let(:court_date) { 2.days.ago }
+      let(:court_date) { 2.days.from_now }
 
       context 'when the court outcome is blank' do
         let(:court_outcome) { nil }
 
         it 'returns false' do
-          expect(subject).to eq(true)
+          expect(subject).to eq(false)
         end
       end
 

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
@@ -144,7 +144,7 @@ describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
         let(:court_date) { nil }
 
         it 'returns false' do
-          expect(subject).to eq(true)
+          expect(subject).to eq(false)
         end
       end
     end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
@@ -111,8 +111,17 @@ describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
       end
     end
 
-    context 'when there is a adjourned on terms outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY }
+    context 'when there is a court outcome' do
+      let(:court_outcome) {
+        [
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+        ].sample
+      }
       let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
 
       context 'with a court date 2 years ago' do
@@ -136,108 +145,6 @@ describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
 
         it 'returns false' do
           expect(subject).to eq(true)
-        end
-      end
-    end
-
-    context 'when there is a adjourned on terms outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
-      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-
-      context 'with a court date 2 years ago' do
-        let(:court_date) { 2.years.ago }
-
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
-      end
-
-      context 'with a court date 8 years ago' do
-        let(:court_date) { 8.years.ago }
-
-        it 'returns false' do
-          expect(subject).to eq(false)
-        end
-      end
-    end
-
-    context 'when there is a adjourned (secondary) on terms outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY }
-      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-
-      context 'with a court date 2 years ago' do
-        let(:court_date) { 2.years.ago }
-
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
-      end
-
-      context 'with a court date 8 years ago' do
-        let(:court_date) { 8.years.ago }
-
-        it 'returns false' do
-          expect(subject).to eq(false)
-        end
-      end
-    end
-
-    context 'when there is a suspended possession outcome outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION }
-      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-
-      context 'with a court date 2 years ago' do
-        let(:court_date) { 2.years.ago }
-
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
-        context 'with a court date 8 years ago' do
-          let(:court_date) { 8.years.ago }
-
-          it 'returns false' do
-            expect(subject).to eq(false)
-          end
-        end
-      end
-    end
-
-    context 'when there is a outright possession with date outcome outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
-      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-
-      context 'with a court date 2 years ago' do
-        let(:court_date) { 2.years.ago }
-
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
-        context 'with a court date 8 years ago' do
-          let(:court_date) { 8.years.ago }
-
-          it 'returns false' do
-            expect(subject).to eq(false)
-          end
-        end
-      end
-    end
-
-    context 'when there is a outright possession forthwith outcome outcome' do
-      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH }
-      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
-
-      context 'with a court date 2 years ago' do
-        let(:court_date) { 2.years.ago }
-
-        it 'returns true' do
-          expect(subject).to eq(true)
-        end
-        context 'with a court date 8 years ago' do
-          let(:court_date) { 8.years.ago }
-
-          it 'returns false' do
-            expect(subject).to eq(false)
-          end
         end
       end
     end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
@@ -1,0 +1,305 @@
+require 'rails_helper'
+
+describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers do
+  class DummyCourtCaseHelperClass
+    include Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
+
+    def initialize(case_priority, criteria, documents)
+      @case_priority = case_priority
+      @criteria = criteria
+      @documents = documents
+    end
+  end
+
+  let(:court_case_model) { Hackney::Income::Models::CourtCase }
+  let(:case_priority) { build(:case_priority, is_paused_until: nil) }
+  let(:criteria) { Stubs::StubCriteria.new }
+  let(:helpers) { DummyCourtCaseHelperClass.new(case_priority, criteria, nil) }
+  let(:most_recent_court_case) { nil }
+
+  before do
+    unless most_recent_court_case.nil?
+      court_case = build(:court_case, tenancy_ref: criteria.tenancy_ref,
+                                      court_date: most_recent_court_case[:court_date],
+                                      court_outcome: most_recent_court_case[:court_outcome])
+      allow(court_case_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([court_case])
+    end
+  end
+
+  describe 'court_date_in_future' do
+    subject { helpers.court_date_in_future? }
+
+    context 'when there is no court case' do
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the court case has a future court date' do
+      let(:most_recent_court_case) { { court_date: 6.days.from_now } }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the court case has a past court date' do
+      let(:most_recent_court_case) { { court_date: 6.days.ago } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the court case does not have a court date' do
+      let(:most_recent_court_case) { { court_date: nil } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
+  describe 'no_court_date?' do
+    subject { helpers.no_court_date? }
+
+    context 'when there is no court case' do
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when the court case has a future court date' do
+      let(:most_recent_court_case) { { court_date: 6.days.from_now } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the court case has a past court date' do
+      let(:most_recent_court_case) { { court_date: 6.days.ago } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when the court case does not have a court date' do
+      let(:most_recent_court_case) { { court_date: nil } }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
+  describe 'court_warrant_active?' do
+    subject { helpers.court_warrant_active? }
+
+    context 'when there is no court case' do
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is no court outcome' do
+      let(:most_recent_court_case) { { court_outcome: nil } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is a adjourned on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:court_date) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+
+      context 'with a court date is nil' do
+        let(:court_date) { nil }
+
+        it 'returns false' do
+          expect(subject).to eq(true)
+        end
+      end
+    end
+
+    context 'when there is a adjourned on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:court_date) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a adjourned (secondary) on terms outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS_SECONDARY }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'with a court date 8 years ago' do
+        let(:court_date) { 8.years.ago }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a suspended possession outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:court_date) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when there is a outright possession with date outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:court_date) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when there is a outright possession forthwith outcome outcome' do
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH }
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+
+      context 'with a court date 2 years ago' do
+        let(:court_date) { 2.years.ago }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+        context 'with a court date 8 years ago' do
+          let(:court_date) { 8.years.ago }
+
+          it 'returns false' do
+            expect(subject).to eq(false)
+          end
+        end
+      end
+    end
+  end
+
+  describe 'court_outcome_missing?' do
+    subject { helpers.court_outcome_missing? }
+
+    context 'when there is no court case' do
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is no court date' do
+      let(:most_recent_court_case) { { court_date: nil } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when there is a court date in the past' do
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+      let(:court_date) { 2.days.ago }
+
+      context 'when the court outcome is blank' do
+        let(:court_outcome) { nil }
+
+        it 'returns true' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'when the court outcome is not blank' do
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+
+    context 'when there is a court date in the future' do
+      let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
+      let(:court_date) { 2.days.ago }
+
+      context 'when the court outcome is blank' do
+        let(:court_outcome) { nil }
+
+        it 'returns false' do
+          expect(subject).to eq(true)
+        end
+      end
+
+      context 'when the court outcome is not blank' do
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We want to use MAA agreements rather than the agreements from UH whenever we running classification

## Changes proposed in this pull request
- Add agreements helpers for MA court cases `MACourtCaseHelpers`

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-176

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated