### PR TITLE
Allow rendering court outcome letter with variable or one-off payment agreement

### DIFF
--- a/app/models/hackney/income_collection/letter/court_outcome/with_terms.rb
+++ b/app/models/hackney/income_collection/letter/court_outcome/with_terms.rb
@@ -7,7 +7,8 @@ module Hackney
 
           MANDATORY_FIELDS = %i[balance_on_court_outcome_date amount agreement_frequency rent date_of_first_payment].freeze
 
-          attr_reader :balance_on_court_outcome_date, :instalment_amount, :agreement_frequency, :rent, :date_of_first_payment, :rent_charge, :total_amount_payable
+          attr_reader :balance_on_court_outcome_date, :instalment_amount, :agreement_frequency, :rent, :date_of_first_payment,
+                      :rent_charge, :total_amount_payable, :initial_payment_amount, :initial_payment_date
 
           def initialize(params)
             super(params)
@@ -21,6 +22,8 @@ module Hackney
             @date_of_first_payment = format_date(validated_params[:date_of_first_payment])
             @rent_charge = format('%.2f', calculate_rent(@rent, @agreement_frequency))
             @total_amount_payable = format('%.2f', calculate_total_amount_payable(@rent_charge, @instalment_amount))
+            @initial_payment_amount = format('%.2f', params[:initial_payment_amount]) unless params[:initial_payment_amount].nil?
+            @initial_payment_date = format_date(params[:initial_payment_date]) unless params[:initial_payment_date].nil?
           end
         end
       end

--- a/lib/hackney/pdf/templates/income/court_outcome_letter.erb
+++ b/lib/hackney/pdf/templates/income/court_outcome_letter.erb
@@ -18,7 +18,18 @@ Dear <%= @letter.title %> <%= @letter.surname %>,
 
   <% if @letter.formal_agreement %>
     <p>
-      The Court has decided that you must pay the Council the total amount of £<%= @letter.balance_on_court_outcome_date %> by instalments of £<%= @letter.instalment_amount %> <%= @letter.agreement_frequency %> in addition to your current rent. The current rent is £<%= @letter.rent %> per week. The total amount to be paid is £<%= @letter.total_amount_payable %>. The first payment must be made on or before <%= @letter.date_of_first_payment %>.
+      The Court has decided that you must pay the Council the total amount of £<%= @letter.balance_on_court_outcome_date %> by instalments of:
+      <ul class = "no_bullets">
+          <% unless @letter.initial_payment_amount.nil? %>
+            <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
+            <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
+          <% end %>
+          <li><%= @letter.agreement_frequency.
+                  capitalize %> rent: £<%= @letter.rent_charge %> </li>
+          <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+          <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
+          <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
+      </ul>    
     </p>
   <% end %>
 

--- a/lib/hackney/pdf/templates/income/court_outcome_letter.erb
+++ b/lib/hackney/pdf/templates/income/court_outcome_letter.erb
@@ -18,28 +18,27 @@ Dear <%= @letter.title %> <%= @letter.surname %>,
 
   <% if @letter.formal_agreement %>
     <p>
-      The Court has decided that you must pay the Council the total amount of £<%= @letter.balance_on_court_outcome_date %> by instalments of:
-      <ul class = "no_bullets">
-          <% if @letter.agreement_frequency == 'one_off' %>
-            <li>Amount towards the rent: £<%= @letter.rent_charge %> </li>
-            <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
-            <li>Total amount payable £<%= @letter.total_amount_payable %></li>
-            <li>Date of payment: <%= @letter.date_of_first_payment %> </li>
-          <% else %>
-            <% unless @letter.initial_payment_amount.nil? %>
-              <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
-              <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
-            <% end %>
-            <li><%= @letter.agreement_frequency.
-                    capitalize %> rent: £<%= @letter.rent_charge %> </li>
-            <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
-            <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
-            <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
-          <% end %>
-      </ul>    
+      The Court has decided that you must pay the Council the total amount of £<%= @letter.balance_on_court_outcome_date %> by instalments of: 
     </p>
