### PR TITLE
Add uh court case migrator

### DIFF
--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -8,7 +8,6 @@ module Hackney
       end
 
       def migrate(criteria)
-
         Rails.logger.debug { "Starting migration for UH court case for tenancy ref #{criteria.tenancy_ref}" }
 
         unless criteria_contains_court_data(criteria)
@@ -41,7 +40,7 @@ module Hackney
         court_case_params[:court_outcome] = nil if existing_court_case.court_outcome.present?
 
         if court_case_params.compact.keys.empty?
-          Rails.logger.debug { "UH Criteria does not contain any new information" }
+          Rails.logger.debug { 'UH Criteria does not contain any new information' }
           return
         end
 
@@ -55,14 +54,26 @@ module Hackney
       end
 
       def criteria_contains_court_data(criteria)
-        criteria.courtdate.present? || criteria.court_outcome.present?
+        !get_courtdate(criteria.courtdate).nil? || !map_court_outcome(criteria.court_outcome).nil?
       end
 
       def map_criteria_to_court_case_params(criteria)
         {
-          court_date: criteria.courtdate,
-          court_outcome: criteria.court_outcome
+          court_date: get_courtdate(criteria.courtdate),
+          court_outcome: map_court_outcome(criteria.court_outcome)
         }
+      end
+
+      def get_courtdate(courtdate)
+        return nil if courtdate == DateTime.parse('1900-01-01 00:00:00')
+
+        courtdate
+      end
+
+      def map_court_outcome(outcome)
+        return nil if outcome.strip.empty?
+
+        outcome.strip
       end
     end
   end

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -1,17 +1,60 @@
 module Hackney
   module Income
     class MigrateUhCourtCase
-      def initialize(create_court_case:)
+      def initialize(create_court_case:, view_court_cases:, update_court_case:)
         @create_court_case = create_court_case
+        @view_court_cases = view_court_cases
+        @update_court_case = update_court_case
       end
 
       def migrate(criteria)
-        @create_court_case.execute(map_criteria_to_court_case_params(criteria)) if should_migrate_criteria(criteria)
+
+        Rails.logger.debug { "Starting migration for UH court case for tenancy ref #{criteria.tenancy_ref}" }
+
+        unless criteria_contains_court_data(criteria)
+          Rails.logger.debug { "No court case data in criteria for tenancy ref #{criteria.tenancy_ref}" }
+          return
+        end
+
+        existing_court_cases = @view_court_cases.execute(tenancy_ref: criteria.tenancy_ref)
+        if existing_court_cases.empty?
+          Rails.logger.debug { "Found no existing court cases for tenancy ref #{criteria.tenancy_ref}" }
+          @create_court_case.execute(tenancy_ref: criteria.tenancy_ref, **map_criteria_to_court_case_params(criteria))
+          return
+        end
+
+        if existing_court_cases.count != 1
+          Rails.logger.info { "Will not update multiple court cases for tenancy ref #{criteria.tenancy_ref}" }
+          return
+        end
+
+        existing_court_case = existing_court_cases.first
+
+        unless court_case_missing_detail(existing_court_case)
+          Rails.logger.info { "Will not update existing complete court case for tenancy ref #{criteria.tenancy_ref}" }
+          return
+        end
+
+        court_case_params = map_criteria_to_court_case_params(criteria)
+
+        court_case_params[:court_date] = nil if existing_court_case.court_date.present?
+        court_case_params[:court_outcome] = nil if existing_court_case.court_outcome.present?
+
+        if court_case_params.compact.keys.empty?
+          Rails.logger.debug { "UH Criteria does not contain any new information" }
+          return
+        end
+
+        @update_court_case.execute(id: existing_court_case.id, **court_case_params)
       end
 
       private
 
