### PR TITLE
Change wording for date of first payment

### DIFF
--- a/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
+++ b/lib/hackney/pdf/templates/income/informal_agreement_confirmation_letter.erb
@@ -29,7 +29,7 @@
               capitalize %> rent: £<%= @letter.rent_charge %> </li>
       <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
       <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
-      <li>Date of first payment: <%= @letter.date_of_first_payment %> </li>
+      <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
     <% end %>
   </ul>
 

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -172,7 +172,7 @@ describe Hackney::PDF::IncomePreview do
         expect(rendered_letter[:preview]).to include("#{agreement.frequency.humanize} rent: £#{weekly_rent}")
         expect(rendered_letter[:preview]).to include("Amount towards the arrears: £#{agreement.amount}")
         expect(rendered_letter[:preview]).to include("Total amount payable £#{format('%.2f', agreement.amount + weekly_rent)} #{agreement.frequency}")
-        expect(rendered_letter[:preview]).to include("Date of first payment: #{agreement.start_date.strftime('%d %B %Y')}")
+        expect(rendered_letter[:preview]).to include("Date of first #{agreement.frequency} payment: #{agreement.start_date.strftime('%d %B %Y')}")
         expect(rendered_letter[:preview]).not_to include('Lump-sum payment amount:')
         expect(rendered_letter[:preview]).not_to include('Lump-sum payment date:')
       end
@@ -203,7 +203,7 @@ describe Hackney::PDF::IncomePreview do
         expect(rendered_letter[:preview]).to include("#{agreement.frequency.humanize} rent: £#{weekly_rent}")
         expect(rendered_letter[:preview]).to include("Amount towards the arrears: £#{agreement.amount}")
         expect(rendered_letter[:preview]).to include("Total amount payable £#{format('%.2f', agreement.amount + weekly_rent)} #{agreement.frequency}")
-        expect(rendered_letter[:preview]).to include("Date of first payment: #{agreement.start_date.strftime('%d %B %Y')}")
+        expect(rendered_letter[:preview]).to include("Date of first #{agreement.frequency} payment: #{agreement.start_date.strftime('%d %B %Y')}")
       end
     end
 


### PR DESCRIPTION
## Context
Ian requested a change on the wording of the `date of first payment`

## Changes in this pull request
- Use `date of first (monthly/weekly/etc.) payment: ` so its clear that this refers to the regular payments when there is a lump sum payment 

