### PR TITLE
Add tests around classification rules with agreement/court case data from MA

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -5,10 +5,11 @@ module Hackney
         class Classifier
           include Helpers
 
-          def initialize(case_priority, criteria, documents)
+          def initialize(case_priority, criteria, documents, use_ma_data = false)
             @criteria = criteria
             @case_priority = case_priority
             @documents = documents
+            @use_ma_data = use_ma_data
           end
 
           def execute
@@ -30,7 +31,7 @@ module Hackney
               Rulesets::CheckData
             ]
 
-            actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents).execute }
+            actions = rulesets.map { |ruleset| ruleset.new(@case_priority, @criteria, @documents, @use_ma_data).execute }
 
             actions.compact!
 

--- a/lib/hackney/income/tenancy_classification/v2/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers.rb
@@ -3,12 +3,7 @@ module Hackney
     module TenancyClassification
       module V2
         module Helpers
-          # Replace these with:
-          # include Hackney::Income::TenancyClassification::V2::Helpers::MAAgreementHelpers
-          # include Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
-          # when agreements synced from UH
-          include Hackney::Income::TenancyClassification::V2::Helpers::UHAgreementHelpers
-          include Hackney::Income::TenancyClassification::V2::Helpers::UHCourtCaseHelpers
+          include Hackney::Income::TenancyClassification::V2::Helpers::HelpersProxy
 
           def case_paused?
             @case_priority.paused?

--- a/lib/hackney/income/tenancy_classification/v2/helpers/helpers_proxy.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/helpers_proxy.rb
@@ -1,0 +1,98 @@
+module Hackney
+  module Income
+    module TenancyClassification
+      module V2
+        module Helpers
+          module HelpersProxy
+            # The intention of this class if to be able to run the existing classification engine
+            # with both Manage Arrears data and Universal Housing data.
+            include Hackney::Income::TenancyClassification::V2::Helpers::MAAgreementHelpers
+            include Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
+            include Hackney::Income::TenancyClassification::V2::Helpers::UHAgreementHelpers
+            include Hackney::Income::TenancyClassification::V2::Helpers::UHCourtCaseHelpers
+
+            def active_agreement?
+              if @use_ma_data
+                active_agreement_ma?
+              else
+                active_agreement_uh?
+              end
+            end
+
+            def informal_breached_agreement?
+              if @use_ma_data
+                informal_breached_agreement_ma?
+              else
+                informal_breached_agreement_uh?
+              end
+            end
+
+            def breached_agreement?
+              if @use_ma_data
+                breached_agreement_ma?
+              else
+                breached_agreement_uh?
+              end
+            end
+
+            def court_breach_agreement?
+              if @use_ma_data
+                court_breach_agreement_ma?
+              else
+                court_breach_agreement_uh?
+              end
+            end
+
+            def court_warrant_active?
+              if @use_ma_data
+                court_warrant_active_ma?
+              else
+                court_warrant_active_uh?
+              end
+            end
+
+            def court_date_in_future?
+              if @use_ma_data
+                court_date_in_future_ma?
+              else
+                court_date_in_future_uh?
+              end
+            end
+
+            def no_court_date?
+              if @use_ma_data
+                no_court_date_ma?
+              else
+                no_court_date_uh?
+              end
+            end
+
+            def court_outcome_missing?
+              if @use_ma_data
+                court_outcome_missing_ma?
+              else
+                court_outcome_missing_uh?
+              end
+            end
+
+            def court_date
+              if @use_ma_data
+                court_date_ma
+              else
+                court_date_uh
+              end
+            end
+
+            def court_outcome
+              if @use_ma_data
+                court_outcome_ma
+              else
+                court_outcome_uh
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
@@ -6,21 +6,22 @@ module Hackney
           module MAAgreementHelpers
             include HelpersBase
 
-            def active_agreement?
+            def active_agreement_ma?
               most_recent_agreement.present? && most_recent_agreement.active?
             end
 