-      def should_migrate_criteria(criteria)
+      def court_case_missing_detail(court_case)
+        court_case.court_date.blank? || court_case.court_outcome.blank?
+      end
+
+      def criteria_contains_court_data(criteria)
         criteria.courtdate.present? || criteria.court_outcome.present?
       end
 

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -73,7 +73,24 @@ module Hackney
       def map_court_outcome(outcome)
         return nil if outcome.strip.empty?
 
-        outcome.strip
+        case outcome.strip
+        when Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
+        when Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
+        when Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+          Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+        when Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+          Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+        when Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_ANOTHER_HEARING_DATE
+          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_ANOTHER_HEARING_DATE
+        end
       end
     end
   end

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -1,0 +1,21 @@
+module Hackney
+  module Income
+    class MigrateUhCourtCase
+      def initialize(create_court_case:)
+        @create_court_case = create_court_case
+      end
+
+      def migrate(criteria)
+        @create_court_case.execute(map_criteria_to_court_case_params(criteria)) if criteria.courtdate
+      end
+
+      private
+
+      def map_criteria_to_court_case_params(criteria)
+        {
+          court_date: criteria.courtdate
+        }
+      end
+    end
+  end
+end

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -6,14 +6,19 @@ module Hackney
       end
 
       def migrate(criteria)
-        @create_court_case.execute(map_criteria_to_court_case_params(criteria)) if criteria.courtdate
+        @create_court_case.execute(map_criteria_to_court_case_params(criteria)) if should_migrate_criteria(criteria)
       end
 
       private
 
+      def should_migrate_criteria(criteria)
+        criteria.courtdate.present? || criteria.court_outcome.present?
+      end
+
       def map_criteria_to_court_case_params(criteria)
         {
-          court_date: criteria.courtdate
+          court_date: criteria.courtdate,
+          court_outcome: criteria.court_outcome
         }
       end
     end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -254,6 +254,10 @@ module Hackney
         Hackney::Income::UpdateCourtCase.new
       end
 
+      def migrate_uh_court_case
+        Hackney::Income::MigrateUhCourtCase.new(create_court_case: create_court_case)
+      end
+
       private
 
       def cloud_storage

--- a/lib/hackney/tenancy/updated_court_outcome_codes.rb
+++ b/lib/hackney/tenancy/updated_court_outcome_codes.rb
@@ -5,8 +5,11 @@ module Hackney
       ADJOURNED_TO_NEXT_OPEN_DATE = 'AND'.freeze
       ADJOURNED_TO_ANOTHER_HEARING_DATE = 'AAH'.freeze
       ADJOURNED_FOR_DIRECTIONS_HEARING = 'ADH'.freeze
+      ADJOURNED_FOR_ANOTHER_HEARING_DATE = 'AHD'.freeze
 
       SUSPENSION_ON_TERMS = 'SOT'.freeze
+      STRUCK_OUT = 'STO'.freeze
+      WITHDRAWN_ON_THE_DAY = 'WIT'.freeze
 
       STAY_OF_EXECUTION = 'SOE'.freeze
     end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe Hackney::Income::MigrateUhCourtCase do
+  subject(:migrator) { described_class.new(create_court_case: create_court_case).migrate(criteria) }
+
+  let(:create_court_case) { double(Hackney::Income::CreateCourtCase) }
+
+  let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
+
+  context 'when provided a criteria without a court date or court outcome' do
+    let(:criteria_attributes) {
+      {
+        court_outcome: nil,
+        courtdate: nil
+      }
+    }
+
+    it 'does not create a court case' do
+      expect(create_court_case).not_to receive(:execute)
+      subject
+    end
+  end
+
+  context 'when provided a criteria with a court date but without a court outcome' do
+    let(:criteria_attributes) {
+      {
+        court_outcome: nil,
+        courtdate: DateTime.now.midnight - 7.days
+      }
+    }
+
+    it 'creates a partial court case' do
+      expect(create_court_case).to receive(:execute).with(
+        court_date: criteria_attributes[:courtdate]
+      )
+      subject
+    end
+  end
+end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -13,20 +13,23 @@ describe Hackney::Income::MigrateUhCourtCase do
   let(:view_court_cases) { double(Hackney::Income::ViewCourtCases) }
   let(:update_court_case) { double(Hackney::Income::UpdateCourtCase) }
 
