### PR TITLE
Use court breach visit action code in classifier

### DIFF
--- a/lib/hackney/income/tenancy_classification/rulesets/address_court_agreement_breach.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/address_court_agreement_breach.rb
@@ -19,7 +19,7 @@ module Hackney
           def valid_actions_to_address_court_agreement_breach
             [
               Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
-              Hackney::Tenancy::ActionCodes::VISIT_MADE
+              Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE
             ]
           end
         end

--- a/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment.rb
@@ -21,7 +21,7 @@ module Hackney
 
           def valid_actions_for_court_breach_no_payment
             [
-              Hackney::Tenancy::ActionCodes::VISIT_MADE
+              Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE
             ]
           end
         end

--- a/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter.rb
@@ -15,7 +15,7 @@ module Hackney
             return false if @criteria.last_communication_action.in?([
               Hackney::Tenancy::ActionCodes::INFORMAL_BREACH_LETTER_SENT,
               Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
-              Hackney::Tenancy::ActionCodes::VISIT_MADE
+              Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE
             ])
 
             if @criteria.last_communication_date.present?

--- a/lib/hackney/tenancy/action_codes.rb
+++ b/lib/hackney/tenancy/action_codes.rb
@@ -57,6 +57,7 @@ module Hackney
       STAGE_THREE_COMPLETE = 'ZR3'.freeze
 
       VISIT_MADE = 'VIM'.freeze
+      COURT_BREACH_VISIT_MADE = 'CBV'.freeze
 
       WARRANT_OF_POSSESSION = 'WPA'.freeze
 

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
@@ -10,7 +10,7 @@ describe '"Court Breach - No Payment" examples' do
     nosp_served_date: 8.months.ago.to_date,
     courtdate: 14.days.ago.to_date,
     court_outcome: 'Jail',
-    last_communication_action: Hackney::Tenancy::ActionCodes::VISIT_MADE,
+    last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE,
     last_communication_date: 8.days.ago.to_date,
     days_since_last_payment: 8,
     most_recent_agreement: {

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
@@ -29,7 +29,7 @@ describe 'Send Court Breach Letter Rule', type: :feature do
     base_example.merge(
       description: 'with a last_communication_action which is NOT a court_breach_letter_code',
       outcome: :no_action,
-      last_communication_action: Hackney::Tenancy::ActionCodes::VISIT_MADE
+      last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE
     ),
     base_example.deep_merge(
       description: 'when there is no agreement',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
@@ -40,6 +40,13 @@ describe 'Various "Send breach letter" examples (new)' do
       court_outcome: 'something'
     ),
     base_example.merge(
+      description: 'with a last_communication_action which is visit made',
+      outcome: :address_court_agreement_breach,
+      courtdate: 4.months.ago,
+      court_outcome: 'something',
+      last_communication_action: Hackney::Tenancy::ActionCodes::VISIT_MADE
+    ),
+    base_example.merge(
       description: 'with the last communication being a court breach letter',
       outcome: :no_action,
       last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -39,7 +39,7 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
   }
 
   let(:criteria) { Stubs::StubCriteria.new(attributes) }
-  let(:case_priority) { build(:case_priority, is_paused_until: is_paused_until) }
+  let(:case_priority) { build_stubbed(:case_priority, is_paused_until: is_paused_until) }
   let(:agreement_model) { Hackney::Income::Models::Agreement }
   let(:court_case_model) { Hackney::Income::Models::CourtCase }
   let(:eviction_model) { Hackney::Income::Models::Eviction }


### PR DESCRIPTION
## Context
The current Visit Made action can be used for other visits than court breach visits, therefore we shouldn't use this for determining the next recommended action for court breaches.

## Changes in this pull request
- Add a more specific Court Breach Visit Made action code in classification rules

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-520

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
