### PR TITLE
Change formal agreement to informal on strike out date

### DIFF
--- a/lib/hackney/income/update_agreement_state.rb
+++ b/lib/hackney/income/update_agreement_state.rb
@@ -18,6 +18,7 @@ module Hackney
         expected_balance = expected_balance(agreement)
         current_balance = current_balance
 
+        strike_out(agreement) if agreement.formal? && agreement.court_case.strike_out_date <= Date.today
         return update_last_checked_date(agreement) if state_has_not_changed?(agreement, expected_balance, current_balance)
 
         new_state = if current_balance <= 0
@@ -100,6 +101,10 @@ module Hackney
       def state_has_not_changed?(agreement, expected_balance, current_balance)
         current_state = agreement.agreement_states.last
         current_state.expected_balance == expected_balance && current_state.checked_balance == current_balance
+      end
+
+      def strike_out(agreement)
+        agreement.update!(agreement_type: :informal)
       end
     end
   end

--- a/spec/lib/hackney/income/update_agreement_state_spec.rb
+++ b/spec/lib/hackney/income/update_agreement_state_spec.rb
@@ -282,6 +282,26 @@ describe Hackney::Income::UpdateAgreementState do
     end
   end
 
+  context 'when its a formal agreement' do
+    it 'changes the formal agreement into informal on strikeout date' do
+      next_check_date = start_date + days_before_check.days
+
+      court_case = create(:court_case, tenancy_ref: tenancy_ref, strike_out_date: next_check_date)
+      agreement = create(:agreement, agreement_type: :formal,
+                                     start_date: start_date,
+                                     tenancy_ref: tenancy_ref,
+                                     court_case_id: court_case.id)
+      create(:agreement_state, :live, agreement: agreement)
+
+      current_balance = 50
+
+      Timecop.freeze(next_check_date) do
+        subject.execute(agreement: agreement, current_balance: current_balance)
+        expect(agreement.agreement_type).to eq('informal')
+      end
+    end
+  end
+
   describe '#full_months_since' do
     it 'can calculate the exact number of months since start date' do
       [


### PR DESCRIPTION
## Context
A formal agreement is expected to change into an informal agreement on strikeout date:
- if there is a strikeout date the agreement goes from court to informal

## Changes proposed in this pull request
- Add this condition to `update_agreement_state` use-case

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-384

## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
