### PR TITLE
Call update_agreement_state when creating formal/informal agreements

### DIFF
--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -1,9 +1,10 @@
 module Hackney
   module Income
     class CreateAgreement
-      def initialize(add_action_diary:, cancel_agreement:)
+      def initialize(add_action_diary:, cancel_agreement:, update_agreement_state:)
         @add_action_diary = add_action_diary
         @cancel_agreement = cancel_agreement
+        @update_agreement_state = update_agreement_state
       end
 
       def find_case_details(tenancy_ref)
@@ -49,6 +50,10 @@ module Hackney
           initial_payment_amount: params[:initial_payment_amount],
           initial_payment_date: params[:initial_payment_date]
         }
+      end
+
+      def update_agreement_state(agreement:, current_balance:)
+        @update_agreement_state.execute(agreement: agreement, current_balance: current_balance)
       end
     end
   end

--- a/lib/hackney/income/create_formal_agreement.rb
+++ b/lib/hackney/income/create_formal_agreement.rb
@@ -25,6 +25,8 @@ module Hackney
 
         new_agreement = create_agreement(formal_agreement_params)
 
+        update_agreement_state(agreement: new_agreement, current_balance: case_details.balance)
+
         add_action_diary_entry(
           tenancy_ref: tenancy_ref,
           comment: "Formal agreement created: #{formal_agreement_params[:notes]}",

--- a/lib/hackney/income/create_informal_agreement.rb
+++ b/lib/hackney/income/create_informal_agreement.rb
@@ -22,6 +22,8 @@ module Hackney
 
         new_agreement = create_agreement(agreement_params)
 
+        update_agreement_state(agreement: new_agreement, current_balance: case_details.balance)
+
         add_action_diary_entry(
           tenancy_ref: tenancy_ref,
           comment: "Informal agreement created: #{agreement_params[:notes]}",

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -202,7 +202,8 @@ module Hackney
       def create_agreement
         Hackney::Income::CreateAgreement.new(
           add_action_diary: add_action_diary,
-          cancel_agreement: cancel_agreement
+          cancel_agreement: cancel_agreement,
+          update_agreement_state: update_agreement_state
         )
       end
 
@@ -257,14 +258,16 @@ module Hackney
       def create_informal_agreement
         Hackney::Income::CreateInformalAgreement.new(
           add_action_diary: add_action_diary,
-          cancel_agreement: cancel_agreement
+          cancel_agreement: cancel_agreement,
+          update_agreement_state: update_agreement_state
         )
       end
 
       def create_formal_agreement
         Hackney::Income::CreateFormalAgreement.new(
           add_action_diary: add_action_diary,
-          cancel_agreement: cancel_agreement
+          cancel_agreement: cancel_agreement,
+          update_agreement_state: update_agreement_state
         )
       end
 

--- a/spec/lib/hackney/income/create_formal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_formal_agreement_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 describe Hackney::Income::CreateFormalAgreement do
-  subject { described_class.new(add_action_diary: add_action_diary, cancel_agreement: cancel_agreement) }
+  subject { described_class.new(add_action_diary: add_action_diary, cancel_agreement: cancel_agreement, update_agreement_state: update_agreement_state) }
 
   let(:cancel_agreement) { spy }
   let(:add_action_diary) { spy }
+  let(:update_agreement_state) { spy }
   let(:new_agreement_params) do
     {
       tenancy_ref: tenancy_ref,

--- a/spec/lib/hackney/income/create_informal_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_informal_agreement_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 describe Hackney::Income::CreateInformalAgreement do
-  subject { described_class.new(add_action_diary: add_action_diary, cancel_agreement: cancel_agreement) }
+  subject { described_class.new(add_action_diary: add_action_diary, cancel_agreement: cancel_agreement, update_agreement_state: update_agreement_state) }
 
   let(:cancel_agreement) { spy }
   let(:add_action_diary) { spy }
+  let(:update_agreement_state) { spy }
   let(:new_agreement_params) do
     {
       tenancy_ref: tenancy_ref,


### PR DESCRIPTION
## Context
Elaine raised that entering historical agreements can cause confusions. Because the breach detector runs nightly, even if these agreements meant to breached according to the entered data, they would not be breached until next day morning.
Would be a better user experience if agreements brought up to date when created.

## Changes in this pull request
- Call update_agreement_state when creating formal/informal agreements

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
