### PR TITLE
use stored eviction date

### DIFF
--- a/lib/hackney/income/tenancy_classification/helpers.rb
+++ b/lib/hackney/income/tenancy_classification/helpers.rb
@@ -10,7 +10,7 @@ module Hackney
         end
 
         def case_has_eviction_date?
-          @criteria.eviction_date.present?
+          eviction_date.present?
         end
 
         def should_prevent_action?

--- a/lib/hackney/income/tenancy_classification/helpers/helpers_base.rb
+++ b/lib/hackney/income/tenancy_classification/helpers/helpers_base.rb
@@ -10,6 +10,10 @@ module Hackney
           def most_recent_court_case
             @most_recent_court_case ||= Hackney::Income::Models::CourtCase.where(tenancy_ref: @criteria.tenancy_ref).last
           end
+
+          def eviction_date
+            @eviction_date ||= Hackney::Income::Models::Eviction.where(tenancy_ref: @criteria.tenancy_ref).last&.date
+          end
         end
       end
     end

--- a/lib/hackney/income/worktray_item_gateway.rb
+++ b/lib/hackney/income/worktray_item_gateway.rb
@@ -3,10 +3,12 @@ module Hackney
     class WorktrayItemGateway
       GatewayModel = Hackney::Income::Models::CasePriority
       CourtCaseModel = Hackney::Income::Models::CourtCase
+      EvictionModel = Hackney::Income::Models::Eviction
 
       def store_worktray_item(tenancy_ref:, criteria:, classification:)
         gateway_model_instance = GatewayModel.find_or_initialize_by(tenancy_ref: tenancy_ref)
         court_case = CourtCaseModel.where(tenancy_ref: tenancy_ref).last
+        eviction = EvictionModel.where(tenancy_ref: tenancy_ref).last
 
         begin
           gateway_model_instance.tap do |tenancy|
@@ -24,7 +26,7 @@ module Hackney
               patch_code: criteria.patch_code,
               courtdate: court_case&.court_date,
               court_outcome: court_case&.court_outcome,
-              eviction_date: criteria.eviction_date,
+              eviction_date: eviction&.date,
               universal_credit: criteria.universal_credit,
               uc_rent_verification: criteria. uc_rent_verification,
               uc_direct_payment_requested: criteria.uc_direct_payment_requested,

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -42,6 +42,7 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
   let(:case_priority) { build(:case_priority, is_paused_until: is_paused_until) }
   let(:agreement_model) { Hackney::Income::Models::Agreement }
   let(:court_case_model) { Hackney::Income::Models::CourtCase }
+  let(:eviction_model) { Hackney::Income::Models::Eviction }
 
   let(:attributes) do
     {
@@ -91,6 +92,8 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
                                                   terms: terms)
         end
 
+        eviction = build_stubbed(:eviction, tenancy_ref: criteria.tenancy_ref, date: eviction_date) if eviction_date.present?
+
         if most_recent_agreement.present?
           agreement_type = court_case.present? ? :formal : :informal
           state = most_recent_agreement[:breached] == true ? :breached : :live
@@ -106,6 +109,7 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
 
         allow(court_case_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([court_case])
         allow(agreement_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([agreement])
+        allow(eviction_model).to receive(:where).with(tenancy_ref: criteria.tenancy_ref).and_return([eviction])
       end
 
       if options[:outcome]


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
use the sorted eviction date when classifying it

## Changes in this pull request
<!-- List all the changes -->
- fetch the eviction date stored in the DB while classifying and storing a worktray item 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-494

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
