### PR TITLE
Write to action diary and sync when court case created

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -23,11 +23,10 @@ class CourtCasesController < ApplicationController
       balance_on_court_outcome_date: create_court_case_params[:balance_on_court_outcome_date],
       strike_out_date: create_court_case_params[:strike_out_date],
       terms: create_court_case_params[:terms],
-      disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim],
-      username: create_court_case_params[:username]
+      disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim]
     }
 
-    new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)
+    new_court_case = income_use_case_factory.create_court_case_and_sync.execute(court_case_params: court_case_params, username: create_court_case_params[:username])
     response = map_court_case_to_response(court_case: new_court_case)
 
     render json: response

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -12,7 +12,7 @@ class CourtCasesController < ApplicationController
   end
 
   def create
-    parameters = %i[tenancy_ref court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim].freeze
+    parameters = %i[tenancy_ref court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim username].freeze
 
     create_court_case_params = params.permit(parameters)
 
@@ -23,7 +23,8 @@ class CourtCasesController < ApplicationController
       balance_on_court_outcome_date: create_court_case_params[:balance_on_court_outcome_date],
       strike_out_date: create_court_case_params[:strike_out_date],
       terms: create_court_case_params[:terms],
-      disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim]
+      disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim],
+      username: create_court_case_params[:username]
     }
 
     new_court_case = income_use_case_factory.create_court_case.execute(court_case_params: court_case_params)

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -1,10 +1,6 @@
 module Hackney
   module Income
     class CreateCourtCase
-      def initialize(add_action_diary_and_sync_case:)
-        @add_action_diary_and_sync_case = add_action_diary_and_sync_case
-      end
-
       def execute(court_case_params:)
         params = {
           tenancy_ref: court_case_params[:tenancy_ref],
@@ -17,13 +13,6 @@ module Hackney
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)
-
-        @add_action_diary_and_sync_case.execute(
-          tenancy_ref: court_case_params[:tenancy_ref],
-          action_code: Hackney::Tenancy::ActionCodes::COURT_DATE_SET,
-          comment: 'Court case created',
-          username: court_case_params[:username]
-        )
 
         court_case
       end

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -1,6 +1,10 @@
 module Hackney
   module Income
     class CreateCourtCase
+      def initialize(add_action_diary_and_sync_case:)
+        @add_action_diary_and_sync_case = add_action_diary_and_sync_case
+      end
+
       def execute(court_case_params:)
         params = {
           tenancy_ref: court_case_params[:tenancy_ref],
@@ -13,6 +17,14 @@ module Hackney
         }
 
         court_case = Hackney::Income::Models::CourtCase.create!(params)
+
+        @add_action_diary_and_sync_case.execute(
+          tenancy_ref: court_case_params[:tenancy_ref],
+          action_code: Hackney::Tenancy::ActionCodes::COURT_DATE_SET,
+          comment: 'Court case created',
+          username: court_case_params[:username]
+        )
+
         court_case
       end
     end

--- a/lib/hackney/income/create_court_case_and_sync.rb
+++ b/lib/hackney/income/create_court_case_and_sync.rb
@@ -1,0 +1,35 @@
+module Hackney
+  module Income
+    class CreateCourtCaseAndSync
+      def initialize(create_court_case:, add_action_diary_and_sync_case_usecase:)
+        @create_court_case = create_court_case
+        @add_action_diary_and_sync_case_usecase = add_action_diary_and_sync_case_usecase
+      end
+
+      def execute(court_case_params:, username: nil)
+        params = {
+          tenancy_ref: court_case_params[:tenancy_ref],
+          court_date: court_case_params[:court_date],
+          court_outcome: court_case_params[:court_outcome],
+          balance_on_court_outcome_date: court_case_params[:balance_on_court_outcome_date],
+          strike_out_date: court_case_params[:strike_out_date],
+          terms: court_case_params[:terms],
+          disrepair_counter_claim: court_case_params[:disrepair_counter_claim]
+        }
+
+        court_case = @create_court_case.execute(court_case_params: params)
+
+        if username
+          @add_action_diary_and_sync_case_usecase.execute(
+            tenancy_ref: court_case_params[:tenancy_ref],
+            action_code: Hackney::Tenancy::ActionCodes::COURT_DATE_SET,
+            comment: 'Court case created',
+            username: username
+          )
+        end
+
+        court_case
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -279,10 +279,15 @@ module Hackney
         Hackney::Income::CancelAgreement.new
       end
 
