### PR TITLE
Allow agreement endpoints to create and retrieve variable payment agreement

### DIFF
--- a/app/controllers/agreement_response_helper.rb
+++ b/app/controllers/agreement_response_helper.rb
@@ -13,6 +13,8 @@ module AgreementResponseHelper
       createdBy: agreement.created_by,
       notes: agreement.notes,
       lastChecked: agreement.last_checked || '',
+      initialPaymentAmount: agreement.initial_payment_amount,
+      initialPaymentDate: agreement.initial_payment_date&.strftime('%F'),
       history: map_agreement_state_history(agreement.agreement_states)
     }
   end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -23,7 +23,9 @@ class AgreementsController < ApplicationController
       frequency: params.fetch(:frequency).to_sym,
       created_by: params.fetch(:created_by),
       notes: params.fetch(:notes),
-      court_case_id: params.dig(:court_case_id)
+      court_case_id: params.dig(:court_case_id),
+      initial_payment_amount: params.dig(:initial_payment_amount),
+      initial_payment_date: params.dig(:initial_payment_date)
     }
 
     if formal_agreement?(agreement_params)

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -194,6 +194,12 @@ definitions:
       startingBalance:
         type: number
         example: '1000'
+      initialPaymentAmount: 
+        type: number
+        example: '100'
+      initialPaymentDate:
+        type: string
+        format: date
       amount:
         type: number
         example: '50'

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -37,6 +37,19 @@ module Hackney
           @cancel_agreement.execute(agreement_id: agreement.id)
         end
       end
+
+      def assign_agreement_params(params)
+        {
+          tenancy_ref: params[:tenancy_ref],
+          amount: params[:amount],
+          start_date: params[:start_date],
+          frequency: params[:frequency],
+          created_by: params[:created_by],
+          notes: params[:notes],
+          initial_payment_amount: params[:initial_payment_amount],
+          initial_payment_date: params[:initial_payment_date]
+        }
+      end
     end
   end
 end

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -21,7 +21,9 @@ module Hackney
           frequency: new_agreement_params[:frequency],
           created_by: new_agreement_params[:created_by],
           notes: new_agreement_params[:notes],
-          court_case_id: court_case.id
+          court_case_id: court_case.id,
+          initial_payment_amount: new_agreement_params[:initial_payment_amount],
+          initial_payment_date: new_agreement_params[:initial_payment_date]
         }
 
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -12,19 +12,12 @@ module Hackney
         case_details = find_case_details(tenancy_ref)
         return if case_details.nil?
 
-        formal_agreement_params = {
-          tenancy_ref: tenancy_ref,
-          agreement_type: :formal,
-          starting_balance: case_details[:balance],
-          amount: new_agreement_params[:amount],
-          start_date: new_agreement_params[:start_date],
-          frequency: new_agreement_params[:frequency],
-          created_by: new_agreement_params[:created_by],
-          notes: new_agreement_params[:notes],
-          court_case_id: court_case.id,
-          initial_payment_amount: new_agreement_params[:initial_payment_amount],
-          initial_payment_date: new_agreement_params[:initial_payment_date]
-        }
+        formal_agreement_params = assign_agreement_params(new_agreement_params)
+                                  .merge(
+                                    agreement_type: :formal,
+                                    starting_balance: case_details[:balance],
+                                    court_case_id: court_case.id
+                                  )
 
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
 

--- a/lib/hackney/income/create_informal_agreement.rb
+++ b/lib/hackney/income/create_informal_agreement.rb
@@ -9,18 +9,8 @@ module Hackney
         case_details = find_case_details(tenancy_ref)
         return if case_details.nil?
 
-        agreement_params = {
-          tenancy_ref: tenancy_ref,
-          agreement_type: :informal,
-          starting_balance: case_details[:balance],
-          amount: new_agreement_params[:amount],
-          start_date: new_agreement_params[:start_date],
-          frequency: new_agreement_params[:frequency],
-          created_by: new_agreement_params[:created_by],
-          notes: new_agreement_params[:notes],
-          initial_payment_amount: new_agreement_params[:initial_payment_amount],
-          initial_payment_date: new_agreement_params[:initial_payment_date]
-        }
+        agreement_params = assign_agreement_params(new_agreement_params)
+                           .merge(agreement_type: :informal, starting_balance: case_details[:balance])
 
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)
 

--- a/lib/hackney/income/create_informal_agreement.rb
+++ b/lib/hackney/income/create_informal_agreement.rb
@@ -17,7 +17,9 @@ module Hackney
           start_date: new_agreement_params[:start_date],
           frequency: new_agreement_params[:frequency],
           created_by: new_agreement_params[:created_by],
-          notes: new_agreement_params[:notes]
+          notes: new_agreement_params[:notes],
+          initial_payment_amount: new_agreement_params[:initial_payment_amount],
+          initial_payment_date: new_agreement_params[:initial_payment_date]
         }
 
         active_agreements = Hackney::Income::Models::Agreement.where(tenancy_ref: tenancy_ref).select(&:active?)

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Agreements', type: :request do
   let(:starting_balance) { Faker::Commerce.price(range: 100...1000) }
   let(:created_by) { Faker::Name.name }
   let(:notes) { Faker::ChuckNorris.fact }
