### PR TITLE
Add court date letter

### DIFF
--- a/app/models/hackney/income_collection/letter.rb
+++ b/app/models/hackney/income_collection/letter.rb
@@ -20,6 +20,8 @@ module Hackney
           Letter::FormalAgreementBreach.new(letter_params)
         when *Hackney::IncomeCollection::Letter::CourtOutcome::TEMPLATE_PATHS
           Letter::CourtOutcome.build(letter_params)
+        when *Hackney::IncomeCollection::Letter::CourtDate::TEMPLATE_PATHS
+          Letter::CourtDate.new(letter_params)
         else
           new(letter_params)
         end

--- a/app/models/hackney/income_collection/letter/court_date.rb
+++ b/app/models/hackney/income_collection/letter/court_date.rb
@@ -1,0 +1,23 @@
+module Hackney
+  module IncomeCollection
+    class Letter
+      class CourtDate < Hackney::IncomeCollection::Letter
+        include LetterDateHelper
+
+        TEMPLATE_PATHS = [
+          'lib/hackney/pdf/templates/income/court_date_letter.erb'
+        ].freeze
+        MANDATORY_FIELDS = %i[court_date].freeze
+
+        attr_reader :court_date
+
+        def initialize(params)
+          super(params)
+
+          validated_params = validate_mandatory_fields(MANDATORY_FIELDS, params)
+          @court_date = format_date(validated_params[:court_date])
+        end
+      end
+    end
+  end
+end

--- a/app/models/hackney/income_collection/letter/court_date.rb
+++ b/app/models/hackney/income_collection/letter/court_date.rb
@@ -9,13 +9,14 @@ module Hackney
         ].freeze
         MANDATORY_FIELDS = %i[court_date].freeze
 
-        attr_reader :court_date
+        attr_reader :court_date, :court_time
 
         def initialize(params)
           super(params)
 
           validated_params = validate_mandatory_fields(MANDATORY_FIELDS, params)
           @court_date = format_date(validated_params[:court_date])
+          @court_time = format_time(validated_params[:court_date])
         end
       end
     end

--- a/app/models/hackney/letter_date_helper.rb
+++ b/app/models/hackney/letter_date_helper.rb
@@ -5,5 +5,11 @@ module Hackney
 
       date.strftime('%d %B %Y')
     end
+
+    def format_time(time)
+      return if time.nil?
+
+      time.strftime('%R')
+    end
   end
 end

--- a/lib/hackney/pdf/templates/income/court_date_letter.erb
+++ b/lib/hackney/pdf/templates/income/court_date_letter.erb
@@ -1,0 +1,70 @@
+<%= @logo %>
+<div class="top_space"></div>
+<%= @hackney_address %>
+
+<%= @tenant_address %>
+
+<div>
+  <p>
+    <%= @today_date %>
+  </p>
+
+  <p>
+    Dear <%= @letter.title %> <%= @letter.surname %>,
+  </p>
+
+  <p>
+    <strong>
+      NOTICE TO ADVISE YOU OF A COURT HEARING
+    </strong>
+  </p>
+
+  <p>
+    <strong>
+      You Owe £<%= @letter.total_collectable_arrears_balance %> as at <%= @today_date %>
+    </strong>
+  </p>
+
+  <p>
+    A Court Hearing date has been set for <%= @letter.court_date %> at [insert time]. The Court will have contacted you about this.
+  </p>
+
+  <p>
+  At the Court hearing, the Council will be asking for:
+    <ul>
+      <li>A Money Judgment for the arrears that you owe.
+      <li>A Possession Order for your home.
+      <li>Payment towards the Council's legal costs.
+    </ul>
+  </p>
+
+  <p>
+    You should contact a Citizen's Advice Bureau or a solicitor for independent advice. It is important that you attend the Court Hearing to explain your circumstances to the Judge.
+  </p>
+
+  <p>
+    We are aware that the coronavirus pandemic has had a direct impact on many of our tenants’ ability to pay their current rent so we will not escalate any case to Court if you can demonstrate that your arrears have accrued as a result of the impact of Covid-19 on your finances. You must however be able to show that you looked into the support available, claimed all the benefits to which you are entitled, and have taken any appropriate advice which is freely available.
+  </p>
+
+  <p>
+    You would have been informed in previous correspondence about the work carried out by our Financial Inclusion Team. They can offer advice and support to help you maximise your income by looking at benefits you may be entitled to and access other financial support. If you think that you would benefit from a referral to our Financial Inclusion Team then please contact me as soon as possible via email: income.services@hackney.gov.uk or telephone to speak to an Officer on 020 8356 3100.
+  </p>
+
+  <p>
+    Please contact me immediately to ensure I have your current financial details, if you do not contact me, the Council will request a Court Order based on the most recent information we have.
+  </p>
+
+  <p>
+    If you do not clear your arrears, you may be evicted from your home. You should contact the Council's Housing Needs Section for further advice on what will happen if you are evicted. The Housing Needs address and telephone number is: 1 Hillman Street, London E8 1DY and 020 8356 2929
+  </p>
+
+  <p>
+    Yours sincerely,
+  </p>
+
+  <p>
+    Ian Clark
+    <br>
+    Team Manager
+  </p>
+</div>

--- a/lib/hackney/pdf/templates/income/court_date_letter.erb
+++ b/lib/hackney/pdf/templates/income/court_date_letter.erb
@@ -13,20 +13,23 @@
     Dear <%= @letter.title %> <%= @letter.surname %>,
   </p>
 
