### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Context
 <!-- Why are you making this change? What might surprise someone about it? -->
 
-## Changes proposed in this pull request
+## Changes in this pull request
 <!-- List all the changes -->
 
 ## Guidance to review
@@ -11,6 +11,6 @@
 <!-- https://hackney.atlassian.net/123-example-card -->
 
 ## Things to check
-
+- [ ] This code doesn't rely on migrations in the same Pull Request
 - [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
 - [ ] Environment variables have been updated

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -125,6 +125,7 @@ describe Hackney::Income::Models::Agreement, type: :model do
         described_class.create!(
           tenancy_ref: '123',
           created_by: user_name,
+          frequency: :weekly,
           agreement_type: :informal,
           initial_payment_amount: initial_payment_amount,
           initial_payment_date: nil


### PR DESCRIPTION
## Context
Last Friday we had a minor outage when deployed a DB migration that dropped a field from DB. It's generally a good practice not to deploy a DB migration and code that relies on this migration in the same PR. 

## Changes proposed in this pull request
- Update PR template with guidance for DB migration