-      def create_court_case
-        Hackney::Income::CreateCourtCase.new(
-          add_action_diary_and_sync_case: add_action_diary_and_sync_case
+      def create_court_case_and_sync
+        Hackney::Income::CreateCourtCaseAndSync.new(
+          create_court_case: create_court_case,
+          add_action_diary_and_sync_case_usecase: add_action_diary_and_sync_case
         )
+      end
+
+      def create_court_case
+        Hackney::Income::CreateCourtCase.new
       end
 
       def view_court_cases

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -280,7 +280,9 @@ module Hackney
       end
 
       def create_court_case
-        Hackney::Income::CreateCourtCase.new
+        Hackney::Income::CreateCourtCase.new(
+          add_action_diary_and_sync_case: add_action_diary_and_sync_case
+        )
       end
 
       def view_court_cases

--- a/spec/lib/hackney/income/create_court_case_and_sync_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_and_sync_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe Hackney::Income::CreateCourtCaseAndSync do
+  subject {
+    described_class.new(
+      create_court_case: create_court_case,
+      add_action_diary_and_sync_case_usecase: add_action_diary_and_sync_case_usecase
+    )
+  }
+
+  let(:add_action_diary_and_sync_case_usecase) { double(UseCases::AddActionDiaryAndSyncCase) }
+  let(:create_court_case) { double(Hackney::Income::CreateCourtCase) }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS }
+  let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:strike_out_date) { Faker::Date.forward(days: 365) }
+  let(:terms) { [true, false].sample }
+  let(:disrepair_counter_claim) { [true, false].sample }
+  let(:username) { Faker::Name.name }
+
+  let(:new_court_case_params) do
+    {
+      tenancy_ref: tenancy_ref,
+      court_date: court_date,
+      court_outcome: court_outcome,
+      balance_on_court_outcome_date: balance_on_court_outcome_date,
+      strike_out_date: strike_out_date,
+      terms: terms,
+      disrepair_counter_claim: disrepair_counter_claim
+    }
+  end
+
+  context 'when a username is provided' do
+    it 'calls the create court date usecase and adds to the action diary and re-syncs the case' do
+      expect(add_action_diary_and_sync_case_usecase).to receive(:execute).with(
+        tenancy_ref: tenancy_ref,
+        action_code: 'CDS',
+        comment: 'Court case created',
+        username: username
+      )
+
+      expect(create_court_case).to receive(:execute).with(court_case_params: new_court_case_params)
+
+      subject.execute(court_case_params: new_court_case_params, username: username)
+    end
+  end
+
+  it 'creates and returns a new court date' do
+    expect(add_action_diary_and_sync_case_usecase).not_to receive(:execute).with(
+      tenancy_ref: tenancy_ref,
+      action_code: 'CDS',
+      comment: 'Court case created',
+      username: username
+    )
+
+    expect(create_court_case).to receive(:execute).with(court_case_params: new_court_case_params)
+
+    subject.execute(court_case_params: new_court_case_params)
+  end
+end

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Hackney::Income::CreateCourtCase do
-  subject { described_class.new }
+  subject { described_class.new(add_action_diary_and_sync_case: add_action_diary_and_sync_case) }
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
@@ -10,6 +10,9 @@ describe Hackney::Income::CreateCourtCase do
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
   let(:terms) { [true, false].sample }
   let(:disrepair_counter_claim) { [true, false].sample }
+  let(:username) { Faker::Name.name }
+
+  let(:add_action_diary_and_sync_case) { spy }
 
   let(:new_court_case_params) do
     {
@@ -19,8 +22,20 @@ describe Hackney::Income::CreateCourtCase do
       balance_on_court_outcome_date: balance_on_court_outcome_date,
       strike_out_date: strike_out_date,
       terms: terms,
-      disrepair_counter_claim: disrepair_counter_claim
+      disrepair_counter_claim: disrepair_counter_claim,
+      username: username
     }