+    <ul class = "no_bullets">
+      <% if @letter.agreement_frequency == 'one_off' %>
+        <li>Amount towards the rent: £<%= @letter.rent_charge %> </li>
+        <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+        <li>Total amount payable £<%= @letter.total_amount_payable %></li>
+        <li>Date of payment: <%= @letter.date_of_first_payment %> </li>
+      <% else %>
+        <% unless @letter.initial_payment_amount.nil? %>
+          <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
+          <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
+        <% end %>
+        <li><%= @letter.agreement_frequency.
+                capitalize %> rent: £<%= @letter.rent_charge %> </li>
+        <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+        <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
+        <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
+      <% end %>
+    </ul>   
   <% end %>
-
   <p>
     The Court will send you a copy of the Order.
   </p>

--- a/lib/hackney/pdf/templates/income/court_outcome_letter.erb
+++ b/lib/hackney/pdf/templates/income/court_outcome_letter.erb
@@ -20,15 +20,22 @@ Dear <%= @letter.title %> <%= @letter.surname %>,
     <p>
       The Court has decided that you must pay the Council the total amount of £<%= @letter.balance_on_court_outcome_date %> by instalments of:
       <ul class = "no_bullets">
-          <% unless @letter.initial_payment_amount.nil? %>
-            <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
-            <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
+          <% if @letter.agreement_frequency == 'one_off' %>
+            <li>Amount towards the rent: £<%= @letter.rent_charge %> </li>
+            <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+            <li>Total amount payable £<%= @letter.total_amount_payable %></li>
+            <li>Date of payment: <%= @letter.date_of_first_payment %> </li>
+          <% else %>
+            <% unless @letter.initial_payment_amount.nil? %>
+              <li>Lump-sum payment amount: £<%= @letter.initial_payment_amount %> </li>
+              <li>Lump-sum payment date: <%= @letter.initial_payment_date %> </li>
+            <% end %>
+            <li><%= @letter.agreement_frequency.
+                    capitalize %> rent: £<%= @letter.rent_charge %> </li>
+            <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
+            <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
+            <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
           <% end %>
-          <li><%= @letter.agreement_frequency.
-                  capitalize %> rent: £<%= @letter.rent_charge %> </li>
-          <li>Amount towards the arrears: £<%= @letter.instalment_amount %> </li>
-          <li>Total amount payable £<%= @letter.total_amount_payable %> <%= @letter.agreement_frequency %></li>
-          <li>Date of first <%= @letter.agreement_frequency %> payment: <%= @letter.date_of_first_payment %> </li>
       </ul>    
     </p>
   <% end %>

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -359,6 +359,17 @@ describe Hackney::PDF::IncomePreview do
           expect(rendered_letter[:preview]).to include("Date of first #{agreement.frequency} payment: #{agreement.start_date.strftime('%d %B %Y')}")
         end
       end
+
+      context 'when it has a one_off payment agreement' do
+        let(:frequency) { :one_off }
+
+        it 'renders the right content' do
+          expect(rendered_letter[:preview]).to include("Amount towards the rent: £#{weekly_rent}")
+          expect(rendered_letter[:preview]).to include("Amount towards the arrears: £#{agreement.amount}")
+          expect(rendered_letter[:preview]).to include("Total amount payable £#{format('%.2f', agreement.amount + weekly_rent)}")
+          expect(rendered_letter[:preview]).to include("Date of payment: #{agreement.start_date.strftime('%d %B %Y')}")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context
We want to be able to render the payment details for formal variable payment agreements or formal one-off payment agreements when sending a court outcome letter.

## Changes in this pull request
- Allow rendering court outcome with variable payment agreements
- Allow rendering court outcome letter with a one-off payment agreement

![image](https://user-images.githubusercontent.com/22743709/93610452-fce51800-f9c4-11ea-8e7e-75a2cf4e0758.png)
![image](https://user-images.githubusercontent.com/22743709/93611100-c65bcd00-f9c5-11ea-9624-32428ca6711a.png)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-497

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
