### PR TITLE
Add one-off payment frequency

### DIFF
--- a/app/models/hackney/income/models/agreement.rb
+++ b/app/models/hackney/income/models/agreement.rb
@@ -10,7 +10,7 @@ module Hackney
         belongs_to :court_case, optional: true, class_name: 'Hackney::Income::Models::CourtCase'
         has_many :agreement_states, class_name: 'Hackney::Income::Models::AgreementState'
         enum agreement_type: { informal: 'informal', formal: 'formal' }
-        enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3, unsupported_legacy_frequency: 4 }
+        enum frequency: { weekly: 0, monthly: 1, fortnightly: 2, '4 weekly': 3, unsupported_legacy_frequency: 4, one_off: 5 }
 
         def active?
           ACTIVE_STATES.include?(current_state)

--- a/spec/factories/agreement.rb
+++ b/spec/factories/agreement.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     notes { Faker::ChuckNorris.fact }
     created_by { Faker::Name.name }
     starting_balance { Faker::Commerce.price(range: 100...1000) }
-    frequency { [:weekly, :monthly, :fortnightly, '4 weekly'].sample }
+    frequency { [:weekly, :monthly, :fortnightly, '4 weekly', :one_off].sample }
     start_date { Faker::Date.between(from: 2.days.ago, to: Date.today) }
     amount { Faker::Commerce.price(range: 10...100) }
     initial_payment_date { nil }

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -138,9 +138,9 @@ describe Hackney::PDF::IncomePreview do
             agreement_frequency: agreement.frequency,
             amount: agreement.amount,
             date_of_first_payment: agreement.start_date,
-            rent: weekly_rent,
+            rent: BigDecimal(weekly_rent, 4),
             title: '',
-            total_collectable_arrears_balance: test_collectable_arrears
+            total_collectable_arrears_balance: BigDecimal(test_collectable_arrears, 5)
           ),
           username: username
         ).and_call_original
@@ -164,7 +164,8 @@ describe Hackney::PDF::IncomePreview do
             created_date: agreement.created_at,
             expected_balance: state.expected_balance,
             checked_balance: state.checked_balance,
-            total_collectable_arrears_balance: test_collectable_arrears
+            total_collectable_arrears_balance: BigDecimal(test_collectable_arrears, 5),
+            rent: BigDecimal(weekly_rent, 4)
           ),
           username: username
         ).and_call_original

--- a/spec/models/hackney/income/models/agreement_spec.rb
+++ b/spec/models/hackney/income/models/agreement_spec.rb
@@ -56,8 +56,8 @@ describe Hackney::Income::Models::Agreement, type: :model do
   end
 
   describe 'frequency' do
-    it 'only accepts :weekly/:monthly as frequency' do
-      ['weekly', 'monthly', 'fortnightly', '4 weekly'].each do |frequency|
+    it 'only accepts valid frequencies' do
+      ['weekly', 'monthly', 'fortnightly', '4 weekly', 'unsupported_legacy_frequency', 'one_off'].each do |frequency|
         expect { described_class.new(frequency: frequency) }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow officers to create agreements for a one-off payment.
## Changes in this pull request
<!-- List all the changes -->
- Add `one_off` as an option for frequency in the Agreement model
- Add tests to make sure the status is updated accordingly

- Fix flaky test that failed sometimes because of float comparison

To do:
- Add one-off as an option in the frontend, need to remember to push this change to prod before the one in the frontend.
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Is this all that's needed for one-off payments? 
I'm really worried I'm missing something - so please shout if I need to add anything!
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-465?atlOrigin=eyJpIjoiZDFhMGNkYWU2ODc1NDFjMDkxNTNhMGIzNzdjMDVjYjgiLCJwIjoiaiJ9
## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
