### PR TITLE
when uh frequency is not in MA, write a comment about what it was

### DIFF
--- a/spec/lib/hackney/income/migrate_uh_agreement_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_agreement_spec.rb
@@ -88,11 +88,12 @@ describe Hackney::Income::MigrateUhAgreement, universal: true do
     let(:start_date) { '2012-12-24' }
     let(:comment) { 'Something' }
     let(:frequency) { 4 }
+    let(:status) { '400       ' }
 
     let(:uh_agreements) {
       [{
         start_date: start_date,
-        status: '400       ',
+        status: status,
         breached: true,
         last_check_balance: last_check_balance,
         last_check_date: '2013-11-30',
@@ -152,7 +153,7 @@ describe Hackney::Income::MigrateUhAgreement, universal: true do
             starting_balance: starting_balance,
             amount: amount,
             start_date: start_date,
-            frequency: nil,
+            frequency: 4,
             created_by: 'Managed Arrears migration from UH',
             notes: "Frequency no longer supported, original frequency was '6 Monthly'. #{comment}",
             court_case_id: nil
@@ -172,6 +173,17 @@ describe Hackney::Income::MigrateUhAgreement, universal: true do
         )
 
         subject.migrate(tenancy_ref: tenancy_ref)
+      end
+    end
+
+    context 'when migrating a live agreement with not supported frequency' do
+      let(:status) { '200       ' }
+      let(:frequency) { 8 }
+
+      it 'raises an error' do
+        expect {
+          subject.migrate(tenancy_ref: tenancy_ref)
+        }.to raise_error StandardError, "Can not migrate live agreement with unsupported frequency, #{tenancy_ref}"
       end
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
UH is weird and wonderful and agreements have all sorts of frequencies, and we only support half of them. 

The following PR depends on https://github.com/LBHackney-IT/lbh-income-api/pull/515 being merged in


## Changes proposed in this pull request
<!-- List all the changes -->
- when an agreement with an unsupported frequency is migrated, we set the frequency to [`unsupported_legacy_frequency `](https://github.com/LBHackney-IT/lbh-income-api/pull/515) and write a comment about what the frequency used to be 
- when a live agreement with an unsupported frequency, we raise a error what will be captured by sentry so that officers can amend the case accordingly in UH before we sync 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&modal=detail&selectedIssue=MAAP-469
## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
