### PR TITLE
Allow generating informal agreement breach letter preview

### DIFF
--- a/app/models/hackney/income_collection/letter/informal_agreement_breach.rb
+++ b/app/models/hackney/income_collection/letter/informal_agreement_breach.rb
@@ -7,7 +7,7 @@ module Hackney
         TEMPLATE_PATHS = [
           'lib/hackney/pdf/templates/income/informal_agreement_breach_letter.erb'
         ].freeze
-        MANDATORY_FIELDS = %i[created_date expected_balance checked_balance shortfall_amount].freeze
+        MANDATORY_FIELDS = %i[created_date expected_balance checked_balance].freeze
 
         attr_reader :created_date, :expected_balance, :checked_balance, :shortfall_amount
 

--- a/lib/hackney/pdf/income_preview.rb
+++ b/lib/hackney/pdf/income_preview.rb
@@ -63,7 +63,6 @@ module Hackney
 
       def get_breached_agreement_info(agreement)
         state = agreement.agreement_states.last
-
         {
           created_date: agreement.created_at,
           expected_balance: state.expected_balance,

--- a/lib/hackney/pdf/templates/income/informal_agreement_breach_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_breach_letter.erb
@@ -10,7 +10,7 @@
   </p>
 
   <p>
-    According to my records you haven’t paid your repayment agreement, which you made on <%= @letter.created_date %> .  This means that your current rent arrears have increased to <%= @letter.total_collectable_arrears_balance %> .
+    According to my records you haven’t paid your repayment agreement, which you made on <%= @letter.created_date %>.  This means that your current rent arrears have increased to £<%= @letter.total_collectable_arrears_balance %> .
   </p>
 
   <p>
@@ -18,7 +18,7 @@
   </p>
 
   <p>
-    <strong>You need to pay <%= @letter.shortfall_amount %> immediately to bring your agreement back to the agreed amount, and to prevent any further action being taken against you.</strong>
+    <strong>You need to pay £<%= @letter.shortfall_amount %> immediately to bring your agreement back to the agreed amount, and to prevent any further action being taken against you.</strong>
   </p>
 
   <p>

--- a/lib/use_cases/generate_and_store_letter.rb
+++ b/lib/use_cases/generate_and_store_letter.rb
@@ -7,7 +7,7 @@ module UseCases
       letter_use_case_factory = Hackney::Letter::UseCaseFactory.new
 
       income_collection_templates = %w[income_collection_letter_1 income_collection_letter_2]
-      agreement_templates = %w[informal_agreement_confirmation_letter]
+      agreement_templates = %w[informal_agreement_confirmation_letter informal_agreement_breach_letter]
 
       if template_id.in?(income_collection_templates)
         letter_data = pdf_use_case_factory.get_income_preview.execute(

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -108,8 +108,7 @@ describe Hackney::IncomeCollection::Letter do
         expect(letter.errors).to eq [
           { message: 'missing mandatory field', name: 'created_date' },
           { message: 'missing mandatory field', name: 'expected_balance' },
-          { message: 'missing mandatory field', name: 'checked_balance' },
-          { message: 'missing mandatory field', name: 'shortfall_amount' }
+          { message: 'missing mandatory field', name: 'checked_balance' }
         ]
       end
     end

--- a/spec/use_cases/generate_and_store_letter_spec.rb
+++ b/spec/use_cases/generate_and_store_letter_spec.rb
@@ -115,5 +115,29 @@ describe UseCases::GenerateAndStoreLetter do
         use_case_output
       end
     end
+
+    context 'when the template is an informal agreement breach letter template' do
+      let(:tenancy_ref) { Faker::Number.number(digits: 4).to_s }
+      let(:user_group) { ['income-collection-group'] }
+      let(:template_id) { 'informal_agreement_breach_letter' }
+
+      it 'gets all the data and generates the letter' do
+        expect_any_instance_of(Hackney::Income::UniversalHousingIncomeGateway)
+          .to receive(:get_income_info).with(tenancy_ref: tenancy_ref)
+                                       .and_return(letter_fields)
+        expect_any_instance_of(Hackney::Income::SqlTenancyCaseGateway)
+          .to receive(:find).with(tenancy_ref: tenancy_ref)
+                            .and_return(
+                              build(:case_priority,
+                                    tenancy_ref: tenancy_ref,
+                                    collectable_arrears: Faker::Number.number(digits: 3))
+                            )
+        expect(Hackney::Income::Models::Agreement)
+          .to receive(:where).with(tenancy_ref: tenancy_ref)
+                             .and_return([create(:agreement_state, :breached).agreement])
+
+        use_case_output
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context
Informal agreement breach letter has not been added to `GenerateAndStoreLetter` templates so we cannot generate a letter preview for this template 

## Changes proposed in this pull request
- Minor tweaks to the template 
- Allow generating the preview

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&modal=detail&selectedIssue=MAAP-371
## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