+  let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
+  let(:existing_court_cases) { [] }
+
   before do
     allow(view_court_cases).to receive(:execute).and_return(existing_court_cases)
     allow(update_court_case).to receive(:execute).and_return([])
   end
 
-  let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
-  let(:existing_court_cases) { [] }
+  UH_NIL_COURT_OUTCOME = '   '.freeze
+  UH_NIL_DATE = DateTime.parse('1900-01-01 00:00:00')
 
   context 'when there is no existing court case' do
     context 'when provided a criteria without a court date or court outcome' do
       let(:criteria_attributes) {
         {
-          court_outcome: nil,
-          courtdate: nil
+          court_outcome: UH_NIL_COURT_OUTCOME,
+          courtdate: UH_NIL_DATE
         }
       }
 
@@ -39,7 +42,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided a criteria with a court date but without a court outcome' do
       let(:criteria_attributes) {
         {
-          court_outcome: nil,
+          court_outcome: UH_NIL_COURT_OUTCOME,
           courtdate: DateTime.now.midnight - 7.days
         }
       }
@@ -59,7 +62,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       let(:criteria_attributes) {
         {
           court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-          courtdate: nil
+          courtdate: UH_NIL_DATE
         }
       }
 
@@ -155,8 +158,8 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria without a court date or outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: nil,
-            courtdate: nil
+            court_outcome: UH_NIL_COURT_OUTCOME,
+            courtdate: UH_NIL_DATE
           }
         }
 
@@ -170,7 +173,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria with a court date but no outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: nil,
+            court_outcome: UH_NIL_COURT_OUTCOME,
             courtdate: DateTime.now.midnight
           }
         }
@@ -212,8 +215,8 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria without a court date or outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: nil,
-            courtdate: nil
+            court_outcome: UH_NIL_COURT_OUTCOME,
+            courtdate: UH_NIL_DATE
           }
         }
 
@@ -227,7 +230,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria with a court date but no outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: nil,
+            court_outcome: UH_NIL_COURT_OUTCOME,
             courtdate: DateTime.now.midnight
           }
         }
@@ -265,7 +268,7 @@ describe Hackney::Income::MigrateUhCourtCase do
         let(:criteria_attributes) {
           {
             court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
-            courtdate: nil
+            courtdate: UH_NIL_DATE
           }
         }
 

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -101,5 +101,19 @@ describe Hackney::Income::MigrateUhCourtCase do
         subject
       end
     end
+
+    context 'when provided a criteria with a court date but no outcome' do
+      let(:criteria_attributes) {
+        {
+            court_outcome: nil,
+            court_date: DateTime.now.midnight
+        }
+      }
+
+      it 'does not update the court case' do
+        expect(update_court_case).not_to receive(:execute)
+        subject
+      end
+    end
   end
 end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -7,72 +7,74 @@ describe Hackney::Income::MigrateUhCourtCase do
 
   let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
 
