### PR TITLE
Add POST eviction date endpoint

### DIFF
--- a/app/controllers/eviction_date_response_helper.rb
+++ b/app/controllers/eviction_date_response_helper.rb
@@ -1,0 +1,9 @@
+module EvictionDateResponseHelper
+  def map_eviction_date_to_response(eviction_date:)
+    {
+      id: eviction_date.id,
+      tenancyRef: eviction_date.tenancy_ref,
+      evictionDate: eviction_date.eviction_date
+    }
+  end
+end

--- a/app/controllers/eviction_dates_controller.rb
+++ b/app/controllers/eviction_dates_controller.rb
@@ -1,0 +1,18 @@
+class EvictionDatesController < ApplicationController
+  include EvictionDateResponseHelper
+  def create
+    parameters = %i[tenancy_ref eviction_date].freeze
+
+    create_eviction_date_params = params.permit(parameters)
+
+    eviction_date_params = {
+      tenancy_ref: create_eviction_date_params[:tenancy_ref],
+      eviction_date: create_eviction_date_params[:eviction_date]
+    }
+
+    new_eviction_date = income_use_case_factory.create_eviction_date.execute(eviction_date_params: eviction_date_params)
+    response = map_eviction_date_to_response(eviction_date: new_eviction_date)
+
+    render json: response
+  end
+end

--- a/app/models/hackney/income/models/eviction_date.rb
+++ b/app/models/hackney/income/models/eviction_date.rb
@@ -1,0 +1,9 @@
+module Hackney
+  module Income
+    module Models
+      class EvictionDate < ApplicationRecord
+        validates_presence_of :tenancy_ref
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     post '/court_case/:tenancy_ref', to: 'court_cases#create'
     patch '/court_case/:id/update', to: 'court_cases#update'
 
+    post '/eviction_date/:tenancy_ref', to: 'eviction_dates#create'
+
     get 'actions', to: 'actions#index'
   end
 end

--- a/db/migrate/20200915105700_create_eviction_date.rb
+++ b/db/migrate/20200915105700_create_eviction_date.rb
@@ -1,0 +1,10 @@
+class CreateEvictionDate < ActiveRecord::Migration[5.2]
+  def change
+    create_table :eviction_dates do |t|
+      t.datetime :eviction_date
+      t.string :tenancy_ref, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_03_143523) do
+ActiveRecord::Schema.define(version: 2020_09_15_105700) do
 
   create_table "actions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tenancy_ref"
@@ -148,6 +148,13 @@ ActiveRecord::Schema.define(version: 2020_09_03_143523) do
     t.string "username"
     t.string "email"
     t.index ["uuid"], name: "index_documents_on_uuid", unique: true
+  end
+
+  create_table "eviction_dates", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "eviction_date"
+    t.string "tenancy_ref", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -171,6 +171,43 @@ paths:
           description: Court case not found
       tags:
         - court_cases
+
+  /eviction_date/{tenancy_ref}:
+    post:
+      summary: 'Create a eviction date for the tenancy id'
+      description: Create eviction date with specified tenancy id
+      operationId: postEvictionDateForTenancy
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: tenancy_ref
+          required: true
+          type: string
+          description: Eviction date for tenancy
+        - in: body
+          name: eviction_date
+          description: Eviction date to create
+          schema:
+            type: object
+            required:
+              - evictionDate
+            properties:
+              evictionDate:
+                type: string
+                example: '01/08/2020'
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/eviction_date'
+        400:
+          description: Invalid search parameter
+        404:
+          description: Eviction date not found
+      tags:
+        - eviction_dates
+
 definitions:
   agreementsList:
     type: object
@@ -194,7 +231,7 @@ definitions:
       startingBalance:
         type: number
         example: '1000'
-      initialPaymentAmount: 
+      initialPaymentAmount:
         type: number
         example: '100'
       initialPaymentDate:
@@ -359,5 +396,18 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/action'
+  eviction_date:
+    type: object
+    properties:
+      id:
+        type: integer
+        example: 12
+      tenancyRef:
+        type: string
+        example: '1'
+      evictionDate:
+        type: string
+        format: date
+        example: '01/08/2020'
 schemes:
   - https

--- a/lib/hackney/income/create_eviction_date.rb
+++ b/lib/hackney/income/create_eviction_date.rb
@@ -1,0 +1,15 @@
+module Hackney
+  module Income
+    class CreateEvictionDate
+      def execute(eviction_date_params:)
+        params = {
+          tenancy_ref: eviction_date_params[:tenancy_ref],
+          eviction_date: eviction_date_params[:eviction_date]
+        }
+
+        eviction_date = Hackney::Income::Models::EvictionDate.create!(params)
+        eviction_date
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -284,6 +284,10 @@ module Hackney
         Hackney::Income::UpdateCourtCase.new
       end
 
+      def create_eviction_date
+        Hackney::Income::CreateEvictionDate.new
+      end
+
       private
 
       def cloud_storage

