### PR TITLE
Validate terms for more outcomes

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -3,39 +3,40 @@ module Hackney
     module Models
       class CourtCase < ApplicationRecord
         validates_presence_of :tenancy_ref
-        validates_inclusion_of :terms, in: [true, false], if: :adjourned?
-        validates_inclusion_of :disrepair_counter_claim, in: [true, false], if: :adjourned?
+        validates_inclusion_of :terms, in: [true, false], if: :can_have_terms?
+        validates_inclusion_of :disrepair_counter_claim, in: [true, false], if: :can_have_terms?
         validate :court_outcome_is_valid
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
 
-        ADJOURNED_COURT_OUTCOMES =
+        COURT_OUTCOMES_THAT_CAN_HAVE_TERMS=
           [
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+
           ].freeze
 
         OTHER_COURT_OUTCOMES =
           [
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
           ].freeze
 
-        def adjourned?
-          ADJOURNED_COURT_OUTCOMES.include?(court_outcome)
+        def can_have_terms?
+          COURT_OUTCOMES_THAT_CAN_HAVE_TERMS.include?(court_outcome)
         end
 
         private
 
         def court_outcome_is_valid
           return unless court_outcome.present?
-          errors.add(:court_outcome, 'must be a valid court outcome code') unless (ADJOURNED_COURT_OUTCOMES + OTHER_COURT_OUTCOMES).include?(court_outcome)
+          errors.add(:court_outcome, 'must be a valid court outcome code') unless (COURT_OUTCOMES_THAT_CAN_HAVE_TERMS + OTHER_COURT_OUTCOMES).include?(court_outcome)
         end
       end
     end

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -8,7 +8,7 @@ module Hackney
         validate :court_outcome_is_valid
         has_many :agreements, -> { where agreement_type: :formal }, class_name: 'Hackney::Income::Models::Agreement'
 
-        COURT_OUTCOMES_THAT_CAN_HAVE_TERMS=
+        COURT_OUTCOMES_THAT_CAN_HAVE_TERMS =
           [
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
@@ -17,7 +17,6 @@ module Hackney
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
             Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
-
           ].freeze
 
         OTHER_COURT_OUTCOMES =
@@ -36,7 +35,9 @@ module Hackney
 
         def court_outcome_is_valid
           return unless court_outcome.present?
-          errors.add(:court_outcome, 'must be a valid court outcome code') unless (COURT_OUTCOMES_THAT_CAN_HAVE_TERMS + OTHER_COURT_OUTCOMES).include?(court_outcome)
+
+          valid_court_outcomes = COURT_OUTCOMES_THAT_CAN_HAVE_TERMS + OTHER_COURT_OUTCOMES
+          errors.add(:court_outcome, 'must be a valid court outcome code') unless valid_court_outcomes.include?(court_outcome)
         end
       end
     end

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -20,7 +20,7 @@ module Hackney
           Rails.logger.debug { "Found no existing court cases for tenancy ref #{criteria.tenancy_ref}" }
 
           court_case_params = map_criteria_to_court_case_params(criteria).merge(tenancy_ref: criteria.tenancy_ref)
-          
+
           # We are not syncing terms and disrepair_counter_claim but we validating presence of these if an outcome can have terms
           # will set these to false by default when syncing old data
           court_case_params = court_case_params.merge(terms: false, disrepair_counter_claim: false) if can_have_terms?(court_case_params)

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -20,10 +20,10 @@ module Hackney
           Rails.logger.debug { "Found no existing court cases for tenancy ref #{criteria.tenancy_ref}" }
 
           court_case_params = map_criteria_to_court_case_params(criteria).merge(tenancy_ref: criteria.tenancy_ref)
-
-          # We are not syncing terms and disrepair_counter_claim but we validating presence of these if its an adjourned outcome
+          
+          # We are not syncing terms and disrepair_counter_claim but we validating presence of these if an outcome can have terms
           # will set these to false by default when syncing old data
