### PR TITLE
Allow creating both formal and informal agreements

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -22,10 +22,16 @@ class AgreementsController < ApplicationController
       start_date: params.fetch(:start_date),
       frequency: params.fetch(:frequency),
       created_by: params.fetch(:created_by),
-      notes: params.fetch(:notes)
+      notes: params.fetch(:notes),
+      court_case_id: params.dig(:court_case_id)
     }
 
-    created_agreement = income_use_case_factory.create_informal_agreement.execute(new_agreement_params: agreement_params)
+    if formal_agreement?(agreement_params)
+      created_agreement = income_use_case_factory.create_formal_agreement.execute(new_agreement_params: agreement_params)
+    else
+      created_agreement = income_use_case_factory.create_informal_agreement.execute(new_agreement_params: agreement_params)
+    end
+
     response = map_agreement_to_response(agreement: created_agreement)
     render json: response
   end
@@ -42,5 +48,9 @@ class AgreementsController < ApplicationController
 
   def agreements_params
     params.permit([:tenancy_ref])
+  end
+
+  def formal_agreement?(params)
+    params[:agreement_type] == 'formal' && params[:court_case_id].present?
   end
 end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -231,6 +231,13 @@ module Hackney
         )
       end
 
+      def create_formal_agreement
+        Hackney::Income::CreateFormalAgreement.new(
+          add_action_diary: add_action_diary,
+          cancel_agreement: cancel_agreement
+        )
+      end
+
       def cancel_agreement
         Hackney::Income::CancelAgreement.new
       end


### PR DESCRIPTION
## Context
The create action on agreements controller calls `create informal agreement` use-case, we want to be able to create both based on request params

## Changes proposed in this pull request
- Allow calling `create formal agreement` use-case when there is a `court case id` and :formal `agreement_type` 
