### PR TITLE
Add court outcome validation

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -5,15 +5,34 @@ module Hackney
         validates_presence_of :tenancy_ref
         validates_presence_of :terms, if: :adjourned?
         validates_presence_of :disrepair_counter_claim, if: :adjourned?
+        validate :court_outcome_is_valid
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
 
-        def adjourned?
+        ADJOURNED_COURT_OUTCOMES =
           [
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING
-          ].include?(court_outcome)
+          ].freeze
+
+        OTHER_COURT_OUTCOMES =
+          [
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+          ].freeze
+
+        def adjourned?
+          ADJOURNED_COURT_OUTCOMES.include?(court_outcome)
+        end
+
+        private
+
+        def court_outcome_is_valid
+          return unless court_outcome.present?
+          errors.add(:court_outcome, 'must be a valid court outcome code') unless (ADJOURNED_COURT_OUTCOMES + OTHER_COURT_OUTCOMES).include?(court_outcome)
         end
       end
     end

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -3,8 +3,8 @@ module Hackney
     module Models
       class CourtCase < ApplicationRecord
         validates_presence_of :tenancy_ref
-        validates_presence_of :terms, if: :adjourned?
-        validates_presence_of :disrepair_counter_claim, if: :adjourned?
+        validates_inclusion_of :terms, in: [true, false], if: :adjourned?
+        validates_inclusion_of :disrepair_counter_claim, in: [true, false], if: :adjourned?
         validate :court_outcome_is_valid
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
 

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -2,8 +2,21 @@ FactoryBot.define do
   factory :court_case, class: Hackney::Income::Models::CourtCase do
     tenancy_ref { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
     court_date { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-    court_outcome { 'MAA' }
     balance_on_court_outcome_date { Faker::Commerce.price(range: 10...100) }
     strike_out_date { Faker::Date.forward(days: 365) }
+    court_outcome do
+      [
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+      ].sample
+    end
+    terms { adjourned? }
+    disrepair_counter_claim { adjourned? }
   end
 end

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
         Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
       ].sample
     end
-    terms { adjourned? }
-    disrepair_counter_claim { adjourned? }
+    terms { [true, false].sample if adjourned? }
+    disrepair_counter_claim { [true, false].sample if adjourned? }
   end
 end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -5,7 +5,7 @@ describe Hackney::Income::CreateCourtCase do
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-  let(:court_outcome) { 'MAA' }
+  let(:court_outcome) { 'SOT' }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
 

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -22,7 +22,7 @@ describe Hackney::Income::CreateFormalAgreement do
       tenancy_ref: tenancy_ref,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...1000),
       court_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-      court_outcome: 'MAA',
+      court_outcome: 'SOT',
       strike_out_date: Faker::Date.forward(days: 365)
     )
   end

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -167,7 +167,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     let(:existing_court_cases) {
       [create(:court_case,
               court_date: DateTime.now.midnight - 1.month,
-              court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY),
+              court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE),
        create(:court_case,
               court_date: DateTime.now.midnight - 7.days,
               court_outcome: nil)]
@@ -176,7 +176,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided with any criteria' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
           courtdate: DateTime.now.midnight
         }
       }
@@ -274,7 +274,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       let(:existing_court_cases) {
         [create(:court_case,
                 court_date: nil,
-                court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY)]
+                court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE)]
       }
 
       context 'when provided a criteria without a court date or outcome' do

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -14,7 +14,7 @@ describe Hackney::Income::ViewCourtCases do
   context 'when there is a court case for the tenancy' do
     let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...1000) }
     let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
-    let(:court_outcome) { 'MAA' }
+    let(:court_outcome) { 'SOT' }
     let(:strike_out_date) { Faker::Date.forward(days: 365) }
     let(:court_cases_param) do
       {

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -72,8 +72,8 @@ describe Hackney::Income::Models::CourtCase, type: :model do
   context 'when the court outcome is adjourned' do
     before { allow(subject).to receive(:adjourned?).and_return(true) }
 
-    it { is_expected.to validate_presence_of(:terms) }
-    it { is_expected.to validate_presence_of(:disrepair_counter_claim) }
+    it { is_expected.to allow_value(%w[true false]).for(:terms) }
+    it { is_expected.to allow_value(%w[true false]).for(:disrepair_counter_claim) }
   end
 
   context 'when the court outcome is invalid' do

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe Hackney::Income::Models::CourtCase, type: :model do
+  let(:valid_non_adjourned_outcome) do
+    [
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+    ].sample
+  end
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+
   it 'includes the fields for a court case' do
     court_case = described_class.new
     expect(court_case.attributes).to include(
@@ -17,13 +27,11 @@ describe Hackney::Income::Models::CourtCase, type: :model do
   it { is_expected.to validate_presence_of(:tenancy_ref) }
   it { is_expected.to have_many(:agreements) }
 
-  tenancy_ref = Faker::Number.number(digits: 2).to_s
-
   it 'can have associated formal agreements' do
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
       court_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
-      court_outcome: Faker::ChuckNorris.fact,
+      court_outcome: valid_non_adjourned_outcome,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...100),
       strike_out_date: Faker::Date.forward(days: 365)
     )
@@ -54,7 +62,7 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     it 'is still a valid court case' do
       court_case = described_class.create!(
         tenancy_ref: tenancy_ref,
-        court_outcome: Faker::ChuckNorris.fact
+        court_outcome: valid_non_adjourned_outcome
       )
 
       expect(court_case).to be_a Hackney::Income::Models::CourtCase
@@ -66,5 +74,13 @@ describe Hackney::Income::Models::CourtCase, type: :model do
 
     it { is_expected.to validate_presence_of(:terms) }
     it { is_expected.to validate_presence_of(:disrepair_counter_claim) }
+  end
+
+  context 'when the court outcome is invalid' do
+    it 'raises an error' do
+      expect { described_class.create!(tenancy_ref: tenancy_ref, court_outcome: 'invalid_outcome') }
+        .to raise_error ActiveRecord::RecordInvalid,
+                        'Validation failed: Court outcome must be a valid court outcome code'
+    end
   end
 end

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe 'CourtCases', type: :request do
   let(:id) { Faker::Number.number(digits: 3).to_s }
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
-  let(:court_outcome) { 'MAA' }
+  let(:court_outcome) do
+    [
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+    ].sample
+  end
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365).to_s }
   let(:terms) { false }


### PR DESCRIPTION
## Context
Currently, there is no validation around `court outcome` in `CourtCase` model, this field is used in the classifier and in the breach detector, therefor allowing invalid court outcomes can cause issues. 

## Changes proposed in this pull request
- Add validation around the `court outcome` field on the `CourtCase` model
- Change test setups where necessary 

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
