### PR TITLE
Fix court case fields on CasePriority

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,6 +2,9 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
+        after_create :update_case_priority
+        after_update :update_case_priority
+
         validates_presence_of :tenancy_ref
         validates_inclusion_of :terms, in: [true, false], if: :can_have_terms?
         validates_inclusion_of :disrepair_counter_claim, in: [true, false], if: :can_have_terms?
@@ -38,6 +41,10 @@ module Hackney
 
           valid_court_outcomes = COURT_OUTCOMES_THAT_CAN_HAVE_TERMS + OTHER_COURT_OUTCOMES
           errors.add(:court_outcome, 'must be a valid court outcome code') unless valid_court_outcomes.include?(court_outcome)
+        end
+
+        def update_case_priority
+          Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)&.update!(court_outcome: court_outcome, courtdate: court_date)
         end
       end
     end

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -2,8 +2,8 @@ module Hackney
   module Income
     module Models
       class CourtCase < ApplicationRecord
-        after_create :update_case_priority
-        after_update :update_case_priority
+        after_create :update_associated_worktray_item
+        after_update :update_associated_worktray_item
 
         validates_presence_of :tenancy_ref
         validates_inclusion_of :terms, in: [true, false], if: :can_have_terms?
@@ -43,7 +43,7 @@ module Hackney
           errors.add(:court_outcome, 'must be a valid court outcome code') unless valid_court_outcomes.include?(court_outcome)
         end
 
-        def update_case_priority
+        def update_associated_worktray_item
           Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)&.update!(court_outcome: court_outcome, courtdate: court_date)
         end
       end

--- a/lib/hackney/income/worktray_item_gateway.rb
+++ b/lib/hackney/income/worktray_item_gateway.rb
@@ -2,9 +2,11 @@ module Hackney
   module Income
     class WorktrayItemGateway
       GatewayModel = Hackney::Income::Models::CasePriority
+      CourtCaseModel = Hackney::Income::Models::CourtCase
 
       def store_worktray_item(tenancy_ref:, criteria:, classification:)
         gateway_model_instance = GatewayModel.find_or_initialize_by(tenancy_ref: tenancy_ref)
+        court_case = CourtCaseModel.where(tenancy_ref: tenancy_ref).last
 
         begin
           gateway_model_instance.tap do |tenancy|
@@ -20,8 +22,8 @@ module Hackney
               active_nosp: criteria.active_nosp?,
               classification: classification,
               patch_code: criteria.patch_code,
-              courtdate: criteria.courtdate,
-              court_outcome: criteria.court_outcome,
+              courtdate: court_case&.court_date,
+              court_outcome: court_case&.court_outcome,
               eviction_date: criteria.eviction_date,
               universal_credit: criteria.universal_credit,
               uc_rent_verification: criteria. uc_rent_verification,

--- a/spec/lib/hackney/income/view_cases_spec.rb
+++ b/spec/lib/hackney/income/view_cases_spec.rb
@@ -116,11 +116,7 @@ describe Hackney::Income::ViewCases do
 
           expect(subject.cases).to include(a_hash_including(
                                              ref: tenancy_attributes.fetch(:ref),
-                                             current_arrears_agreement_status: nil,
-
-                                             # TODO: the following fields needs update, no longer should be pulled from UH agreements
-                                             courtdate: tenancy_priority_factors.fetch(:courtdate),
-                                             court_outcome: tenancy_priority_factors.fetch(:court_outcome)
+                                             current_arrears_agreement_status: nil
                                            ))
         end
       end
@@ -136,10 +132,7 @@ describe Hackney::Income::ViewCases do
 
           expect(subject.cases).to include(a_hash_including(
                                              ref: tenancy_attributes.fetch(:ref),
-                                             current_arrears_agreement_status: agreements.last.current_state,
-                                             # TODO: the following fields needs update, no longer should be pulled from UH agreements
-                                             courtdate: tenancy_priority_factors.fetch(:courtdate),
-                                             court_outcome: tenancy_priority_factors.fetch(:court_outcome)
+                                             current_arrears_agreement_status: agreements.last.current_state
                                            ))
         end
       end

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -47,6 +47,39 @@ describe Hackney::Income::Models::CourtCase, type: :model do
     expect(Hackney::Income::Models::Agreement.first.court_case).to eq(court_case)
   end
 
+  context 'when there is a case priority' do
+    let(:case_priority) { create(:case_priority, tenancy_ref: tenancy_ref, courtdate: nil, court_outcome: nil) }
+
+    it 'updates the court case details on the existing case priority' do
+      expected_court_date = Faker::Date.between(from: 10.days.ago, to: 3.days.ago)
+      expected_court_outcome = valid_outcomes_without_terms
+
+      expect(case_priority.courtdate).to be_nil
+      expect(case_priority.court_outcome).to be_nil
+
+      court_case = described_class.create!(
+        tenancy_ref: tenancy_ref,
+        court_date: expected_court_date,
+        court_outcome: expected_court_outcome
+      )
+
+      case_priority.reload
+
+      expect(case_priority.courtdate).to eq(expected_court_date)
+      expect(case_priority.court_outcome).to eq(expected_court_outcome)
+
+      updated_court_date = Faker::Date.between(from: 10.days.ago, to: 3.days.ago)
+      updated_court_outcome = valid_outcomes_without_terms
+
+      court_case.update!(court_outcome: updated_court_outcome, court_date: updated_court_date)
+
+      case_priority.reload
+
+      expect(case_priority.courtdate).to eq(updated_court_date)
+      expect(case_priority.court_outcome).to eq(updated_court_outcome)
+    end
+  end
+
   context 'when there is only a court date (e.g. adding a court date before the case takes place)' do
     it 'is still a valid court case' do
       court_case = described_class.create!(


### PR DESCRIPTION
## Context
There are `court_case` and `court_date` fields on `CasePriority` model, which is currently synced from UH. To show accurate data to the users, we want to show the `CourtCase` data that lives and managed in MA. 

## Changes proposed in this pull request
- Change `CourtCase` to update related `CasePriority` whenever a court case created or changed
- Use court case data from MA when syncing case priorities 

## Guidance to review
I went down a miserable route and tried to remove `courtdate` and `court_outcome` fields from `CasePriority` model, but these are used when filtering tenancies, so we'd need to make changes in `WorktrayItemGateway` to be able to filter tenancies by `Upcoming Court Dates`.

By updating `CasePriority` whenever a court case created allows us to preserve the existing behaviour with the minimum change, also better for optimisation when filtering by `court_date` 

## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
