### PR TITLE
Allow generating and storing informal agreement confirmation letters

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -60,10 +60,4 @@ class LettersController < ApplicationController
   def generate_and_store_use_case
     UseCases::GenerateAndStoreLetter.new
   end
-
-  def income_collection_document?(document)
-    metadata = JSON.parse(document.metadata)
-    income_collection_templates = %w[income_collection_letter_1 income_collection_letter_2]
-    metadata['template']['id'].in?(income_collection_templates)
-  end
 end

--- a/app/models/hackney/income_collection/letter/informal_agreement.rb
+++ b/app/models/hackney/income_collection/letter/informal_agreement.rb
@@ -7,9 +7,9 @@ module Hackney
         TEMPLATE_PATHS = [
           'lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb'
         ].freeze
-        MANDATORY_FIELDS = %i[rent balance agreement_frequency amount date_of_first_payment].freeze
+        MANDATORY_FIELDS = %i[rent agreement_frequency amount date_of_first_payment].freeze
 
-        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable, :date_of_first_payment, :instalment_amount, :balance
+        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable, :date_of_first_payment, :instalment_amount
 
         def initialize(params)
           super(params)
@@ -19,7 +19,6 @@ module Hackney
           @rent = validated_params[:rent]
           @instalment_amount = format('%.2f', validated_params[:amount]) unless validated_params[:amount].nil?
           @date_of_first_payment = format_date(validated_params[:date_of_first_payment])
-          @balance = validated_params[:balance]
 
           return unless @rent
           @rent_charge = format('%.2f', calculate_rent(@rent, @agreement_frequency))

--- a/app/models/hackney/income_collection/letter/informal_agreement.rb
+++ b/app/models/hackney/income_collection/letter/informal_agreement.rb
@@ -7,9 +7,9 @@ module Hackney
         TEMPLATE_PATHS = [
           'lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb'
         ].freeze
-        MANDATORY_FIELDS = %i[rent agreement_frequency amount rent_charge instalment_amount total_amount_payable date_of_first_payment].freeze
+        MANDATORY_FIELDS = %i[rent balance agreement_frequency amount date_of_first_payment].freeze
 
-        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable, :date_of_first_payment
+        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable, :date_of_first_payment, :instalment_amount, :balance
 
         def initialize(params)
           super(params)
@@ -17,8 +17,9 @@ module Hackney
           validated_params = validate_mandatory_fields(MANDATORY_FIELDS, params)
           @agreement_frequency = validated_params[:agreement_frequency]
           @rent = validated_params[:rent]
-          @instalment_amount = validated_params[:amount]
-          @date_of_first_payment = validated_params[:date_of_first_payment]
+          @instalment_amount = format('%.2f', validated_params[:amount]) unless validated_params[:amount].nil?
+          @date_of_first_payment = format_date(validated_params[:date_of_first_payment])
+          @balance = validated_params[:balance]
 
           return unless @rent
           @rent_charge = format('%.2f', calculate_rent(@rent, @agreement_frequency))

--- a/app/models/hackney/letter_date_helper.rb
+++ b/app/models/hackney/letter_date_helper.rb
@@ -1,7 +1,7 @@
 module Hackney
   module LetterDateHelper
     def format_date(date)
-      return nil if date.nil?
+      return if date.nil?
 
       date.strftime('%d %B %Y')
     end

--- a/lib/hackney/pdf/income_preview.rb
+++ b/lib/hackney/pdf/income_preview.rb
@@ -44,6 +44,7 @@ module Hackney
         info_from_uh = @income_information_gateway.get_income_info(tenancy_ref: tenancy_ref)
         stored_info = @tenancy_case_gateway.find(tenancy_ref: tenancy_ref)
         info_from_uh[:total_collectable_arrears_balance] = stored_info.collectable_arrears
+        info_from_uh[:rent] = stored_info.weekly_rent
         info_from_uh
       end
 
@@ -53,11 +54,7 @@ module Hackney
       end
 
       def get_agreement_info(tenancy_ref, agreement)