-            def informal_breached_agreement?
+            def informal_breached_agreement_ma?
               breached_agreement? && !court_breach_agreement?
             end
 
-            def breached_agreement?
+            def breached_agreement_ma?
               return false if most_recent_agreement.blank?
+              return false if most_recent_agreement.start_date.blank?
 
               most_recent_agreement.breached?
             end
 
-            def court_breach_agreement?
+            def court_breach_agreement_ma?
               return false unless breached_agreement?
               return false unless most_recent_agreement.formal?
 

--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers.rb
@@ -6,7 +6,7 @@ module Hackney
           module MACourtCaseHelpers
             include HelpersBase
 
-            def court_warrant_active?
+            def court_warrant_active_ma?
               return false if most_recent_court_case.blank?
               return false if most_recent_court_case.court_date.blank?
               return false if most_recent_court_case.court_outcome.blank?
@@ -25,20 +25,28 @@ module Hackney
               false
             end
 
-            def court_date_in_future?
+            def court_date_in_future_ma?
               return false unless most_recent_court_case.present? && most_recent_court_case.court_date.present?
               most_recent_court_case.court_date.future?
             end
 
-            def no_court_date?
+            def no_court_date_ma?
               most_recent_court_case.blank? || most_recent_court_case.court_date.blank?
             end
 
-            def court_outcome_missing?
-              return false if court_date_in_future?
-              return false if no_court_date?
+            def court_outcome_missing_ma?
+              return false if court_date_in_future_ma?
+              return false if no_court_date_ma?
 
               most_recent_court_case.court_outcome.blank?
+            end
+
+            def court_date_ma
+              most_recent_court_case&.court_date
+            end
+
+            def court_outcome_ma
+              most_recent_court_case&.court_outcome
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/helpers/uh_agreement_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/uh_agreement_helpers.rb
@@ -4,22 +4,22 @@ module Hackney
       module V2
         module Helpers
           module UHAgreementHelpers
-            def active_agreement?
+            def active_agreement_uh?
               @criteria.active_agreement? || (@criteria.most_recent_agreement.present? && @criteria.most_recent_agreement[:status].in?(%i[active breached]))
             end
 
-            def informal_breached_agreement?
+            def informal_breached_agreement_uh?
               breached_agreement? && !court_breach_agreement?
             end
 
-            def breached_agreement?
+            def breached_agreement_uh?
               return false if @criteria.most_recent_agreement.blank?
               return false if @criteria.most_recent_agreement[:start_date].blank?
 
               @criteria.most_recent_agreement[:breached]
             end
 
-            def court_breach_agreement?
+            def court_breach_agreement_uh?
               return false unless breached_agreement?
               return false if @criteria.courtdate.blank?
 

--- a/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/uh_court_case_helpers.rb
@@ -4,7 +4,7 @@ module Hackney
       module V2
         module Helpers
           module UHCourtCaseHelpers
-            def court_warrant_active?
+            def court_warrant_active_uh?
               return false if @criteria.courtdate.blank?
               return false if @criteria.court_outcome.blank?
 
@@ -22,19 +22,27 @@ module Hackney
               false
             end
 
-            def court_date_in_future?
+            def court_date_in_future_uh?
               @criteria.courtdate.present? && @criteria.courtdate.future?
             end
 
-            def no_court_date?
+            def no_court_date_uh?
               @criteria.courtdate.blank?
             end
 
-            def court_outcome_missing?
-              return false if court_date_in_future?
-              return false if no_court_date?
+            def court_outcome_missing_uh?
+              return false if court_date_in_future_uh?
+              return false if no_court_date_uh?
 
               @criteria.court_outcome.blank?
+            end
+
+            def court_date_uh
+              @criteria.courtdate
+            end
+
+            def court_outcome_uh
+              @criteria.court_outcome
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_court_date.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_court_date.rb
@@ -14,7 +14,7 @@ module Hackney
               return false if should_prevent_action?
               return false if @criteria.collectable_arrears.blank?
               return false if @criteria.weekly_gross_rent.blank?
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
 
               return false unless @criteria.nosp.served?
 
