### PR TITLE
save gross rent (rent + other charges)

### DIFF
--- a/lib/hackney/income/worktray_item_gateway.rb
+++ b/lib/hackney/income/worktray_item_gateway.rb
@@ -13,7 +13,7 @@ module Hackney
             tenancy.assign_attributes(
               balance: criteria.balance,
               collectable_arrears: criteria.collectable_arrears,
-              weekly_rent: criteria.weekly_rent,
+              weekly_rent: criteria.weekly_gross_rent,
               days_since_last_payment: criteria.days_since_last_payment,
               nosp_served: criteria.nosp_served?,
               nosp_served_date: criteria.nosp_served_date,


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We we're saving and displaying just the rent on letters, but we should be displaying the rent value as `rent + other charges` aka what the tenant needs to pay.


## Changes in this pull request
<!-- List all the changes -->
save gross rent as weekly rent 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