-  context 'when provided a criteria without a court date or court outcome' do
-    let(:criteria_attributes) {
-      {
-        court_outcome: nil,
-        courtdate: nil
+  context 'when there is no existing court case' do
+    context 'when provided a criteria without a court date or court outcome' do
+      let(:criteria_attributes) {
+        {
+          court_outcome: nil,
+          courtdate: nil
+        }
       }
-    }
 
-    it 'does not create a court case' do
-      expect(create_court_case).not_to receive(:execute)
-      subject
+      it 'does not create a court case' do
+        expect(create_court_case).not_to receive(:execute)
+        subject
+      end
     end
-  end
 
-  context 'when provided a criteria with a court date but without a court outcome' do
-    let(:criteria_attributes) {
-      {
-        court_outcome: nil,
-        courtdate: DateTime.now.midnight - 7.days
+    context 'when provided a criteria with a court date but without a court outcome' do
+      let(:criteria_attributes) {
+        {
+          court_outcome: nil,
+          courtdate: DateTime.now.midnight - 7.days
+        }
       }
-    }
 
-    it 'creates a partial court case' do
-      expect(create_court_case).to receive(:execute).with(
-        hash_including(
-          court_date: criteria_attributes[:courtdate]
+      it 'creates a partial court case' do
+        expect(create_court_case).to receive(:execute).with(
+          hash_including(
+            court_date: criteria_attributes[:courtdate]
+          )
         )
-      )
-      subject
+        subject
+      end
     end
-  end
 
-  context 'when provided a criteria with a court outcome but without a court date' do
-    let(:criteria_attributes) {
-      {
-        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-        courtdate: nil
+    context 'when provided a criteria with a court outcome but without a court date' do
+      let(:criteria_attributes) {
+        {
+          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          courtdate: nil
+        }
       }
-    }
 
-    it 'creates a partial court case' do
-      expect(create_court_case).to receive(:execute).with(
-        hash_including(
-          court_outcome: criteria_attributes[:court_outcome]
+      it 'creates a partial court case' do
+        expect(create_court_case).to receive(:execute).with(
+          hash_including(
+            court_outcome: criteria_attributes[:court_outcome]
+          )
         )
-      )
-      subject
+        subject
+      end
     end
-  end
 
-  context 'when provided a criteria with a court date and a court outcome' do
-    let(:criteria_attributes) {
-      {
-        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-        courtdate: DateTime.now.midnight - 7.days
+    context 'when provided a criteria with a court date and a court outcome' do
+      let(:criteria_attributes) {
+        {
+          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          courtdate: DateTime.now.midnight - 7.days
+        }
       }
-    }
 
-    it 'creates a partial court case' do
-      expect(create_court_case).to receive(:execute).with(
-        hash_including(
-          court_date: criteria_attributes[:courtdate],
-          court_outcome: criteria_attributes[:court_outcome]
+      it 'creates a partial court case' do
+        expect(create_court_case).to receive(:execute).with(
+          hash_including(
+            court_date: criteria_attributes[:courtdate],
+            court_outcome: criteria_attributes[:court_outcome]
+          )
         )
-      )
-      subject
+        subject
+      end
     end
   end
 end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -31,7 +31,46 @@ describe Hackney::Income::MigrateUhCourtCase do
 
     it 'creates a partial court case' do
       expect(create_court_case).to receive(:execute).with(
-        court_date: criteria_attributes[:courtdate]
+        hash_including(
+          court_date: criteria_attributes[:courtdate]
+        )
+      )
+      subject
+    end
+  end
+
+  context 'when provided a criteria with a court outcome but without a court date' do
+    let(:criteria_attributes) {
+      {
+        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+        courtdate: nil
+      }
+    }
+
+    it 'creates a partial court case' do
+      expect(create_court_case).to receive(:execute).with(
+        hash_including(
+          court_outcome: criteria_attributes[:court_outcome]
+        )
+      )
+      subject
+    end
+  end
+
+  context 'when provided a criteria with a court date and a court outcome' do
+    let(:criteria_attributes) {
+      {
+        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+        courtdate: DateTime.now.midnight - 7.days
+      }
+    }
+
+    it 'creates a partial court case' do
+      expect(create_court_case).to receive(:execute).with(
+        hash_including(
+          court_date: criteria_attributes[:courtdate],
+          court_outcome: criteria_attributes[:court_outcome]
+        )
       )
       subject
     end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -4,6 +4,8 @@ describe Hackney::Income::MigrateUhCourtCase do
   subject(:migrator) { described_class.new(create_court_case: create_court_case).migrate(criteria) }
 
   let(:create_court_case) { double(Hackney::Income::CreateCourtCase) }
+  let(:view_court_cases) { double(Hackney::Income::ViewCourtCases) }
+  let(:update_court_case) { double(Hackney::Income::UpdateCourtCase) }
 
   let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
 
@@ -73,6 +75,29 @@ describe Hackney::Income::MigrateUhCourtCase do
             court_outcome: criteria_attributes[:court_outcome]
           )
         )
+        subject
+      end
+    end
+  end
+
+  context 'when a partial court case already exists with a court date but no outcome' do
+    before do
+      allow(view_court_cases).to(receive(:execute).and_return([{
+        court_date: DateTime.now.midnight - 7.days,
+        court_outcome: nil
+      }]))
+    end
+
+    context 'when provided a criteria without a court date or outcome' do
+      let(:criteria_attributes) {
+        {
+          court_outcome: nil,
+          courtdate: nil
+        }
+      }
+
+      it 'does not update the court case' do
+        expect(update_court_case).not_to receive(:execute)
         subject
       end
     end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -1,13 +1,25 @@
 require 'rails_helper'
 
 describe Hackney::Income::MigrateUhCourtCase do
-  subject(:migrator) { described_class.new(create_court_case: create_court_case).migrate(criteria) }
+  subject(:migrator) {
+    described_class.new(
+      create_court_case: create_court_case,
+      view_court_cases: view_court_cases,
+      update_court_case: update_court_case
+    ).migrate(criteria)
+  }
 
   let(:create_court_case) { double(Hackney::Income::CreateCourtCase) }
   let(:view_court_cases) { double(Hackney::Income::ViewCourtCases) }
   let(:update_court_case) { double(Hackney::Income::UpdateCourtCase) }
 
+  before do
+    allow(view_court_cases).to receive(:execute).and_return(existing_court_cases)
+    allow(update_court_case).to receive(:execute).and_return([])
+  end
+
   let(:criteria) { Stubs::StubCriteria.new(criteria_attributes) }
+  let(:existing_court_cases) { [] }
 
   context 'when there is no existing court case' do
     context 'when provided a criteria without a court date or court outcome' do
@@ -35,6 +47,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
           hash_including(
+            tenancy_ref: criteria.tenancy_ref,
             court_date: criteria_attributes[:courtdate]
           )
         )
@@ -53,6 +66,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
           hash_including(
+            tenancy_ref: criteria.tenancy_ref,
             court_outcome: criteria_attributes[:court_outcome]
           )
         )
@@ -71,6 +85,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
           hash_including(
+            tenancy_ref: criteria.tenancy_ref,
             court_date: criteria_attributes[:courtdate],
             court_outcome: criteria_attributes[:court_outcome]
           )
@@ -80,39 +95,184 @@ describe Hackney::Income::MigrateUhCourtCase do
     end
   end
 
-  context 'when a partial court case already exists with a court date but no outcome' do
-    before do
-      allow(view_court_cases).to(receive(:execute).and_return([{
-        court_date: DateTime.now.midnight - 7.days,
-        court_outcome: nil
-      }]))
-    end
+  context 'when there are multiple court cases in MA' do
+    let(:existing_court_cases) {
+      [create(:court_case,
+              court_date: DateTime.now.midnight - 1.month,
+              court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY),
+       create(:court_case,
+              court_date: DateTime.now.midnight - 7.days,
+              court_outcome: nil)]
+    }
 
-    context 'when provided a criteria without a court date or outcome' do
+    context 'when provided with any criteria' do
       let(:criteria_attributes) {
         {
-          court_outcome: nil,
-          courtdate: nil
+          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+          courtdate: DateTime.now.midnight
         }
       }
 
-      it 'does not update the court case' do
+      it 'does not update any existing court cases' do
+        expect(create_court_case).not_to receive(:execute)
         expect(update_court_case).not_to receive(:execute)
         subject
       end
     end
+  end
 
-    context 'when provided a criteria with a court date but no outcome' do
+  context 'when there is a single complete court case in MA' do
+    let(:existing_court_cases) {
+      [create(:court_case,
+              court_date: DateTime.now.midnight - 14.days,
+              court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS)]
+    }
+
+    context 'when provided with a criteria' do
       let(:criteria_attributes) {
         {
-            court_outcome: nil,
-            court_date: DateTime.now.midnight
+          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          courtdate: DateTime.now.midnight - 7.days
         }
       }
 
-      it 'does not update the court case' do
+      it 'does not update the complete court case' do
+        expect(create_court_case).not_to receive(:execute)
         expect(update_court_case).not_to receive(:execute)
         subject
+      end
+    end
+  end
+
+  context 'when there is a single partial court case in MA' do
+    context 'when a partial court case already exists with a court date but no outcome' do
+      let(:existing_court_cases) {
+        [create(:court_case,
+                court_date: DateTime.now.midnight - 7.days,
+                court_outcome: nil)]
+      }
+
+      context 'when provided a criteria without a court date or outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: nil,
+            courtdate: nil
+          }
+        }
+
+        it 'does not update the court case' do
+          expect(create_court_case).not_to receive(:execute)
+          expect(update_court_case).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when provided a criteria with a court date but no outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: nil,
+            courtdate: DateTime.now.midnight
+          }
+        }
+
+        it 'does not update the court case' do
+          expect(create_court_case).not_to receive(:execute)
+          expect(update_court_case).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when provided a criteria with a court date and an outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+            courtdate: DateTime.now.midnight
+          }
+        }
+
+        it 'does update the court case with the court outcome only' do
+          expect(create_court_case).not_to receive(:execute)
+          expect(update_court_case).to receive(:execute).with(
+            id: existing_court_cases[0].id,
+            court_date: nil,
+            court_outcome: criteria_attributes[:court_outcome]
+          )
+          subject
+        end
+      end
+    end
+
+    context 'when a partial court case already exists without a court date but has an outcome' do
+      let(:existing_court_cases) {
+        [create(:court_case,
+                court_date: nil,
+                court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY)]
+      }
+
+      context 'when provided a criteria without a court date or outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: nil,
+            courtdate: nil
+          }
+        }
+
+        it 'does not update the court case' do
+          expect(create_court_case).not_to receive(:execute)
+          expect(update_court_case).not_to receive(:execute)
+          subject
+        end
+      end
+
+      context 'when provided a criteria with a court date but no outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: nil,
+            courtdate: DateTime.now.midnight
+          }
+        }
+
+        it 'does update the court case with the date' do
+          expect(create_court_case).not_to receive(:execute)
+          expect(update_court_case).to receive(:execute).with(
+            id: existing_court_cases[0].id,
+            court_date: criteria_attributes[:courtdate],
+            court_outcome: nil
+          )
+          subject
+        end
+      end
+
+      context 'when provided a criteria with a court date and an outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+            courtdate: DateTime.now.midnight
+          }
+        }
+
+        it 'does update the court case with the court date only' do
+          expect(update_court_case).to receive(:execute).with(
+            id: existing_court_cases[0].id,
+            court_date: criteria_attributes[:courtdate],
+            court_outcome: nil
+          )
+          subject
+        end
+      end
+
+      context 'when provided a criteria with only an outcome' do
+        let(:criteria_attributes) {
+          {
+            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+            courtdate: nil
+          }
+        }
+
+        it 'does not update the court case' do
+          expect(update_court_case).not_to receive(:execute)
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to model court cases within MA. We're going to migrate the data in from UH on this so we can look up for formal agreements and allow officers to manage court cases through MA

## Changes proposed in this pull request
<!-- List all the changes -->
Initial start on wiring up a court case migrator. It's responsibility is to determine whether it can/should create a court case in MA, and do so.

It will update court cases on subsequent syncs, provided there's only a single court case, and that it won't overwrite existing data on that single court case.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-417

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
