### PR TITLE
  Update breach detector to handle variable payment agreements

### DIFF
--- a/spec/lib/hackney/income/update_agreement_state_spec.rb
+++ b/spec/lib/hackney/income/update_agreement_state_spec.rb
@@ -295,6 +295,98 @@ describe Hackney::Income::UpdateAgreementState do
     end
   end
 
+  context 'when its a variable payment agreement(optional one-off payment)' do
+    let(:initial_payment_amount) { 50 }
+    let(:starting_balance) { 100 }
+
+    context 'when the initial playment date is before the start date of recurring payment' do
+      let(:initial_payment_date) { start_date - 15.days }
+
+      it 'expects a single initial payment on the initial payment date' do
+        agreement = stub_informal_agreement(
+          start_date: start_date,
+          frequency: :weekly,
+          amount: 10,
+          starting_balance: starting_balance,
+          initial_payment_amount: initial_payment_amount,
+          initial_payment_date: initial_payment_date
+        )
+
+        Timecop.freeze(initial_payment_date) do
+          subject.execute(agreement: agreement, current_balance: starting_balance)
+
+          expect(agreement.current_state).to eq('live')
+        end
+
+        Timecop.freeze(initial_payment_date + days_before_check.days) do
+          subject.execute(agreement: agreement, current_balance: starting_balance)
+
+          expect(agreement.current_state).to eq('breached')
+        end
+
+        first_recurring_payment_date = start_date + days_before_check.days
+        day_before_first_recurring_payment_date = first_recurring_payment_date - 1.day
+
+        Timecop.freeze(day_before_first_recurring_payment_date) do
+          subject.execute(agreement: agreement, current_balance: starting_balance - initial_payment_amount)
+
+          expect(agreement.current_state).to eq('live')
+        end
+
+        Timecop.freeze(first_recurring_payment_date) do
+          subject.execute(agreement: agreement, current_balance: starting_balance - initial_payment_amount)
+
+          expect(agreement.current_state).to eq('breached')
+        end
+      end
+    end
+
+    context 'when the initial playment date is on the start date of recurring payment' do
+      let(:recurring_payment_amount) { 10 }
+
+      it 'expects a one off payment and the first instalment of the recurring payment on the same date' do
+        agreement = stub_informal_agreement(
+          start_date: start_date,
+          frequency: :weekly,
+          amount: recurring_payment_amount,
+          starting_balance: starting_balance,
+          initial_payment_amount: initial_payment_amount,
+          initial_payment_date: start_date
+        )
+
+        first_recurring_payment_date = start_date + days_before_check.days
+        day_before_first_recurring_payment_date = first_recurring_payment_date - 1.day
+
+        Timecop.freeze(day_before_first_recurring_payment_date) do
+          subject.execute(agreement: agreement, current_balance: starting_balance)
+
+          expect(agreement.current_state).to eq('live')
+        end
+
+        Timecop.freeze(first_recurring_payment_date) do
+          all_payment_completed = starting_balance - initial_payment_amount - recurring_payment_amount
+          subject.execute(agreement: agreement, current_balance: all_payment_completed)
+
+          expect(agreement.current_state).to eq('live')
+
+          missed_initial_payment_amount = starting_balance - recurring_payment_amount
+          subject.execute(agreement: agreement, current_balance: missed_initial_payment_amount)
+
+          expect(agreement.current_state).to eq('breached')
+
+          missed_recurring_payment_amount = starting_balance - initial_payment_amount
+          subject.execute(agreement: agreement, current_balance: missed_recurring_payment_amount)
+
+          expect(agreement.current_state).to eq('breached')
+
+          subject.execute(agreement: agreement, current_balance: 0)
+
+          expect(agreement.current_state).to eq('completed')
+        end
+      end
+    end
+  end
+
   context 'when its a formal agreement' do
     context 'when there is a strikeout date' do
       it 'changes the formal agreement into informal on strikeout date' do
@@ -449,13 +541,15 @@ describe Hackney::Income::UpdateAgreementState do
     end
   end
 
-  def stub_informal_agreement(start_date:, frequency:, amount:, starting_balance:)
+  def stub_informal_agreement(start_date:, frequency:, amount:, starting_balance:, initial_payment_amount: nil, initial_payment_date: nil)
     agreement = create(:agreement,
                        tenancy_ref: tenancy_ref,
                        start_date: start_date,
                        frequency: frequency,
                        amount: amount,
-                       starting_balance: starting_balance)
+                       starting_balance: starting_balance,
+                       initial_payment_amount: initial_payment_amount,
+                       initial_payment_date: initial_payment_date)
 
     create(:agreement_state,
            :live,


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to enter an initial payment amount and date, so I can enter court agreements that have a larger first payment that followed by frequent smaller payments.
This is the third slice, allowing the breach detector to detect breached variable payment agreements

## Changes in this pull request
- Extend `UpdateAgreementState` to check whether the `initial_payment`(one-off payment before recurring payments) has been made

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
