### PR TITLE
Fix agreement query when syncing cases

### DIFF
--- a/lib/hackney/income/sync_case_priority.rb
+++ b/lib/hackney/income/sync_case_priority.rb
@@ -15,7 +15,7 @@ module Hackney
       def execute(tenancy_ref:)
         criteria = @prioritisation_gateway.priorities_for_tenancy(tenancy_ref).fetch(:criteria)
         documents = DocumentModel.exclude_uploaded.by_payment_ref(criteria.payment_ref)
-        agreement = AgreementModel.find_by(tenancy_ref: tenancy_ref)
+        agreement = AgreementModel.where(tenancy_ref: tenancy_ref).select(&:active?).last
 
         @update_agreement_state.execute(agreement: agreement, current_balance: criteria.balance) unless agreement.nil?
 

--- a/spec/lib/hackney/income/sync_case_priority_spec.rb
+++ b/spec/lib/hackney/income/sync_case_priority_spec.rb
@@ -77,16 +77,11 @@ describe Hackney::Income::SyncCasePriority do
 
   context 'when there is an existing agreement' do
     let(:agreement) { build(:agreement, tenancy_ref: tenancy_ref, current_state: :live) }
-    let(:case_priority) {
-      build(:case_priority,
-            tenancy_ref: tenancy_ref,
-            classification: :send_letter_one,
-            patch_code: Faker::Number.number(digits: 4),
-            is_paused_until: Date.today + 2.days)
-    }
 
     it 'updates the agreement state' do
-      expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
+      allow(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(
+        build(:case_priority, tenancy_ref: tenancy_ref)
+      )
       expect(agreement_model).to receive(:where).with(tenancy_ref: tenancy_ref).and_return([agreement])
       expect(update_agreement_state)
         .to receive(:execute)
@@ -96,13 +91,6 @@ describe Hackney::Income::SyncCasePriority do
   end
 
   context 'when there are multiple agreements' do
-    let(:case_priority) {
-      build(:case_priority,
-            tenancy_ref: tenancy_ref,
-            classification: :send_letter_one,
-            patch_code: Faker::Number.number(digits: 4),
-            is_paused_until: Date.today + 2.days)
-    }
     let(:active_agreement) { create(:agreement, tenancy_ref: tenancy_ref) }
 
     before do
@@ -114,7 +102,9 @@ describe Hackney::Income::SyncCasePriority do
     end
 
     it 'updates the latest active agreement' do
-      expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
+      allow(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(
+        build(:case_priority, tenancy_ref: tenancy_ref)
+      )
       expect(update_agreement_state)
         .to receive(:execute)
         .with(agreement: active_agreement, current_balance: balance)

--- a/spec/lib/hackney/income/sync_case_priority_spec.rb
+++ b/spec/lib/hackney/income/sync_case_priority_spec.rb
@@ -7,7 +7,9 @@ describe Hackney::Income::SyncCasePriority do
   let(:stored_worktray_item_gateway) { double(store_worktray_item: stub_tenancy_object) }
   let(:document_model) { Hackney::Cloud::Document }
   let(:agreement_model) { Hackney::Income::Models::Agreement }
-  let(:criteria) { Stubs::StubCriteria.new }
+  let(:criteria) { Stubs::StubCriteria.new(balance: balance) }
+  let(:balance) { Faker::Commerce.price(range: 100...1000) }
+  let(:tenancy_ref) { '000009/01' }
   let(:tenancy_classification_stub) { double('Classifier') }
 
   let(:prioritisation_gateway) do
@@ -41,8 +43,6 @@ describe Hackney::Income::SyncCasePriority do
   end
 
   context 'when given a case priority' do
-    let(:tenancy_ref) { '000009/01' }
-
     let(:case_priority) {
       build(:case_priority,
             tenancy_ref: tenancy_ref,
@@ -59,8 +59,6 @@ describe Hackney::Income::SyncCasePriority do
   end
 
   context 'when given a paused case priority' do
-    let(:tenancy_ref) { '000009/01' }
-
     let(:case_priority) {
       build(:case_priority,
             tenancy_ref: tenancy_ref,
@@ -78,8 +76,7 @@ describe Hackney::Income::SyncCasePriority do
   end
 
   context 'when there is an existing agreement' do
-    let(:tenancy_ref) { '000009/01' }
-    let(:agreement) { build(:agreement, tenancy_ref: tenancy_ref) }
+    let(:agreement) { build(:agreement, tenancy_ref: tenancy_ref, current_state: :live) }
     let(:case_priority) {
       build(:case_priority,
             tenancy_ref: tenancy_ref,
@@ -90,10 +87,37 @@ describe Hackney::Income::SyncCasePriority do
 
     it 'updates the agreement state' do
       expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
-      expect(agreement_model).to receive(:find_by).with(tenancy_ref: tenancy_ref).and_return(agreement)
+      expect(agreement_model).to receive(:where).with(tenancy_ref: tenancy_ref).and_return([agreement])
       expect(update_agreement_state)
         .to receive(:execute)
-        .with(agreement: agreement, current_balance: nil)
+        .with(agreement: agreement, current_balance: balance)
+      subject
+    end
+  end
+
+  context 'when there are multiple agreements' do
+    let(:case_priority) {
+      build(:case_priority,
+            tenancy_ref: tenancy_ref,
+            classification: :send_letter_one,
+            patch_code: Faker::Number.number(digits: 4),
+            is_paused_until: Date.today + 2.days)
+    }
+    let(:active_agreement) { create(:agreement, tenancy_ref: tenancy_ref) }
+
+    before do
+      cancelled_agreement = create(:agreement, tenancy_ref: tenancy_ref)
+      create(:agreement_state, :cancelled, agreement: cancelled_agreement)
+      completed_agreement = create(:agreement, tenancy_ref: tenancy_ref)
+      create(:agreement_state, :completed, agreement: completed_agreement)
+      create(:agreement_state, %i[live breached].sample, agreement: active_agreement)
+    end
+
+    it 'updates the latest active agreement' do
+      expect(stored_worktray_item_gateway).to receive(:store_worktray_item).and_return(case_priority)
+      expect(update_agreement_state)
+        .to receive(:execute)
+        .with(agreement: active_agreement, current_balance: balance)
       subject
     end
   end


### PR DESCRIPTION
## Context
There was a mistake when looking up agreements in `SyncCasePriority` use-case, instead of finding the last active agreement, the query returned the first matching agreement. 
 
## Changes proposed in this pull request
- Add a test with multiple agreements 
- Update query to return the latest active agreement for the `tenancy`

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