@@ -23,7 +23,7 @@ module Hackney
 
               return false unless @criteria.nosp.active?
 
-              return false if @criteria.courtdate.present? && @criteria.courtdate > @criteria.last_communication_date
+              return false if court_date.present? && court_date > @criteria.last_communication_date
 
               balance_is_in_arrears_by_number_of_weeks?(4)
             end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/apply_for_outright_possession_warrant.rb
@@ -12,13 +12,13 @@ module Hackney
 
             def action_valid
               return false if should_prevent_action?
-              return false if @criteria.active_agreement?
-              return false if @criteria.courtdate.blank?
-              return false if @criteria.courtdate.future?
-              return false if @criteria.courtdate < 3.months.ago
+              return false if active_agreement?
+              return false if court_date.blank?
+              return false if court_date.future?
+              return false if court_date < 3.months.ago
               return false if @criteria.last_communication_action.in?(blocking_communication_actions)
 
-              @criteria.court_outcome.in?(prerequisite_court_outcomes_for_action)
+              court_outcome.in?(prerequisite_court_outcomes_for_action)
             end
 
             def prerequisite_court_outcomes_for_action

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
@@ -6,10 +6,11 @@ module Hackney
           class BaseRuleset
             include V2::Helpers
 
-            def initialize(case_priority, criteria, documents)
+            def initialize(case_priority, criteria, documents, use_ma_data = false)
               @case_priority = case_priority
               @criteria = criteria
               @documents = documents
+              @use_ma_data = use_ma_data
             end
           end
         end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/check_data.rb
@@ -15,7 +15,7 @@ module Hackney
               return true if !case_paused? && court_warrant_active? && !active_agreement?
 
               # Cases with court outcomes must have court dates recorded
-              return true if !case_paused? && no_court_date? && @criteria.court_outcome.present?
+              return true if !case_paused? && no_court_date? && court_outcome.present?
 
               false
             end

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_no_payment.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_no_payment.rb
@@ -12,7 +12,7 @@ module Hackney
 
             def action_valid
               return false if should_prevent_action?
-              return false if @criteria.courtdate.blank?
+              return false if court_date.blank?
               return false unless court_breach_agreement?
               return false if @criteria.days_since_last_payment.to_i < 8
 

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_visit.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/court_breach_visit.rb
@@ -12,7 +12,7 @@ module Hackney
 
             def action_valid
               return false if should_prevent_action?
-              return false if @criteria.courtdate.blank?
+              return false if court_date.blank?
               return false unless court_breach_agreement?
 
               @criteria.last_communication_action.in?(court_breach_letter_actions) &&

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_court_warning_letter.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_court_warning_letter.rb
@@ -15,10 +15,10 @@ module Hackney
               return false if @criteria.collectable_arrears.blank?
               return false if @criteria.weekly_gross_rent.blank?
 
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
 
               return false if @criteria.last_communication_action.in?(after_court_warning_letter_actions)
-              return false if @criteria.courtdate&.past?
+              return false if court_date&.past?
 
               return false unless @criteria.nosp.valid?
               return false unless @criteria.nosp.active?

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_one.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_one.rb
@@ -15,7 +15,7 @@ module Hackney
               return false if @criteria.collectable_arrears.blank?
               return false if @criteria.weekly_gross_rent.blank?
               return false if @criteria.nosp.served?
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
               return false if breached_agreement? && !court_breach_agreement?
 
               return false if @criteria.last_communication_action.in?(after_letter_one_actions) &&

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_letter_two.rb
@@ -15,7 +15,7 @@ module Hackney
               return false if @criteria.collectable_arrears.blank?
               return false if @criteria.weekly_gross_rent.blank?
 
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
               return false if breached_agreement? && !court_breach_agreement?
               return false if @criteria.nosp.served?
 

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/send_sms.rb
@@ -13,9 +13,9 @@ module Hackney
             def action_valid
               return false if should_prevent_action?
               return false if @criteria.collectable_arrears.blank?