--- a/spec/factories/eviction_date.rb
+++ b/spec/factories/eviction_date.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :eviction_date, class: Hackney::Income::Models::EvictionDate do
+    tenancy_ref { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
+    eviction_date { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  end
+end

--- a/spec/lib/hackney/income/create_eviction_date_spec.rb
+++ b/spec/lib/hackney/income/create_eviction_date_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Hackney::Income::CreateEvictionDate do
+  subject { described_class.new }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:eviction_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+
+  let(:new_eviction_date_params) do
+  {
+    tenancy_ref: tenancy_ref,
+    eviction_date: eviction_date
+  }
+end
+
+  it 'creates and returns a new eviction date' do
+    new_eviction_date = subject.execute(eviction_date_params: new_eviction_date_params)
+
+    eviction_date_id = Hackney::Income::Models::EvictionDate.where(tenancy_ref: tenancy_ref).last.id
+    expect(new_eviction_date).to be_an_instance_of(Hackney::Income::Models::EvictionDate)
+    expect(new_eviction_date.id).to eq(eviction_date_id)
+    expect(new_eviction_date.tenancy_ref).to eq(tenancy_ref)
+    expect(new_eviction_date.eviction_date).to eq(eviction_date)
+  end
+end

--- a/spec/lib/hackney/income/create_eviction_date_spec.rb
+++ b/spec/lib/hackney/income/create_eviction_date_spec.rb
@@ -7,11 +7,11 @@ describe Hackney::Income::CreateEvictionDate do
   let(:eviction_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
 
   let(:new_eviction_date_params) do
-  {
-    tenancy_ref: tenancy_ref,
-    eviction_date: eviction_date
-  }
-end
+    {
+      tenancy_ref: tenancy_ref,
+      eviction_date: eviction_date
+    }
+  end
 
   it 'creates and returns a new eviction date' do
     new_eviction_date = subject.execute(eviction_date_params: new_eviction_date_params)

--- a/spec/models/hackney/income/models/eviction_date_spec.rb
+++ b/spec/models/hackney/income/models/eviction_date_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Hackney::Income::Models::EvictionDate, type: :model do
-
   it 'includes the fields for a eviction date' do
     eviction_date = described_class.new
     expect(eviction_date.attributes).to include(

--- a/spec/models/hackney/income/models/eviction_date_spec.rb
+++ b/spec/models/hackney/income/models/eviction_date_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Hackney::Income::Models::EvictionDate, type: :model do
+
+  it 'includes the fields for a eviction date' do
+    eviction_date = described_class.new
+    expect(eviction_date.attributes).to include(
+      'tenancy_ref',
+      'eviction_date'
+    )
+  end
+
+  it { is_expected.to validate_presence_of(:tenancy_ref) }
+end

--- a/spec/requests/eviction_dates_spec.rb
+++ b/spec/requests/eviction_dates_spec.rb
@@ -1,0 +1,38 @@
+require 'swagger_helper'
+
+RSpec.describe 'EvictionDates', type: :request do
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:eviction_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
+
+  describe 'POST /api/v1/eviction_date/{tenancy_ref}' do
+    path '/eviction_date/{tenancy_ref}' do
+      context 'when creating a new eviction date' do
+        let(:create_eviction_date_instance) { instance_double(Hackney::Income::CreateEvictionDate) }
+        let(:new_eviction_date_params) do
+        {
+          tenancy_ref: tenancy_ref,
+          eviction_date: eviction_date
+        }
+        end
+
+        let(:created_eviction_date) {create(:eviction_date, new_eviction_date_params)}
+
+        before do
+          allow(Hackney::Income::CreateEvictionDate).to receive(:new).and_return(create_eviction_date_instance)
+          allow(create_eviction_date_instance).to receive(:execute)
+            .with(eviction_date_params: new_eviction_date_params)
+            .and_return(created_eviction_date)
+        end
+
+        it 'creates a new eviction date for the given tenancy_ref' do
+          post "/api/v1/eviction_date/#{tenancy_ref}", params: new_eviction_date_params
+
+          parsed_response = JSON.parse(response.body)
+
+          expect(parsed_response['tenancyRef']).to eq(tenancy_ref)
+          expect(parsed_response['evictionDate']).to include(eviction_date)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/eviction_dates_spec.rb
+++ b/spec/requests/eviction_dates_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'EvictionDates', type: :request do
       context 'when creating a new eviction date' do
         let(:create_eviction_date_instance) { instance_double(Hackney::Income::CreateEvictionDate) }
         let(:new_eviction_date_params) do
-        {
-          tenancy_ref: tenancy_ref,
-          eviction_date: eviction_date
-        }
+          {
+            tenancy_ref: tenancy_ref,
+            eviction_date: eviction_date
+          }
         end
 
-        let(:created_eviction_date) {create(:eviction_date, new_eviction_date_params)}
+        let(:created_eviction_date) { create(:eviction_date, new_eviction_date_params) }
 
         before do
           allow(Hackney::Income::CreateEvictionDate).to receive(:new).and_return(create_eviction_date_instance)


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Users need to be able to add eviction dates to a tenancy through MAA, this PR creates the first endpoint to allow users to add an eviction date to our database
## Changes in this pull request
<!-- List all the changes -->

- Add eviction_dates table to database
- Add EvictionDate model
- Add POST create eviction date endpoint to allow an eviction date to be created
- Add CreateEvictionDate usecase
- Update API docs


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Pretty similar to how we create a court case, unsure if the eviction date has all the correct fields or is missing any associations
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-491

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