-        case_priority = Hackney::Income::Models::CasePriority.where(tenancy_ref: tenancy_ref).first
-
         {
-          rent: case_priority.weekly_rent,
-          balance: case_priority.balance,
           agreement_frequency: agreement.frequency,
           amount: agreement.amount,
           date_of_first_payment: agreement.start_date

--- a/lib/hackney/pdf/income_preview.rb
+++ b/lib/hackney/pdf/income_preview.rb
@@ -57,10 +57,10 @@ module Hackney
 
         {
           rent: case_priority.weekly_rent,
+          balance: case_priority.balance,
           agreement_frequency: agreement.frequency,
           amount: agreement.amount,
           date_of_first_payment: agreement.start_date
-
         }
       end
 

--- a/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
@@ -6,8 +6,8 @@
 
 <div>
   <div class="blue_box">
-    <strong>Rent Account Balance: </strong> <br>
-    <strong>Account Number: </strong>
+    <strong>Rent Account Balance: </strong>£<%= @letter.balance %> <br>
+    <strong>Account Number: </strong><%= @letter.tenancy_ref %>
   </div>
 
   <p>
@@ -15,9 +15,9 @@
   </p>
 
   <ul class = "no_bullets">
-    <li>Weekly/Monthly Rent: <%= @letter.rent_charge %> </li>
-    <li>Amount towards the arrears: <%= @letter.instalment_amount %> </li>
-    <li>Total amount payable: <%= @letter.total_amount_payable %> </li>
+    <li>Weekly/Monthly Rent: £<%= @letter.rent_charge %> </li>
+    <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+    <li>Total amount payable: £<%= @letter.total_amount_payable %> </li>
     <li>Date of first payment: <%= @letter.date_of_first_payment %> </li>
   </ul>
 

--- a/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
@@ -6,7 +6,7 @@
 
 <div>
   <div class="blue_box">
-    <strong>Rent Account Balance: </strong>£<%= @letter.balance %> <br>
+    <strong>Rent Account Balance: </strong>£<%= @letter.total_collectable_arrears_balance %> <br>
     <strong>Account Number: </strong><%= @letter.tenancy_ref %>
   </div>
 

--- a/lib/use_cases/generate_and_store_letter.rb
+++ b/lib/use_cases/generate_and_store_letter.rb
@@ -7,12 +7,21 @@ module UseCases
       letter_use_case_factory = Hackney::Letter::UseCaseFactory.new
 
       income_collection_templates = %w[income_collection_letter_1 income_collection_letter_2]
+      agreement_templates = %w[informal_agreement_confirmation_letter]
 
       if template_id.in?(income_collection_templates)
         letter_data = pdf_use_case_factory.get_income_preview.execute(
           tenancy_ref: tenancy_ref,
           template_id: template_id,
           user: user
+        )
+      elsif template_id.in?(agreement_templates)
+        agreement = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?).last
+        letter_data = pdf_use_case_factory.get_income_preview.execute(
+          tenancy_ref: tenancy_ref,
+          template_id: template_id,
+          user: user,
+          agreement: agreement
         )
       else
         letter_data = pdf_use_case_factory.get_preview.execute(

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -86,7 +86,7 @@ describe TenanciesController, type: :controller do
           uc_direct_payment_requested: nil,
           uc_rent_verification: nil,
           universal_credit: nil,
-          weekly_rent: nil,
+          weekly_rent: tenancy_1.weekly_rent.to_s,
           created_at: tenancy_1.created_at.iso8601(3),
           updated_at: tenancy_1.updated_at.iso8601(3)
         )

--- a/spec/factories/case_priority.rb
+++ b/spec/factories/case_priority.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     days_in_arrears { Faker::Number.between(from: 5, to: 1000) }
     active_agreement { false }
     is_paused_until { nil }
+    weekly_rent { Faker::Commerce.price(range: 10..100.0) }
 
     trait :red do
       priority_band { 'red' }

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -91,7 +91,6 @@ describe Hackney::IncomeCollection::Letter do
 
         expect(letter.errors).to eq [
           { message: 'missing mandatory field', name: 'rent' },
-          { message: 'missing mandatory field', name: 'balance' },
           { message: 'missing mandatory field', name: 'agreement_frequency' },
           { message: 'missing mandatory field', name: 'amount' },
           { message: 'missing mandatory field', name: 'date_of_first_payment' }

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -91,11 +91,9 @@ describe Hackney::IncomeCollection::Letter do
 
         expect(letter.errors).to eq [
           { message: 'missing mandatory field', name: 'rent' },
+          { message: 'missing mandatory field', name: 'balance' },
           { message: 'missing mandatory field', name: 'agreement_frequency' },
           { message: 'missing mandatory field', name: 'amount' },
-          { message: 'missing mandatory field', name: 'rent_charge' },
-          { message: 'missing mandatory field', name: 'instalment_amount' },
-          { message: 'missing mandatory field', name: 'total_amount_payable' },
           { message: 'missing mandatory field', name: 'date_of_first_payment' }
         ]
       end

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -49,12 +49,15 @@ describe Hackney::PDF::IncomePreview do
   end
 
   let(:translated_html) { File.open('spec/lib/hackney/pdf/translated_test_income_template.html').read }
+  let(:balance) { Faker::Commerce.price(range: 10..1000.0) }
+  let(:weekly_rent) { Faker::Commerce.price(range: 10..100.0) }
 
   before do
-    Hackney::Income::Models::CasePriority.create!(
-      tenancy_ref: test_tenancy_ref,
-      collectable_arrears: test_collectable_arrears
-    )
+    create(:case_priority,
+           tenancy_ref: test_tenancy_ref,
+           collectable_arrears: test_collectable_arrears,
+           balance: balance,
+           weekly_rent: weekly_rent)
   end
 
   it 'generates letter preview' do
@@ -136,9 +139,10 @@ describe Hackney::PDF::IncomePreview do
             agreement_frequency: agreement.frequency,
             amount: agreement.amount,
             date_of_first_payment: agreement.start_date,
-            rent: nil,
+            rent: weekly_rent,
             title: '',
-            total_collectable_arrears_balance: test_collectable_arrears
+            total_collectable_arrears_balance: test_collectable_arrears,
+            balance: balance
           ),
           username: username
         ).and_call_original

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -38,7 +38,8 @@ describe Hackney::PDF::IncomePreview do
       address_preamble: '',
       title: '',
       forename: 'Bloggs',