-              return false if @criteria.courtdate.present?
+              return false if court_date.present?
               return false if @criteria.nosp.served?
-              return false if @criteria.active_agreement?
+              return false if active_agreement?
               return false if breached_agreement? && !court_breach_agreement?
               return false if @criteria.collectable_arrears >= 10
 

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/update_court_outcome_action.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/update_court_outcome_action.rb
@@ -12,11 +12,11 @@ module Hackney
 
             def action_valid
               return false if should_prevent_action?
-              return false if @criteria.courtdate.blank?
-              return false if @criteria.courtdate.future?
+              return false if court_date.blank?
+              return false if court_date.future?
               return false if court_breach_agreement?
 
-              @criteria.court_outcome.blank?
+              court_outcome.blank?
             end
           end
         end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_court_date_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_court_date_spec.rb
@@ -81,4 +81,5 @@ describe '"Apply for Court Date" examples' do
   ]
 
   include_examples 'TenancyClassification', examples
+  include_examples 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant_spec.rb
@@ -50,4 +50,5 @@ describe 'Apply for Outright Possession Warrant Rule examples' do
     )
   ]
   it_behaves_like 'TenancyClassification', examples
+  include_examples 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
@@ -41,4 +41,5 @@ describe 'Check Data examples' do
     )
   ]
   it_behaves_like 'TenancyClassification', examples
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
@@ -62,4 +62,5 @@ describe '"Court Breach - No Payment" examples' do
   ]
 
   include_examples 'TenancyClassification', examples
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
@@ -45,5 +45,6 @@ describe 'Send Court Breach Letter Rule', type: :feature do
     )
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
   include_examples 'TenancyClassification', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/informal_breach_after_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/informal_breach_after_letter_spec.rb
@@ -41,4 +41,5 @@ describe 'Informal Breach after letter' do
   ]
 
   include_examples 'TenancyClassification', examples
+  include_examples 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
@@ -47,5 +47,6 @@ describe 'Various "Send breach letter" examples (new)' do
     )
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
   include_examples 'TenancyClassification', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_court_warning_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_court_warning_letter_spec.rb
@@ -169,5 +169,6 @@ describe 'Send Court Warning Letter Rule', type: :feature do
     }
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', send_court_warning_letter_condition_matrix
   it_behaves_like 'TenancyClassification', send_court_warning_letter_condition_matrix
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
@@ -87,5 +87,6 @@ describe 'Various "Send informal breach letter" examples (new)' do
     )
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
   include_examples 'TenancyClassification', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_one_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_one_spec.rb
@@ -309,5 +309,6 @@ describe 'Send Letter One Rule', type: :feature do
     }
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', send_letter_one_condition_matrix
   it_behaves_like 'TenancyClassification', send_letter_one_condition_matrix
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_two_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_letter_two_spec.rb
@@ -244,5 +244,6 @@ describe 'Send Letter Two Rule', type: :feature do
     }
   ]
 
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', send_letter_two_condition_matrix
   it_behaves_like 'TenancyClassification', send_letter_two_condition_matrix
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_nosp_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_nosp_spec.rb
@@ -313,4 +313,5 @@ describe 'Send NOSP Rule', type: :feature do
   ]
 
   it_behaves_like 'TenancyClassification', send_nosp_condition_matrix
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', send_nosp_condition_matrix
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_sms_spec.rb
@@ -144,4 +144,5 @@ describe 'Send First SMS Rule examples' do
   ]
 
   it_behaves_like 'TenancyClassification', examples
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
@@ -84,4 +84,5 @@ describe '"Update court outcome" examples' do
   ]
 
   include_examples 'TenancyClassification', examples
+  it_behaves_like 'TenancyClassificationWithAgreementsInMA', examples
 end

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 describe Hackney::Income::TenancyClassification::V2::Helpers::MAAgreementHelpers do
   class DummyAgreementHelperClass
