### PR TITLE
Fix court case sync and mapping

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -13,7 +13,8 @@ module Hackney
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
           ].freeze
 
         OTHER_COURT_OUTCOMES =
@@ -21,7 +22,9 @@ module Hackney
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
           ].freeze
 
         def adjourned?

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -7,7 +7,9 @@ module Hackney
           court_date: court_case_params[:court_date],
           court_outcome: court_case_params[:court_outcome],
           balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
-          strike_out_date: court_case_params[:strike_out_date]
+          strike_out_date: court_case_params[:strike_out_date],
+          terms: court_case_params[:terms],
+          disrepair_counter_claim: court_case_params[:disrepair_counter_claim]
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)

--- a/lib/hackney/tenancy/updated_court_outcome_codes.rb
+++ b/lib/hackney/tenancy/updated_court_outcome_codes.rb
@@ -5,6 +5,10 @@ module Hackney
       ADJOURNED_TO_NEXT_OPEN_DATE = 'AND'.freeze
       ADJOURNED_TO_ANOTHER_HEARING_DATE = 'AAH'.freeze
       ADJOURNED_FOR_DIRECTIONS_HEARING = 'ADH'.freeze
+      ADJOURNED_ON_TERMS = 'ADT'.freeze
+
+      OUTRIGHT_POSSESSION_FORTHWITH = 'OPF'.freeze
+      OUTRIGHT_POSSESSION_WITH_DATE = 'OPD'.freeze
 
       SUSPENSION_ON_TERMS = 'SOT'.freeze
       STRUCK_OUT = 'STO'.freeze

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -13,7 +13,10 @@ FactoryBot.define do
         Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
         Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
         Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+        Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
       ].sample
     end
     terms { [true, false].sample if adjourned? }

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -49,10 +49,11 @@ describe Hackney::Income::MigrateUhCourtCase do
 
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
-          hash_including(
+          court_case_params: {
             tenancy_ref: criteria.tenancy_ref,
-            court_date: criteria_attributes[:courtdate]
-          )
+            court_date: criteria_attributes[:courtdate],
+            court_outcome: nil
+          }
         )
         subject
       end
@@ -68,10 +69,11 @@ describe Hackney::Income::MigrateUhCourtCase do
 
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
-          hash_including(
+          court_case_params: {
             tenancy_ref: criteria.tenancy_ref,
+            court_date: nil,
             court_outcome: criteria_attributes[:court_outcome]
-          )
+          }
         )
         subject
       end
@@ -87,11 +89,11 @@ describe Hackney::Income::MigrateUhCourtCase do
 
       it 'creates a partial court case' do
         expect(create_court_case).to receive(:execute).with(
-          hash_including(
+          court_case_params: {
             tenancy_ref: criteria.tenancy_ref,
             court_date: criteria_attributes[:courtdate],
             court_outcome: criteria_attributes[:court_outcome]
-          )
+          }
         )
         subject
       end
@@ -109,7 +111,7 @@ describe Hackney::Income::MigrateUhCourtCase do
         },
         {
           input: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
-          expected: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
         },
         {
           input: Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
@@ -117,11 +119,11 @@ describe Hackney::Income::MigrateUhCourtCase do
         },
         {
           input: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-          expected: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
         },
         {
           input: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-          expected: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
         },
         {
           input: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
@@ -152,7 +154,7 @@ describe Hackney::Income::MigrateUhCourtCase do
         it "maps the court outcome #{example[:input]} to #{example[:expected]}" do
           expect(create_court_case).to receive(:execute).with(
             hash_including(
-              court_outcome: example[:expected]
+              court_case_params: hash_including(court_outcome: example[:expected])
             )
           )
           subject


### PR DESCRIPTION
## Context
Synced fails because `CreateCourtCase` use-case expects `court_case_params`  as a keyword argument.
When we run `MigrateUhCourtCase` sometimes we map to the old court outcome codes, we shouldn't use these anymore, therefore I added the missing ones to the new court outcome codes. 

## Changes proposed in this pull request
- Use keyword arg when calling `CreateCourtCase` use-case in `MigrateUhCourtCase`
- Use only the new court outcome codes in `MigrateUhCourtCase`
- Add the missing court outcome codes to the new court outcome codes
- When creating an `adjourned` court case in `MigrateUhCourtCase` default the `terms` and `disrepair_counter_claim` as the model has a validation for these

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