-  <p>
-    <strong>
-      NOTICE TO ADVISE YOU OF A COURT HEARING
-    </strong>
-  </p>
+  <div class="red_box">
+    <p>
+      <strong>
+        NOTICE TO ADVISE YOU OF A COURT HEARING
+      </strong>
+    </p>
+  </div>
+  <div class="red_box">
+    <p>
+      <strong>
+        You Owe £<%= @letter.total_collectable_arrears_balance %> as at <%= @today_date %>
+      </strong>
+    </p>
+  </div>
 
   <p>
-    <strong>
-      You Owe £<%= @letter.total_collectable_arrears_balance %> as at <%= @today_date %>
-    </strong>
-  </p>
-
-  <p>
-    A Court Hearing date has been set for <%= @letter.court_date %> at [insert time]. The Court will have contacted you about this.
+    A Court Hearing date has been set for <%= @letter.court_date %> at <%= @letter.court_time %>. The Court will have contacted you about this.
   </p>
 
   <p>

--- a/lib/use_cases/generate_and_store_letter.rb
+++ b/lib/use_cases/generate_and_store_letter.rb
@@ -8,8 +8,7 @@ module UseCases
 
       income_collection_templates = %w[income_collection_letter_1 income_collection_letter_2]
       agreement_templates = %w[informal_agreement_confirmation_letter informal_agreement_breach_letter formal_agreement_breach_letter]
-
-      court_case_templates = %(court_outcome_letter)
+      court_case_templates = %w[court_outcome_letter court_date_letter]
 
       if template_id.in?(income_collection_templates)
         letter_data = pdf_use_case_factory.get_income_preview.execute(

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -177,4 +177,17 @@ describe Hackney::IncomeCollection::Letter do
       end
     end
   end
+
+  it 'generates court date letter' do
+    expect(Hackney::IncomeCollection::Letter::CourtDate).to receive(:new).with(letter_params).and_call_original
+
+    letter = described_class.build(
+      letter_params: letter_params,
+      template_path: Hackney::IncomeCollection::Letter::CourtDate::TEMPLATE_PATHS.sample
+    )
+
+    expect(letter.errors).to eq [
+      { message: 'missing mandatory field', name: 'court_date' },
+    ]
+  end
 end

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -187,7 +187,7 @@ describe Hackney::IncomeCollection::Letter do
     )
 
     expect(letter.errors).to eq [
-      { message: 'missing mandatory field', name: 'court_date' },
+      { message: 'missing mandatory field', name: 'court_date' }
     ]
   end
 end

--- a/spec/models/hackney/income_collection/letter/court_date_spec.rb
+++ b/spec/models/hackney/income_collection/letter/court_date_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Hackney::IncomeCollection::Letter::CourtDate do
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
-  let(:court_date) { Faker::Date.between(from: Date.today, to: 2.days.from_now) }
+  let(:court_date) { Faker::Time.between(from: DateTime.now + 5, to: DateTime.now + 10) }
   let(:letter_params) {
     {
       tenancy_ref: tenancy_ref,

--- a/spec/models/hackney/income_collection/letter/court_date_spec.rb
+++ b/spec/models/hackney/income_collection/letter/court_date_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Hackney::IncomeCollection::Letter::CourtDate do
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:court_date) { Faker::Date.between(from: Date.today, to: 2.days.from_now) }
+  let(:letter_params) {
+    {
+      tenancy_ref: tenancy_ref,
+      payment_ref: Faker::Number.number(digits: 4),
+      lessee_full_name: Faker::Name.name,
+      correspondence_address1: Faker::Address.street_address,
+      correspondence_address2: Faker::Address.secondary_address,
+      correspondence_address3: Faker::Address.city,
+      correspondence_postcode: Faker::Address.zip_code,
+      property_address: Faker::Address.street_address,
+      total_collectable_arrears_balance: Faker::Number.number(digits: 3),
+      court_date: court_date
+    }
+  }
+
+  let!(:letter) { described_class.new(letter_params) }
+
+  context 'when the letter is being generated' do
+    it 'checks that the template file exists' do
+      files = Hackney::IncomeCollection::Letter::CourtDate::TEMPLATE_PATHS
+
+      files.each do |file|
+        expect(Pathname.new(file)).to exist
+      end
+    end
+  end
+end

--- a/spec/models/hackney/income_collection/letter/court_date_spec.rb
+++ b/spec/models/hackney/income_collection/letter/court_date_spec.rb
@@ -18,7 +18,7 @@ describe Hackney::IncomeCollection::Letter::CourtDate do
     }
   }
 
-  let!(:letter) { described_class.new(letter_params) }
+  let(:letter) { described_class.new(letter_params) }
 
   context 'when the letter is being generated' do
     it 'checks that the template file exists' do


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
After an officer has added a court date and time, they want the ability to send a 'Court date letter' to remind the tenant.
## Changes in this pull request
<!-- List all the changes -->
- Add Court Date letter template
- Add Court Date letter model and tests to make sure the letter preview can be generated

![image](https://user-images.githubusercontent.com/32230328/93362086-7b16b280-f83d-11ea-8d71-7d2ab98ae713.png)

To do:
- Hook things up in the frontend so that officers can send this letter once they add a court date and time

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-485?atlOrigin=eyJpIjoiNTk3MTk5NGE1ZjVmNDFiOGE5ZjI5ZDQzNTE5MjUxMGIiLCJwIjoiaiJ9

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