-    include Hackney::Income::TenancyClassification::V2::Helpers::MAAgreementHelpers
+    include Hackney::Income::TenancyClassification::V2::Helpers::HelpersProxy
 
     def initialize(case_priority, criteria, documents)
       @case_priority = case_priority
       @criteria = criteria
       @documents = documents
+      @use_ma_data = true # This will call MAAgreementHelpers trough the HelpersProxy class
     end
   end
   let(:agreement_model) { Hackney::Income::Models::Agreement }

--- a/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/v2/helpers/ma_court_case_helpers_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 describe Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers do
   class DummyCourtCaseHelperClass
-    include Hackney::Income::TenancyClassification::V2::Helpers::MACourtCaseHelpers
+    include Hackney::Income::TenancyClassification::V2::Helpers::HelpersProxy
 
     def initialize(case_priority, criteria, documents)
       @case_priority = case_priority
       @criteria = criteria
       @documents = documents
+      @use_ma_data = true # This will call MACourtCaseHelpers trough the HelpersProxy class
     end
   end
 

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -59,9 +59,6 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
       courtdate: courtdate,
       eviction_date: eviction_date,
       court_outcome: court_outcome,
-      latest_active_agreement_date: latest_active_agreement_date,
-      breach_agreement_date: breach_agreement_date,
-      number_of_broken_agreements: number_of_broken_agreements,
       expected_balance: expected_balance,
       most_recent_agreement: most_recent_agreement,
       days_since_last_payment: days_since_last_payment,
@@ -82,9 +79,6 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
       let(:court_outcome) { options[:court_outcome] }
       let(:courtdate) { options[:courtdate] }
       let(:eviction_date) { options[:eviction_date] || '' }
-      let(:latest_active_agreement_date) { options[:latest_active_agreement_date] }
-      let(:breach_agreement_date) { options[:breach_agreement_date] }
-      let(:number_of_broken_agreements) { options[:number_of_broken_agreements] }
       let(:expected_balance) { options[:expected_balance] }
       let(:most_recent_agreement) { options[:most_recent_agreement] }
       let(:days_since_last_payment) { options[:days_since_last_payment] }

