### PR TITLE
Allow creating variable payment agreement 

### DIFF
--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -6,6 +6,7 @@ module Hackney
 
         validates_presence_of :agreement_type
         validates_presence_of :court_case_id, if: :formal?
+        validates_presence_of :initial_payment_date, if: :variable_payment?
         belongs_to :court_case, optional: true, class_name: 'Hackney::Income::Models::CourtCase'
         has_many :agreement_states, class_name: 'Hackney::Income::Models::AgreementState'
         enum agreement_type: { informal: 'informal', formal: 'formal' }
@@ -41,6 +42,10 @@ module Hackney
 
         def completed?
           current_state == 'completed'
+        end
+
+        def variable_payment?
+          initial_payment_amount.present?
         end
       end
     end

--- a/db/migrate/20200903143523_add_variable_payment_agreement_fields.rb
+++ b/db/migrate/20200903143523_add_variable_payment_agreement_fields.rb
@@ -1,0 +1,6 @@
+class AddVariablePaymentAgreementFields < ActiveRecord::Migration[5.2]
+  def up
+    add_column :agreements, :initial_payment_amount, :decimal, precision: 10, scale: 2
+    add_column :agreements, :initial_payment_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_02_145954) do
+ActiveRecord::Schema.define(version: 2020_09_03_143523) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -61,6 +61,8 @@ ActiveRecord::Schema.define(version: 2020_09_02_145954) do
     t.string "created_by", null: false
     t.text "notes"
     t.bigint "court_case_id"
+    t.decimal "initial_payment_amount", precision: 10, scale: 2
+    t.datetime "initial_payment_date"
     t.index ["court_case_id"], name: "index_agreements_on_court_case_id"
   end
 

--- a/spec/factories/agreement.rb
+++ b/spec/factories/agreement.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     frequency { [:weekly, :monthly, :fortnightly, '4 weekly'].sample }
     start_date { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     amount { Faker::Commerce.price(range: 10...100) }
+    initial_payment_date { nil }
+    initial_payment_amount { nil }
 
     factory :live_agreement do
       current_state { 'live' }
@@ -23,6 +25,11 @@ FactoryBot.define do
 
     factory :completed_agreement do
       current_state { 'completed' }
+    end
+
+    trait :variable_payment do
+      initial_payment_date { start_date - 1.day }
+      initial_payment_amount { Faker::Commerce.price(range: 100...200) }
     end
   end
 

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -102,6 +102,34 @@ describe Hackney::Income::Models::Agreement, type: :model do
     end
   end
 
+  describe 'variable_payment?' do
+    let(:initial_payment_amount) { Faker::Commerce.price(range: 100...1000) }
+    let(:initial_payment_date) { Faker::Date.between(from: 100.days.ago, to: Date.today) }
+
+    it 'returns true when an agreement has initial payment amount and date' do
+      agreement = described_class.new(initial_payment_amount: nil, initial_payment_date: nil)
+      expect(agreement).not_to be_variable_payment
+
+      agreement = described_class.new(
+        initial_payment_amount: initial_payment_amount,
+        initial_payment_date: initial_payment_date
+      )
+      expect(agreement).to be_variable_payment
+    end
+
+    it 'validates the presence of initial_payment_date' do
+      expect {
+        described_class.create!(
+          tenancy_ref: '123',
+          created_by: user_name,
+          agreement_type: :informal,
+          initial_payment_amount: initial_payment_amount,
+          initial_payment_date: nil
+        )
+      }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Initial payment date can't be blank"
+    end
+  end
+
   context 'when formal agreement' do
     let(:agreement) do
       described_class.create(

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -26,7 +26,9 @@ describe Hackney::Income::Models::Agreement, type: :model do
       'tenancy_ref',
       'notes',
       'court_case_id',
-      'id'
+      'id',
+      'initial_payment_date',
+      'initial_payment_amount'
     )
   end
 


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to enter an initial payment amount and date, so I can enter court agreements that have a larger first payment that followed by frequent smaller payments.
This is the first slice of allowing caseworkers to create `variable payment agreement `

## Changes proposed in this pull request
- Add `initial_payment_amount: initial_payment_amount` and `initial_payment_date` fields to agreement table
- Add validation to agreement model and `variable_payment?` helper method
- Update factories  

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464
## Things to check
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