-          court_case_params = court_case_params.merge(terms: false, disrepair_counter_claim: false) if adjourned?(court_case_params)
+          court_case_params = court_case_params.merge(terms: false, disrepair_counter_claim: false) if can_have_terms?(court_case_params)
 
           @create_court_case.execute(court_case_params: court_case_params)
 
@@ -101,8 +101,8 @@ module Hackney
         end
       end
 
-      def adjourned?(court_case_params)
-        Hackney::Income::Models::CourtCase.new(court_case_params).adjourned?
+      def can_have_terms?(court_case_params)
+        Hackney::Income::Models::CourtCase.new(court_case_params).can_have_terms?
       end
     end
   end

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
         Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
       ].sample
     end
-    terms { [true, false].sample if adjourned? }
-    disrepair_counter_claim { [true, false].sample if adjourned? }
+    terms { [true, false].sample if can_have_terms? }
+    disrepair_counter_claim { [true, false].sample if can_have_terms? }
   end
 end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -5,9 +5,11 @@ describe Hackney::Income::CreateCourtCase do
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-  let(:court_outcome) { 'SOT' }
+  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
+  let(:terms) { [true, false].sample }
+  let(:disrepair_counter_claim) { [true, false].sample }
 
   let(:new_court_case_params) do
     {
@@ -15,7 +17,9 @@ describe Hackney::Income::CreateCourtCase do
       court_date: court_date,
       court_outcome: court_outcome,
       balance_on_court_outcome_date: balance_on_court_outcome_date,
-      strike_out_date: strike_out_date
+      strike_out_date: strike_out_date,
+      terms: terms,
+      disrepair_counter_claim: disrepair_counter_claim
     }
   end
 
@@ -30,5 +34,7 @@ describe Hackney::Income::CreateCourtCase do
     expect(court_case.court_outcome).to eq(court_outcome)
     expect(court_case.balance_on_court_outcome_date).to eq(balance_on_court_outcome_date)
     expect(court_case.strike_out_date).to eq(strike_out_date)
+    expect(court_case.terms).to eq(terms)
+    expect(court_case.disrepair_counter_claim).to eq(disrepair_counter_claim)
   end
 end

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -23,7 +23,9 @@ describe Hackney::Income::CreateFormalAgreement do
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...1000),
       court_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
       court_outcome: 'SOT',
-      strike_out_date: Faker::Date.forward(days: 365)
+      strike_out_date: Faker::Date.forward(days: 365),
+      terms: true,
+      disrepair_counter_claim: false
     )
   end
   let(:expected_action_diray_note) { "Formal agreement created: #{notes}" }

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -82,7 +82,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided a criteria with a court date and a court outcome' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
           courtdate: DateTime.now.midnight - 7.days
         }
       }
@@ -92,7 +92,9 @@ describe Hackney::Income::MigrateUhCourtCase do
           court_case_params: {
             tenancy_ref: criteria.tenancy_ref,
             court_date: criteria_attributes[:courtdate],
-            court_outcome: criteria_attributes[:court_outcome]
+            court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+            terms: false,
+            disrepair_counter_claim: false
           }
         )
         subject

--- a/spec/lib/hackney/income/update_court_case_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_spec.rb
@@ -29,8 +29,8 @@ describe Hackney::Income::UpdateCourtCase do
     create(:court_case, id: id, tenancy_ref: tenancy_ref, court_date: court_date)
   end
 
-  context 'when adding an (not adjourned) court outcome to an existing court case' do
-    let(:court_outcome) { 'SOT' }
+  context 'when adding a court outcome that can not have terms to an existing court case' do
+    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT }
 
     it 'updates and returns the court case' do
       court_case = subject.execute(court_case_params: court_case_params)
@@ -44,8 +44,8 @@ describe Hackney::Income::UpdateCourtCase do
     end
   end
 
-  context 'when adding an adjourned court outcome to an existing court case' do
-    let(:court_outcome) { 'AAH' }
+  context 'when adding a court outcome that can have terms to an existing court case' do
+    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE }
     let(:strike_out_date) { Faker::Date.forward(days: 30) }
     let(:terms) { false }
     let(:disrepair_counter_claim) { false }
@@ -81,12 +81,14 @@ describe Hackney::Income::UpdateCourtCase do
   end
 
   context 'when adding a court outcome without a court date to an existing court case' do
+    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS }
+
     it 'updates and returns the court case' do
-      court_case = subject.execute(court_case_params: { id: id, court_date: nil, court_outcome: 'SOT' })
+      court_case = subject.execute(court_case_params: { id: id, court_date: nil, court_outcome: court_outcome })
 
       expect(court_case.id).to eq(id)
       expect(court_case.court_date).not_to be_nil
-      expect(court_case.court_outcome).to eq('SOT')
+      expect(court_case.court_outcome).to eq(court_outcome)
     end
   end
 end

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -6,7 +6,7 @@ describe Hackney::Income::Models::CourtCase, type: :model do
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
     ].sample
   end
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe Hackney::Income::Models::CourtCase, type: :model do
-  let(:valid_non_adjourned_outcome) do
+  let(:valid_outcomes_without_terms) do
     [
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
     ].sample
   end
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
@@ -31,7 +31,7 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     court_case = described_class.create!(
       tenancy_ref: tenancy_ref,
       court_date: Faker::Date.between(from: 10.days.ago, to: 3.days.ago),
-      court_outcome: valid_non_adjourned_outcome,
+      court_outcome: valid_outcomes_without_terms,
       balance_on_court_outcome_date: Faker::Commerce.price(range: 10...100),
       strike_out_date: Faker::Date.forward(days: 365)
     )
@@ -62,15 +62,15 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     it 'is still a valid court case' do
       court_case = described_class.create!(
         tenancy_ref: tenancy_ref,
-        court_outcome: valid_non_adjourned_outcome
+        court_outcome: valid_outcomes_without_terms
       )
 
       expect(court_case).to be_a Hackney::Income::Models::CourtCase
     end
   end
 
-  context 'when the court outcome is adjourned' do
-    before { allow(subject).to receive(:adjourned?).and_return(true) }
+  context 'when the court outcome can have terms' do
+    before { allow(subject).to receive(:can_have_terms?).and_return(true) }
 
     it { is_expected.to allow_value(%w[true false]).for(:terms) }
     it { is_expected.to allow_value(%w[true false]).for(:disrepair_counter_claim) }

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe 'CourtCases', type: :request do
   let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
   let(:court_outcome) do
     [
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
       Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
     ].sample
   end
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
@@ -106,7 +106,7 @@ RSpec.describe 'CourtCases', type: :request do
         patch "/api/v1/court_case/#{id}/update", params: request_body
       end
 
-      context 'when adding a (not adjourned) court outcome' do
+      context 'when adding a court outcome that can not have terms' do
         let(:update_court_case_params) do
           {
             id: id,
@@ -138,7 +138,7 @@ RSpec.describe 'CourtCases', type: :request do
         end
       end
 
-      context 'when adding an adjourned court outcome' do
+      context 'when adding a court outcome that can have terms' do
         let(:court_outcome) { 'AAH' }
         let(:update_court_case_params) do
           {


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We now know that we need to ask the user about whether there's `terms` and a `disrepair counter claim` for additional court outcomes, not just adjourned ones.

This is the backend change to allow this to happen.
## Changes proposed in this pull request
<!-- List all the changes -->
- Updated the court case model to validate for `terms` and `disrepair_counter_claim` for all relevant court outcomes
- Updated migration from UH and other tests accordingly

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Maybe a double check that I got the correct court outcomes
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-461?atlOrigin=eyJpIjoiYTgzMmNjYTEzYmZiNDFjM2FhZjc0OTE4ODZlMGEyMjEiLCJwIjoiaiJ9

