### PR TITLE
Update current_arrears_agreement_status field on ViewCases response

### DIFF
--- a/lib/hackney/income/view_cases.rb
+++ b/lib/hackney/income/view_cases.rb
@@ -28,7 +28,9 @@ module Hackney
           tenancy = full_tenancies.find { |t| t.fetch(:ref) == case_priority.fetch(:tenancy_ref) }
           next if tenancy.nil?
 
-          build_tenancy_list_item(tenancy, case_priority)
+          agreement = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy.fetch(:ref)).last
+
+          build_tenancy_list_item(tenancy, case_priority, agreement)
         end.compact
 
         Response.new(cases, number_of_pages)
@@ -36,11 +38,11 @@ module Hackney
 
       private
 
-      def build_tenancy_list_item(tenancy, case_priority)
+      def build_tenancy_list_item(tenancy, case_priority, agreement)
         {
           ref: tenancy.fetch(:ref),
           current_balance: tenancy.fetch(:current_balance),
-          current_arrears_agreement_status: tenancy.fetch(:current_arrears_agreement_status),
+          current_arrears_agreement_status: agreement&.current_state,
           latest_action: {
             code: tenancy.dig(:latest_action, :code),
             date: tenancy.dig(:latest_action, :date)

--- a/lib/hackney/tenancy/gateway/tenancies_gateway.rb
+++ b/lib/hackney/tenancy/gateway/tenancies_gateway.rb
@@ -29,7 +29,6 @@ module Hackney
             {
               ref: tenancy.fetch('ref'),
               current_balance: tenancy.fetch('current_balance'),
-              current_arrears_agreement_status: tenancy.fetch('current_arrears_agreement_status'),
               latest_action: build_latest_action(tenancy),
               primary_contact: build_primary_contact(tenancy)
             }

--- a/spec/lib/hackney/income/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_criteria_spec.rb
@@ -156,7 +156,7 @@ describe Hackney::Income::UniversalHousingCriteria, universal: true do
       let(:nosp_notice_served_date) { 2.days.ago }
 
       it 'returns the nosp expiry date' do
-        expect(subject).to eq((Hackney::Domain::Nosp::ACTIVE_TIME - 2.days).from_now.to_date)
+        expect(subject).to eq((2.days.ago + Hackney::Domain::Nosp::ACTIVE_TIME).to_date)
       end
 
       context 'when UH returns no nosp expiry date (1900-01-01 00:00:00 +0000)' do

--- a/spec/lib/hackney/tenancy/gateway/tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/tenancy/gateway/tenancies_gateway_spec.rb
@@ -47,7 +47,6 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
         expect(subject).to eq([{
           ref: '000015/01',
           current_balance: '£1000.00',
-          current_arrears_agreement_status: '200',
           latest_action: {
             code: 'FBI',
             date: Time.parse('2018-10-01 12:30:00Z')
@@ -73,7 +72,6 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
         expect(subject).to eq([{
           ref: '000017/01',
           current_balance: '£19.99',
-          current_arrears_agreement_status: nil,
           latest_action: nil,
           primary_contact: nil
         }])
@@ -103,7 +101,6 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
     {
       'ref' => '000015/01',
       'current_balance' => '£1000.00',
-      'current_arrears_agreement_status' => '200',
       'latest_action' => {
         'code' => 'FBI',
         'date' => '2018-10-01 12:30:00Z'
@@ -120,7 +117,6 @@ describe Hackney::Tenancy::Gateway::TenanciesGateway do
     {
       'ref' => '000017/01',
       'current_balance' => '£19.99',
-      'current_arrears_agreement_status' => nil,
       'latest_action' => {
         'code' => nil,
         'date' => '0001-01-01 00 => 00 => 00Z'


### PR DESCRIPTION
## Context
There is agreement data we pull from UH and rendered on `ViewCases` response. Going forward we should show agreement data that is pulled from MA. 

## Changes proposed in this pull request
- Use MA agreements when rendering `current_arrears_agreement_status` for a work tray item
- Remove `current_arrears_agreement_status` when pulling tenancies from UH(we don't need this anymore)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-421

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