-      surname: 'Joe'
+      surname: 'Joe',
+      rent: weekly_rent
     }
   end
   let(:user) do
@@ -49,14 +50,12 @@ describe Hackney::PDF::IncomePreview do
   end
 
   let(:translated_html) { File.open('spec/lib/hackney/pdf/translated_test_income_template.html').read }
-  let(:balance) { Faker::Commerce.price(range: 10..1000.0) }
   let(:weekly_rent) { Faker::Commerce.price(range: 10..100.0) }
 
   before do
     create(:case_priority,
            tenancy_ref: test_tenancy_ref,
            collectable_arrears: test_collectable_arrears,
-           balance: balance,
            weekly_rent: weekly_rent)
   end
 
@@ -141,8 +140,7 @@ describe Hackney::PDF::IncomePreview do
             date_of_first_payment: agreement.start_date,
             rent: weekly_rent,
             title: '',
-            total_collectable_arrears_balance: test_collectable_arrears,
-            balance: balance
+            total_collectable_arrears_balance: test_collectable_arrears
           ),
           username: username
         ).and_call_original

--- a/spec/models/hackney/income_collection/letter/informal_agreement_spec.rb
+++ b/spec/models/hackney/income_collection/letter/informal_agreement_spec.rb
@@ -4,8 +4,8 @@ describe Hackney::IncomeCollection::Letter::InformalAgreement do
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:frequency) { 'weekly' }
   let(:amount) { 30 }
-  let(:start_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
-  let(:weekly_rent) { 10.to_f }
+  let(:start_date) { Date.parse('24/08/2020') }
+  let(:weekly_rent) { 10.to_d }
   let(:letter_params) {
     {
       tenancy_ref: tenancy_ref,
@@ -25,6 +25,14 @@ describe Hackney::IncomeCollection::Letter::InformalAgreement do
   }
 
   let!(:letter) { described_class.new(letter_params) }
+
+  it 'generates a readable date format for first payment date' do
+    expect(letter.date_of_first_payment).to eq('24 August 2020')
+  end
+
+  it 'generates 2 decimal point value for instalment amount' do
+    expect(letter.instalment_amount).to eq('30.00')
+  end
 
   context 'when the letter is being generated' do
     it 'checks that the template file exists' do

--- a/spec/requests/income_collection_letters_spec.rb
+++ b/spec/requests/income_collection_letters_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Income Collection Letters', type: :request do
   let(:user_group) { 'income-collection-group' }
   let(:current_balance) { BigDecimal('525.00') }
   let(:collectable_arrears) { 486.90 }
+  let(:weekly_rent) { Faker::Commerce.price(range: 10...100) }
 
   let(:name) { Faker::Name.name }
 
@@ -29,7 +30,8 @@ RSpec.describe 'Income Collection Letters', type: :request do
     create_valid_uh_records_for_an_income_letter
     Hackney::Income::Models::CasePriority.create!(
       tenancy_ref: tenancy_ref,
-      collectable_arrears: collectable_arrears
+      collectable_arrears: collectable_arrears,
+      weekly_rent: weekly_rent
     )
   end
 
@@ -65,7 +67,8 @@ RSpec.describe 'Income Collection Letters', type: :request do
             'forename' => 'Frank',
             'surname' => 'Enstein',
             'title' => 'Mr',
-            'total_collectable_arrears_balance' => collectable_arrears.to_s
+            'total_collectable_arrears_balance' => collectable_arrears.to_s,
+            'rent' => weekly_rent.to_s
           },
           'template' => {
             'path' => 'lib/hackney/pdf/templates/income/income_collection_letter_1.erb',


### PR DESCRIPTION
## Context
The informal agreement confirmation letter template isn't 100% and it is not integrated with the preview generator.

## Changes proposed in this pull request
- Fix missing and incorrect fields on the template
- Change generate_and_store_letter class to allow generating the preview 

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-370
## Things to check

- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
