### PR TITLE
Use courtoutcome balance for formal agreements

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -23,7 +23,6 @@ class AgreementsController < ApplicationController
       frequency: params.fetch(:frequency).to_sym,
       created_by: params.fetch(:created_by),
       notes: params.fetch(:notes),
-      starting_balance: params.fetch(:starting_balance),
       court_case_id: params.dig(:court_case_id),
       initial_payment_amount: params.dig(:initial_payment_amount),
       initial_payment_date: params.dig(:initial_payment_date)

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -23,6 +23,7 @@ class AgreementsController < ApplicationController
       frequency: params.fetch(:frequency).to_sym,
       created_by: params.fetch(:created_by),
       notes: params.fetch(:notes),
+      starting_balance: params.fetch(:starting_balance),
       court_case_id: params.dig(:court_case_id),
       initial_payment_amount: params.dig(:initial_payment_amount),
       initial_payment_date: params.dig(:initial_payment_date)

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -15,7 +15,7 @@ module Hackney
         formal_agreement_params = assign_agreement_params(new_agreement_params)
                                   .merge(
                                     agreement_type: :formal,
-                                    starting_balance: case_details[:balance],
+                                    starting_balance: new_agreement_params[:starting_balance],
                                     court_case_id: court_case.id
                                   )
 

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -15,7 +15,7 @@ module Hackney
         formal_agreement_params = assign_agreement_params(new_agreement_params)
                                   .merge(
                                     agreement_type: :formal,
-                                    starting_balance: new_agreement_params[:starting_balance],
+                                    starting_balance: court_case.balance_on_court_outcome_date,
                                     court_case_id: court_case.id
                                   )
 

--- a/spec/support/shared_examples/create_agreement.rb
+++ b/spec/support/shared_examples/create_agreement.rb
@@ -60,8 +60,15 @@ RSpec.shared_examples 'CreateAgreement' do
 
     new_state = created_agreement.agreement_states.first
     expect(new_state.agreement_state).to eq('live')
-    expect(new_state.expected_balance).to eq(100)
-    expect(new_state.checked_balance).to eq(100)
+
+    if created_agreement.formal?
+      expect(new_state.expected_balance).to eq(court_case.balance_on_court_outcome_date)
+      expect(new_state.checked_balance).to eq(court_case.balance_on_court_outcome_date)
+    else
+      expect(new_state.expected_balance).to eq(100)
+      expect(new_state.checked_balance).to eq(100)
+    end
+
     expect(new_state.description).to eq('Agreement created')
   end
 
@@ -85,7 +92,13 @@ RSpec.shared_examples 'CreateAgreement' do
       expect(created_agreement.start_date).to eq(start_date)
       expect(created_agreement.frequency).to eq(frequency)
       expect(created_agreement.current_state).to eq('live')
-      expect(created_agreement.starting_balance).to eq(100)
+
+      if created_agreement.formal?
+        expect(created_agreement.starting_balance).to eq(court_case.balance_on_court_outcome_date)
+      else
+        expect(created_agreement.starting_balance).to eq(100)
+      end
+
       expect(created_agreement.created_by).to eq(created_by)
       expect(created_agreement.notes).to eq(notes)
     end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When a formal agreement is created we need to make sure that the starting balance is the same as the balance at the court outcome

## Changes in this pull request
<!-- List all the changes -->
use the court outcome balance when creating a formal agreement

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
