### PR TITLE
MERGE WHEN RELEASING AGREEMENTS - Enable using MA agreements and court cases data in classifier

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/v2/classifier.rb
@@ -5,7 +5,7 @@ module Hackney
         class Classifier
           include Helpers
 
-          def initialize(case_priority, criteria, documents, use_ma_data = false)
+          def initialize(case_priority, criteria, documents, use_ma_data = true)
             @criteria = criteria
             @case_priority = case_priority
             @documents = documents

--- a/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
+++ b/lib/hackney/income/tenancy_classification/v2/rulesets/base_ruleset.rb
@@ -6,7 +6,7 @@ module Hackney
           class BaseRuleset
             include V2::Helpers
 
-            def initialize(case_priority, criteria, documents, use_ma_data = false)
+            def initialize(case_priority, criteria, documents, use_ma_data = true)
               @case_priority = case_priority
               @criteria = criteria
               @documents = documents

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -34,7 +34,7 @@ shared_examples 'TenancyClassification Internal' do |condition_matrix|
 
   let(:assign_classification) {
     described_class.new(
-      case_priority, criteria, []
+      case_priority, criteria, [], false
     )
   }
 


### PR DESCRIPTION
## Context
We are using agreements data that is synced from UH when running classifier, going forward we want to use MA agreement system as the data source.

## Changes proposed in this pull request
- Enable using MA agreements and court cases data in classifier
