### PR TITLE
Allow creating variable and one-off payment agreement confirmation letters

### DIFF
--- a/app/models/hackney/income_collection/letter/informal_agreement.rb
+++ b/app/models/hackney/income_collection/letter/informal_agreement.rb
@@ -9,7 +9,8 @@ module Hackney
         ].freeze
         MANDATORY_FIELDS = %i[rent agreement_frequency amount date_of_first_payment].freeze
 
-        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable, :date_of_first_payment, :instalment_amount
+        attr_reader :rent, :agreement_frequency, :amount, :rent_charge, :total_amount_payable,
+                    :date_of_first_payment, :instalment_amount, :initial_payment_amount, :initial_payment_date
 
         def initialize(params)
           super(params)
@@ -19,6 +20,8 @@ module Hackney
           @rent = validated_params[:rent]
           @instalment_amount = format('%.2f', validated_params[:amount]) unless validated_params[:amount].nil?
           @date_of_first_payment = format_date(validated_params[:date_of_first_payment])
+          @initial_payment_amount = format('%.2f', params[:initial_payment_amount]) unless params[:initial_payment_amount].nil?
+          @initial_payment_date = format_date(params[:initial_payment_date]) unless params[:initial_payment_date].nil?
 
           return unless @rent
           @rent_charge = format('%.2f', calculate_rent(@rent, @agreement_frequency))

--- a/lib/hackney/pdf/income_preview.rb
+++ b/lib/hackney/pdf/income_preview.rb
@@ -69,8 +69,10 @@ module Hackney
         {
           agreement_frequency: agreement.frequency,
           amount: agreement.amount,
-          date_of_first_payment: agreement.start_date
-        }
+          date_of_first_payment: agreement.start_date,
+          initial_payment_amount: agreement.initial_payment_amount,
+          initial_payment_date: agreement.initial_payment_date
+        }.compact
       end
 
       def get_breached_agreement_info(agreement)

--- a/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
@@ -15,11 +15,18 @@
   </p>
 
   <ul class = "no_bullets">
-    <li><%= @letter.agreement_frequency.
-            capitalize %> rent: £<%= @letter.rent_charge %> </li>
-    <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
-    <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
-    <li>Date of first payment: <%= @letter.date_of_first_payment %> </li>
+    <% if @letter.agreement_frequency == 'one_off' %>
+      <li>Amount towards the rent: £<%= @letter.rent_charge %> </li>
+      <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+      <li>Total amount payable £<%= @letter.total_amount_payable %></li>
+      <li>Date of payment: <%= @letter.date_of_first_payment %> </li>
+    <% else %>
+      <li><%= @letter.agreement_frequency.
+              capitalize %> rent: £<%= @letter.rent_charge %> </li>
+      <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+      <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
+      <li>Date of first payment: <%= @letter.date_of_first_payment %> </li>
+    <% end %>
   </ul>
 
   <p>

--- a/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
@@ -21,6 +21,10 @@
       <li>Total amount payable £<%= @letter.total_amount_payable %></li>
       <li>Date of payment: <%= @letter.date_of_first_payment %> </li>
     <% else %>
+      <% unless @letter.initial_payment_amount.nil? %>
+        <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
+        <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
+      <% end %>
       <li><%= @letter.agreement_frequency.
               capitalize %> rent: £<%= @letter.rent_charge %> </li>
       <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to send agreement confirmation letters for different payment conditions, so that I can give clear guidance to the tenant how much they need to pay.

## Changes in this pull request
- Allow creating variable payment agreement confirmation letter
- Allow creating one-off payment agreement confirmation letter

### Templates
![image](https://user-images.githubusercontent.com/22743709/93222825-46382c00-f767-11ea-9be6-46805a167ca1.png)

![image](https://user-images.githubusercontent.com/22743709/93222942-65cf5480-f767-11ea-99f0-9888da356ddf.png)

## Link to Jira card
https://hackney.atlassian.net/browse/MAAP-488

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
