### PR TITLE
Turn down logging on staging & prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = %i[request_id]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = %i[request_id]


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->

Debug level emits lots of noise on db connections which are unnecessary to show on staging and production on a regular basis.

The application logs are stored in Papertrail, which has a data transfer cap and we've tripped the cap recently which has stopped capturing all logs in the papertrail system (including other applications.)

## Changes in this pull request
<!-- List all the changes -->
By default, don't emit debug logs on staging and production.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-489

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