+  let(:initial_payment_amount) { Faker::Commerce.price(range: 50...300) }
+  let(:initial_payment_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
 
   describe 'GET /api/v1/agreements/{tenancy_ref}' do
     path '/agreements/{tenancy_ref}' do
@@ -109,7 +111,9 @@ RSpec.describe 'Agreements', type: :request do
           frequency: frequency.to_sym,
           created_by: created_by,
           notes: notes,
-          court_case_id: nil
+          court_case_id: nil,
+          initial_payment_amount: initial_payment_amount.to_s,
+          initial_payment_date: initial_payment_date.to_s
         }
       end
 

--- a/spec/requests/agreements_spec.rb
+++ b/spec/requests/agreements_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe 'Agreements', type: :request do
                  frequency: frequency,
                  current_state: current_state,
                  created_by: created_by,
-                 notes: notes)
+                 notes: notes,
+                 initial_payment_amount: initial_payment_amount,
+                 initial_payment_date: initial_payment_date)
         ]
       end
 
@@ -58,6 +60,8 @@ RSpec.describe 'Agreements', type: :request do
         expect(parsed_response['agreements'].first['notes']).to eq(notes)
         expect(parsed_response['agreements'].first['history']).to eq([])
         expect(parsed_response['agreements'].first['lastChecked']).to eq('')
+        expect(parsed_response['agreements'].first['initialPaymentAmount']).to eq(initial_payment_amount.to_s)
+        expect(parsed_response['agreements'].first['initialPaymentDate']).to eq(initial_payment_date.to_s)
       end
 
       it 'correctly maps all agreement_states in history' do
@@ -148,6 +152,8 @@ RSpec.describe 'Agreements', type: :request do
           expect(parsed_response['createdBy']).to eq(created_by)
           expect(parsed_response['notes']).to eq(notes)
           expect(parsed_response['history']).to eq([])
+          expect(parsed_response['initialPaymentAmount']).to eq(initial_payment_amount.to_s)
+          expect(parsed_response['initialPaymentDate']).to eq(initial_payment_date.to_s)
         end
       end
 
@@ -179,6 +185,8 @@ RSpec.describe 'Agreements', type: :request do
           expect(parsed_response['createdBy']).to eq(created_by)
           expect(parsed_response['notes']).to eq(notes)
           expect(parsed_response['history']).to eq([])
+          expect(parsed_response['initialPaymentAmount']).to eq(initial_payment_amount.to_s)
+          expect(parsed_response['initialPaymentDate']).to eq(initial_payment_date.to_s)
         end
       end
     end

--- a/spec/support/shared_examples/create_agreement.rb
+++ b/spec/support/shared_examples/create_agreement.rb
@@ -8,6 +8,8 @@ RSpec.shared_examples 'CreateAgreement' do
   let(:created_by) { Faker::Name.name }
   let(:notes) { Faker::ChuckNorris.fact }
   let(:court_case) { create(:court_case, tenancy_ref: tenancy_ref) }
+  let(:initial_payment_amount) { nil }
+  let(:initial_payment_date) { nil }
 
   let(:existing_agreement_params) do
     {
@@ -27,7 +29,9 @@ RSpec.shared_examples 'CreateAgreement' do
       frequency: frequency,
       created_by: created_by,
       court_case_id: court_case.id,
-      notes: notes
+      notes: notes,
+      initial_payment_amount: initial_payment_amount,
+      initial_payment_date: initial_payment_date
     }
   end
 
@@ -104,6 +108,19 @@ RSpec.shared_examples 'CreateAgreement' do
 
       expect(agreements.last.tenancy_ref).to eq(new_agreement.tenancy_ref)
       expect(cancel_agreement).to have_received(:execute).with(agreement_id: agreements.first.id)
+    end
+  end
+
+  context 'when its a variable payment agreement' do
+    let(:initial_payment_amount) { Faker::Commerce.price(range: 10...200) }
+    let(:initial_payment_date) { Faker::Date.between(from: 10.days.ago, to: 3.days.ago) }
+
+    it 'creates and returns a new live agreement that has an initial payment amount and date' do
+      new_agreement = subject.execute(new_agreement_params: new_agreement_params)
+
+      expect(new_agreement.initial_payment_amount).to eq(initial_payment_amount)
+      expect(new_agreement.initial_payment_date).to eq(initial_payment_date)
+      expect(new_agreement).to be_variable_payment
     end
   end
 end


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to enter an initial payment amount and date, so I can enter court agreements that have a larger first payment that followed by frequent smaller payments.
This is the second slice, allowing agreement endpoints to create and retrieve variable payment agreement

## Changes in this pull request
- Update create agreement use-cases
- Allow variable payment params when calling create agreement endpoint
- Allow retrieving a variable payment agreement
- Update API docs
![image](https://user-images.githubusercontent.com/22743709/92387122-ec9f8400-f10c-11ea-87c9-a670890da539.png)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