+  end
+
+  it 'calls the add_action_diary_and_sync_case when a new court case is created' do
+    subject.execute(court_case_params: new_court_case_params)
+
+    expect(add_action_diary_and_sync_case).to have_received(:execute).with(
+      tenancy_ref: tenancy_ref,
+      action_code: 'CDS',
+      comment: 'Court case created',
+      username: username
+    )
   end
 
   it 'creates and returns a new court case' do

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Hackney::Income::CreateCourtCase do
-  subject { described_class.new(add_action_diary_and_sync_case: add_action_diary_and_sync_case) }
+  subject { described_class.new }
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
@@ -10,9 +10,6 @@ describe Hackney::Income::CreateCourtCase do
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
   let(:terms) { [true, false].sample }
   let(:disrepair_counter_claim) { [true, false].sample }
-  let(:username) { Faker::Name.name }
-
-  let(:add_action_diary_and_sync_case) { spy }
 
   let(:new_court_case_params) do
     {
@@ -22,20 +19,8 @@ describe Hackney::Income::CreateCourtCase do
       balance_on_court_outcome_date: balance_on_court_outcome_date,
       strike_out_date: strike_out_date,
       terms: terms,
-      disrepair_counter_claim: disrepair_counter_claim,
-      username: username
+      disrepair_counter_claim: disrepair_counter_claim
     }
-  end
-
-  it 'calls the add_action_diary_and_sync_case when a new court case is created' do
-    subject.execute(court_case_params: new_court_case_params)
-
-    expect(add_action_diary_and_sync_case).to have_received(:execute).with(
-      tenancy_ref: tenancy_ref,
-      action_code: 'CDS',
-      comment: 'Court case created',
-      username: username
-    )
   end
 
   it 'creates and returns a new court case' do

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'CourtCases', type: :request do
   describe 'POST /api/v1/court_case/{tenancy_ref}' do
     path '/court_case/{tenancy_ref}' do
       context 'when creating a new court case by adding a court date'
-      let(:create_court_case_instance) { instance_double(Hackney::Income::CreateCourtCase) }
+      let(:create_court_case_and_sync_instance) { instance_double(Hackney::Income::CreateCourtCaseAndSync) }
       let(:username) { Faker::Name.name }
       let(:new_court_case_params) do
         {
@@ -30,22 +30,22 @@ RSpec.describe 'CourtCases', type: :request do
           balance_on_court_outcome_date: nil,
           strike_out_date: nil,
           terms: nil,
-          disrepair_counter_claim: nil,
-          username: username
+          disrepair_counter_claim: nil
+
         }
       end
 
       let(:created_court_case) { create(:court_case, new_court_case_params) }
 
       before do
-        allow(Hackney::Income::CreateCourtCase).to receive(:new).and_return(create_court_case_instance)
-        allow(create_court_case_instance).to receive(:execute)
-          .with(court_case_params: new_court_case_params)
+        allow(Hackney::Income::CreateCourtCaseAndSync).to receive(:new).and_return(create_court_case_and_sync_instance)
+        allow(create_court_case_and_sync_instance).to receive(:execute)
+          .with(court_case_params: new_court_case_params, username: username)
           .and_return(created_court_case)
       end
 
       it 'creates a new active court_case for the given tenancy_ref' do
-        post "/api/v1/court_case/#{tenancy_ref}", params: new_court_case_params
+        post "/api/v1/court_case/#{tenancy_ref}", params: new_court_case_params.merge(username: username)
 
         parsed_response = JSON.parse(response.body)
 

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'CourtCases', type: :request do
     path '/court_case/{tenancy_ref}' do
       context 'when creating a new court case by adding a court date'
       let(:create_court_case_instance) { instance_double(Hackney::Income::CreateCourtCase) }
+      let(:username) { Faker::Name.name }
       let(:new_court_case_params) do
         {
           tenancy_ref: tenancy_ref,
@@ -29,7 +30,8 @@ RSpec.describe 'CourtCases', type: :request do
           balance_on_court_outcome_date: nil,
           strike_out_date: nil,
           terms: nil,
-          disrepair_counter_claim: nil
+          disrepair_counter_claim: nil,
+          username: username
         }
       end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When a court case is created it should be written to the action diary that one has been created and should re-sync the case

This is the first slice
## Changes in this pull request
<!-- List all the changes -->

- Add `add_action_diary_and_sync_case` usecase to `create_court_case` usecase to allow adding to the action diary and re-syncing when a case is created

- `court_cases_controller` now gets the username from the request

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
The action diary message is quite basic, is it missing anything?
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-521
## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
