### PR TITLE
Add GET eviction dates endpoint

### DIFF
--- a/app/controllers/eviction_dates_controller.rb
+++ b/app/controllers/eviction_dates_controller.rb
@@ -1,5 +1,16 @@
 class EvictionDatesController < ApplicationController
   include EvictionDateResponseHelper
+  def index
+    requested_eviction_date = income_use_case_factory.view_eviction_dates.execute(tenancy_ref: params.fetch(:tenancy_ref))
+
+    dates = requested_eviction_date.map do |e|
+      map_eviction_date_to_response(eviction_date: e)
+    end
+
+    response = { evictionDates: dates }
+    render json: response
+  end
+
   def create
     parameters = %i[tenancy_ref eviction_date].freeze
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     patch '/court_case/:id/update', to: 'court_cases#update'
 
     post '/eviction_date/:tenancy_ref', to: 'eviction_dates#create'
+    get '/eviction_dates/:tenancy_ref', to: 'eviction_dates#index'
 
     get 'actions', to: 'actions#index'
   end

--- a/docs/api/v1/api.yaml
+++ b/docs/api/v1/api.yaml
@@ -172,6 +172,32 @@ paths:
       tags:
         - court_cases
 
+
+  /eviction_dates/{tenancy_ref}:
+    get:
+      summary: 'Find eviction dates by tenancy id'
+      description: Returns eviction dates with specified tenancy id
+      operationId: getEvictionDatesForTenancy
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: tenancy_ref
+          required: true
+          type: string
+          description: Eviction date for tenancy
+      responses:
+        200:
+          description: successful operation
+          schema:
+            $ref: '#/definitions/evictionDateList'
+        400:
+          description: Invalid search parameter
+        404:
+          description: Eviction dates not found
+      tags:
+        - eviction_dates
+
   /eviction_date/{tenancy_ref}:
     post:
       summary: 'Create a eviction date for the tenancy id'
@@ -409,5 +435,12 @@ definitions:
         type: string
         format: date
         example: '01/08/2020'
+  evictionDateList:
+    type: object
+    properties:
+      evictionDates:
+        type: array
+        items:
+          $ref: '#/definitions/eviction_date'
 schemes:
   - https

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -288,6 +288,10 @@ module Hackney
         Hackney::Income::CreateEvictionDate.new
       end
 
+      def view_eviction_dates
+        Hackney::Income::ViewEvictionDates.new
+      end
+
       private
 
       def cloud_storage

--- a/lib/hackney/income/view_eviction_dates.rb
+++ b/lib/hackney/income/view_eviction_dates.rb
@@ -1,0 +1,13 @@
+module Hackney
+  module Income
+    class ViewEvictionDates
+      def execute(tenancy_ref:)
+        requested_dates = Hackney::Income::Models::EvictionDate.where(tenancy_ref: tenancy_ref)
+
+        return [] unless requested_dates.any?
+
+        requested_dates
+      end
+    end
+  end
+end

--- a/spec/lib/hackney/income/view_eviction_dates_spec.rb
+++ b/spec/lib/hackney/income/view_eviction_dates_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe Hackney::Income::ViewEvictionDates do
+  subject { described_class.new.execute(tenancy_ref: tenancy_ref) }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+
+  context 'when there are no eviction dates for the tenancy' do
+    it 'returns an empty array' do
+      expect(subject).to eq([])
+    end
+  end
+
+  context 'when there is an eviction date for a tenancy' do
+    let(:eviction_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
+    let(:eviction_date_params) do
+      {
+
+        tenancy_ref: tenancy_ref,
+        eviction_date: eviction_date
+      }
+    end
+    let!(:expected_eviction_date) { create(:eviction_date, eviction_date_params) }
+
+    it 'returns returns an array of eviction dates for the given tenancy_ref' do
+      response = subject
+
+      expect(response.count).to eq(1)
+      expect(response.first.id).to eq(expected_eviction_date.id)
+      expect(response.first.tenancy_ref).to eq(tenancy_ref)
+      expect(response.first.eviction_date).to eq(eviction_date)
+    end
+  end
+end

--- a/spec/requests/eviction_dates_spec.rb
+++ b/spec/requests/eviction_dates_spec.rb
@@ -35,4 +35,29 @@ RSpec.describe 'EvictionDates', type: :request do
       end
     end
   end
+
+  describe 'GET /api/v1/eviction_date/{tenancy_ref}' do
+    path '/eviction_dates/{tenancy_ref}' do
+      let(:view_eviction_dates_instance) { instance_double(Hackney::Income::ViewEvictionDates) }
+      let(:eviction_dates_array) { create_list(:eviction_date, 3, tenancy_ref: tenancy_ref) }
+
+      before do
+        allow(Hackney::Income::ViewEvictionDates).to receive(:new).and_return(view_eviction_dates_instance)
+        allow(view_eviction_dates_instance).to receive(:execute)
+          .with(tenancy_ref: tenancy_ref)
+          .and_return(eviction_dates_array)
+      end
+
+      it 'calls ViewEvictionDates and renders its response' do
+        get "/api/v1/eviction_dates/#{tenancy_ref}"
+
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response['evictionDates'].count).to eq(3)
+        parsed_response['evictionDates'].each do |court_case|
+          expect(court_case['tenancyRef']).to eq(tenancy_ref)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
This endpoint will allow users to view eviction dates that have been added onto a tenancy
## Changes in this pull request
<!-- List all the changes -->
- Add GET create eviction date endpoint to allow an eviction dates to be viewed
- Add ViewEvictionDates usecase
- Update API docs

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Again pretty similar to how the court cases implementation, unsure if its possible for a tenancy to have multiple eviction dates but followed how it is done for agreements and court cases
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-491
## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
