### PR TITLE
add new frequency to allow for smoother agreement migration from UH

### DIFF
--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -4,12 +4,12 @@ module Hackney
       class Agreement < ApplicationRecord
         ACTIVE_STATES = %w[live breached].freeze
 
-        validates_presence_of :agreement_type
+        validates_presence_of :agreement_type, :frequency
         validates_presence_of :court_case_id, if: :formal?
         belongs_to :court_case, optional: true, class_name: 'Hackney::Income::Models::CourtCase'
         has_many :agreement_states, class_name: 'Hackney::Income::Models::AgreementState'
         enum agreement_type: { informal: 'informal', formal: 'formal' }
-        enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3 }
+        enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3, unsupported_legacy_frequency: 4 }
 
         def active?
           ACTIVE_STATES.include?(current_state)

--- a/lib/hackney/income/update_agreement_state.rb
+++ b/lib/hackney/income/update_agreement_state.rb
@@ -7,6 +7,7 @@ module Hackney
 
       def execute(agreement:, current_balance:)
         return false unless agreement.active?
+        return false if agreement.frequency == 'unsupported_legacy_frequency'
         return false if date_of_first_check(agreement).future?
 
         update_status(agreement, current_balance)

--- a/spec/lib/hackney/income/update_agreement_state_spec.rb
+++ b/spec/lib/hackney/income/update_agreement_state_spec.rb
@@ -85,6 +85,19 @@ describe Hackney::Income::UpdateAgreementState do
     end
   end
 
+  context 'when the frequency of payment is :unsupported_legacy_frequency' do
+    it 'does not change the agreement state' do
+      agreement = stub_informal_agreement(
+        start_date: start_date,
+        frequency: :unsupported_legacy_frequency,
+        amount: 20,
+        starting_balance: 100
+      )
+
+      expect(subject.execute(agreement: agreement, current_balance: 23)).to be_falsy
+    end
+  end
+
   context 'when the frequency of payment is :monthly' do
     it 'updates the state of the agreement when its breached' do
       agreement = stub_informal_agreement(

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -6,7 +6,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
     described_class.create(
       tenancy_ref: '123',
       created_by: user_name,
-      agreement_type: :informal
+      agreement_type: :informal,
+      frequency: :monthly
     )
   end
 
@@ -38,7 +39,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   describe 'agreement_type' do
-    it 'only accepts formal/informal as an agrement type' do
+    it 'only accepts formal/informal as an agreement type' do
       %w[formal informal].each do |agreement_type|
         expect { described_class.new(agreement_type: agreement_type) }.not_to raise_error
       end
@@ -63,6 +64,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
       expect { described_class.new(frequency: 'invalid_frequency') }
         .to raise_error ArgumentError, "'invalid_frequency' is not a valid frequency"
     end
+
+    it { is_expected.to validate_presence_of(:frequency) }
   end
 
   describe 'current_state' do
@@ -114,7 +117,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
         described_class.create!(
           tenancy_ref: '123',
           created_by: user_name,
-          agreement_type: :formal
+          agreement_type: :formal,
+          frequency: :weekly
         )
       }.to raise_error ActiveRecord::RecordInvalid, "Validation failed: Court case can't be blank"
     end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
add new frequency to allow for smoother agreement migration from UH

## Changes proposed in this pull request
<!-- List all the changes -->
- added `unsupported_legacy_frequency` frequency
- make frequency required
- make the breach detector ignore agreements with `unsupported_legacy_frequency`


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