--- a/spec/support/shared_example_for_tenancy_classification_with_agreements_in_ma.rb
+++ b/spec/support/shared_example_for_tenancy_classification_with_agreements_in_ma.rb
@@ -1,0 +1,124 @@
+#
+# Build up a message to put into the testing context. The message will include all the data that can
+# effect the classification outcome. It will produce a context message that looks like the following:
+#   "when 'nosps_in_last_year' is '0', 'nosp_expiry_date' is '', 'weekly_rent' is '5',
+#   'balance' is '25.0', 'is_paused_until' is '', 'active_agreement' is 'false',
+#   'last_communication_date' is '2019-11-19', 'last_communication_action' is 'IC3',
+#   'eviction_date' is '', 'courtdate' is '2019-09-27 16:39:53 UTC'"
+# The `outcome` is skipped as we use it in the `it` message instead. That will look like the following:
+#  "returns `send_NOSP`"
+#
+def build_context_message(options)
+  'when ' + options.each_with_object([]) do |(attribute, value), msg|
+    next msg if attribute == :outcome
+    msg << "'#{attribute}' is '#{value}'"
+    msg
+  end.join(', ')
+end
+
+#
+# `condition_matrix` is an Array of Hashes containing the mandatory key of `outcome` this is what
+# the classification system should evaluate the other attributes as. For a list of data you can set
+# see the `let`s in the `context` towards the end of this file.
+#
+# Alternatively, see any file that uses the Shared Example and see what they are supplying.
+#
+shared_examples 'TenancyClassificationWithAgreementsInMA' do |condition_matrix|
+  describe Hackney::Income::TenancyClassification::V2::Classifier do
+    it_behaves_like 'TenancyClassification examples', condition_matrix
+  end
+end
+
+shared_examples 'TenancyClassification examples' do |condition_matrix|
+  subject { assign_classification.execute }
+
+  let(:assign_classification) {
+    described_class.new(
+      case_priority, criteria, [], true
+    )
+  }
+
+  let(:criteria) { Stubs::StubCriteria.new(attributes) }
+  let(:case_priority) { build(:case_priority, is_paused_until: is_paused_until) }
+  let(:agreement_model) { Hackney::Income::Models::Agreement }
+  let(:court_case_model) { Hackney::Income::Models::CourtCase }
+
+  let(:attributes) do
+    {
+      balance: balance,
+      collectable_arrears: collectable_arrears,
+      weekly_rent: weekly_rent,
+      last_communication_date: last_communication_date,
+      last_communication_action: last_communication_action,
+      nosp_served_date: nosp_served_date,
+      eviction_date: eviction_date,
+      expected_balance: expected_balance,
+      days_since_last_payment: days_since_last_payment,
+      total_payment_amount_in_week: total_payment_amount_in_week
+    }
+  end
+
+  condition_matrix.each do |options|
+    context(options[:description] || build_context_message(options)) do
+      let(:is_paused_until) { options[:is_paused_until] }
+      let(:balance) { options[:balance] }
+      let(:collectable_arrears) { options[:collectable_arrears] }
+      let(:weekly_rent) { options[:weekly_rent] }
+      let(:last_communication_date) { options[:last_communication_date] }
+      let(:last_communication_action) { options[:last_communication_action] }
+      let(:nosp_served_date) { options[:nosp_served_date] }
+      let(:eviction_date) { options[:eviction_date] || '' }
+      let(:expected_balance) { options[:expected_balance] }
+      let(:days_since_last_payment) { options[:days_since_last_payment] }
+      let(:total_payment_amount_in_week) { options[:total_payment_amount_in_week] }
+      let(:active_agreement) { options[:active_agreement] }
+      let(:most_recent_agreement) { options[:most_recent_agreement] }
+      let(:court_outcome) { options[:court_outcome] }
+      let(:courtdate) { options[:courtdate] }
+
+      before do
+        if courtdate.present? || court_outcome.present?
+          if court_outcome.present? && court_outcome == 'AGE'
+            # We should update these on the examples once UH examples are decommissioned so we won't need this mapping
+            disrepair_counter_claim = true
+            terms = true
+            outcome = Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+          end
+          court_case = build_stubbed(:court_case, tenancy_ref: criteria.tenancy_ref,
+                                                  court_date: courtdate,
+                                                  court_outcome: outcome || court_outcome,
+                                                  disrepair_counter_claim: disrepair_counter_claim,
+                                                  terms: terms)
+        end
+
+        if most_recent_agreement.present?
+          agreement_type = court_case.present? ? :formal : :informal
+          state = most_recent_agreement[:breached] == true ? :breached : :live
+          agreement = build_stubbed(:agreement,
+                                    agreement_type: agreement_type,
+                                    tenancy_ref: criteria.tenancy_ref,
+                                    start_date: most_recent_agreement[:start_date],
+                                    court_case_id: court_case&.id,
+                                    current_state: state)
+        elsif active_agreement == true
+          agreement = build_stubbed(:agreement, tenancy_ref: criteria.tenancy_ref, current_state: :live)
+        end
+
+        allow(court_case_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([court_case])
+        allow(agreement_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([agreement])
+      end
+
+      if options[:outcome]
+        it "returns `#{options[:outcome]}`" do
+          expect(subject).to eq(options[:outcome])
+        end
+      elsif options[:outcome_not]
+        it "does not return `#{options[:outcome_not]}`" do
+          expect(subject).not_to eq(options[:outcome_not])
+        end
+      else
+        raise 'outcome or outcome_not as an option'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
We want to be able to test existing classification rules using agreement and court case data from MA rather than UH. 

## Changes proposed in this pull request
- Add a proxy class that can call both UH and MA agreements/court case helper methods 
- Initialize the classifier with a field variable that defines the used data source
- Add shared example file with test setup for agreements/court cases in MA
- Fix existing rules wherever they tied to UH data

TODO:
- Review court outcomes and map these to the new court outcomes

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-176

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated