### PR TITLE
Fix for when there's not court date (from UH)

### DIFF
--- a/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/v2/helpers/ma_agreement_helpers.rb
@@ -24,6 +24,7 @@ module Hackney
             def court_breach_agreement_ma?
               return false unless breached_agreement?
               return false unless most_recent_agreement.formal?
+              return false if most_recent_court_case.court_date.blank?
 
               most_recent_agreement.start_date > most_recent_court_case.court_date
             end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We run into an error after migrating agreements and court cases from UH.

[Court date is nil when checking for breaches](https://sentry.io/organizations/london-borough-of-hackney/issues/1863378649/?project=1276456&referrer=slack) 
## Changes proposed in this pull request
<!-- List all the changes -->
Check if court date is present before comparing to see if it has passed


