### PR TITLE
Add tighter check for adjourned? on court case model

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -8,7 +8,12 @@ module Hackney
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
 
         def adjourned?
-          court_outcome&.start_with?('A')
+          [
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING
+          ].include?(court_outcome)
         end
       end
     end


### PR DESCRIPTION
## Context
It can fail a test when faker generates court_outcome that starts with 'a'

## Changes proposed in this pull request
- Add tighter check for adjourned? on court case model
