### PR TITLE
Tighten some of the classification rules

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -34,6 +34,17 @@ module Hackney
           COURT_OUTCOMES_THAT_CAN_HAVE_TERMS.include?(court_outcome)
         end
 
+        def result_in_agreement?
+          terms.present? && !expired?
+        end
+
+        def expired?
+          return true if struck_out?
+          return true if end_of_life?
+
+          false
+        end
+
         private
 
         def court_outcome_is_valid
@@ -45,6 +56,16 @@ module Hackney
 
         def update_associated_worktray_item
           Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)&.update!(court_outcome: court_outcome, courtdate: court_date)
+        end
+
+        def struck_out?
+          strike_out_date.present? && strike_out_date.to_date <= Date.today
+        end
+
+        def end_of_life?
+          return false if court_date.nil?
+
+          court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
         end
       end
     end

--- a/lib/hackney/income/tenancy_classification/helpers/agreement_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/helpers/agreement_helpers.rb
@@ -10,7 +10,7 @@ module Hackney
           end
 
           def informal_breached_agreement?
-            breached_agreement? && !court_breach_agreement?
+            breached_agreement? && most_recent_agreement&.informal?
           end
 
           def breached_agreement?

--- a/lib/hackney/income/tenancy_classification/rulesets/check_data.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/check_data.rb
@@ -16,7 +16,16 @@ module Hackney
             # Cases with court outcomes must have court dates recorded
             return true if !case_paused? && no_court_date? && court_outcome.present?
 
+            # Cases with court case that should have agreement
+            return true if !case_paused? && court_agreement_missing?
+
             false
+          end
+
+          def court_agreement_missing?
+            return false unless most_recent_court_case.present? && most_recent_court_case.result_in_agreement?
+            return true unless most_recent_agreement.present? && most_recent_agreement.formal?
+            most_recent_agreement.start_date < most_recent_court_case.court_date
           end
         end
       end

--- a/spec/lib/hackney/income/tenancy_classification/helpers/agreement_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/helpers/agreement_helpers_spec.rb
@@ -135,10 +135,9 @@ describe Hackney::Income::TenancyClassification::Helpers::AgreementHelpers do
     end
 
     context 'when agreemnt is not court ordered and it breached' do
-      it 'returns false' do
-        allow(helpers).to receive(:court_breach_agreement?).and_return(false)
-        allow(helpers).to receive(:breached_agreement?).and_return(true)
+      let(:most_recent_agreement) { { start_date: 1.week.ago, state: :breached, agreement_type: :informal } }
 
+      it 'returns true' do
         expect(subject).to eq(true)
       end
     end

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
@@ -8,7 +8,7 @@ describe 'Check Data examples' do
       outcome: :check_data,
       active_agreement: false,
       courtdate: 1.week.ago,
-      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ), base_example.merge(
       desription: 'No action when there is no court warrant',
       outcome: :no_action,
@@ -20,13 +20,13 @@ describe 'Check Data examples' do
       is_paused_until: 1.day.from_now.to_date,
       active_agreement: false,
       courtdate: 1.week.ago,
-      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ), base_example.merge(
-      desription: 'No action when there is an old court warrant, without an agreement, and not paused',
+      desription: 'No action when there is an old court warrant(SUSPENSION_ON_TERMS has 6 years life), without an agreement, and not paused',
       outcome: :no_action,
       active_agreement: false,
       courtdate: 11.years.ago,
-      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
     ), base_example.merge(
       desription: 'No action when there is an not an active court warrant',
       outcome: :no_action,
@@ -36,7 +36,7 @@ describe 'Check Data examples' do
       description: 'Check Data when case has court outcome but no court date',
       outcome: :check_data,
       courtdate: nil,
-      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     )
   ]
   it_behaves_like 'TenancyClassification', examples

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
@@ -9,7 +9,7 @@ describe '"Court Breach - No Payment" examples' do
     balance: 15.0,
     nosp_served_date: 8.months.ago.to_date,
     courtdate: 14.days.ago.to_date,
-    court_outcome: 'Jail',
+    court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
     last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE,
     last_communication_date: 8.days.ago.to_date,
     days_since_last_payment: 8,
@@ -34,6 +34,7 @@ describe '"Court Breach - No Payment" examples' do
     base_example.deep_merge(
       description: 'when there is no agreement',
       outcome: :no_action,
+      court_outcome: 'No agreement outcome',
       most_recent_agreement: nil
     ),
     base_example.deep_merge(
@@ -51,6 +52,7 @@ describe '"Court Breach - No Payment" examples' do
     base_example.deep_merge(
       description: 'when the court date is in the future',
       outcome: :no_action,
+      court_outcome: nil,
       courtdate: 3.months.from_now.to_date
     ),
     base_example.deep_merge(

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
@@ -8,7 +8,7 @@ describe 'Send Court Breach Letter Rule', type: :feature do
     balance: 15.0, # 3 * weekly_rent
     collectable_arrears: 15.0, # 3 * weekly_rent
     active_agreement: false,
-    court_outcome: 'Jail',
+    court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
     last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
     last_communication_date: 2.weeks.ago,
     courtdate: 14.days.ago.to_date,
@@ -34,6 +34,7 @@ describe 'Send Court Breach Letter Rule', type: :feature do
     base_example.deep_merge(
       description: 'when there is no agreement',
       outcome: :no_action,
+      court_outcome: 'no agreement needed',
       most_recent_agreement: nil
     ),
     base_example.deep_merge(

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
@@ -21,42 +21,52 @@ describe 'Various "Send breach letter" examples (new)' do
       outcome: :no_action,
       most_recent_agreement: { start_date: nil }
     ),
-    base_example.merge(
+    base_example.deep_merge(
       description: 'with a court date after the agreement',
       outcome: :send_informal_agreement_breach_letter,
       courtdate: 1.day.ago,
-      court_outcome: 'something'
+      court_outcome: 'outcome with no court agreement'
     ),
     base_example.merge(
       description: 'with a court date before the agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: 'something'
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with a court date more than three months before the agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: 'something'
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with a last_communication_action which is visit made',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: 'something',
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       last_communication_action: Hackney::Tenancy::ActionCodes::VISIT_MADE
     ),
-    base_example.merge(
+    base_example.deep_merge(
       description: 'with a court date and agreement start date on the same day',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: 'something',
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       most_recent_agreement: {
         start_date: 2.weeks.ago,
         breached: true
       }
     ),
-    base_example.merge(
+    base_example.deep_merge(
+      description: 'with a court date and court agreement start date before court date',
+      outcome: :check_data,
+      courtdate: 2.weeks.ago,
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+      most_recent_agreement: {
+        start_date: 3.weeks.ago,
+        breached: true
+      }
+    ),
+    base_example.deep_merge(
       description: 'with the last communication being a court breach letter',
       outcome: :no_action,
       last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
@@ -31,22 +31,16 @@ describe 'Various "Send informal breach letter" examples (new)' do
       most_recent_agreement: { start_date: nil }
     ),
     base_example.merge(
-      description: 'with a court date after the agreement',
-      outcome: :send_informal_agreement_breach_letter,
-      courtdate: 1.day.ago,
-      court_outcome: 'something'
-    ),
-    base_example.merge(
-      description: 'with a court date before the agreement',
+      description: 'with a court date before the court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: 'something'
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
-      description: 'with a court date more than three months before the agreement',
+      description: 'with a court date more than three months before the court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: 'something'
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with the last communication being an informal breach letter',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
@@ -72,9 +72,10 @@ describe '"Update court outcome" examples' do
       courtdate: 367.days.from_now.to_date
     ),
     base_example.merge(
-      description: 'with no court outcome and breached court agreement',
+      description: 'with valid court outcome and breached court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 14.days.ago.to_date,
+      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       most_recent_agreement: {
         start_date: 1.week.ago,
         breached: true

--- a/spec/lib/hackney/income/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_criteria_spec.rb
@@ -99,7 +99,7 @@ describe Hackney::Income::UniversalHousingCriteria, universal: true do
     describe '#court_outcome' do
       subject { criteria.court_outcome }
 
-      let(:court_outcome) { 'AGE' }
+      let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE }
 
       it 'returns a court_outcome' do
         expect(subject).to eq(court_outcome)

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -79,7 +79,7 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
 
       before do
         if courtdate.present? || court_outcome.present?
-          if court_outcome.present? && court_outcome == 'AGE'
+          if court_outcome.present? && court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
             # We should update these on the examples once UH examples are decommissioned so we won't need this mapping
             disrepair_counter_claim = true
             terms = true
@@ -95,7 +95,7 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
         eviction = build_stubbed(:eviction, tenancy_ref: criteria.tenancy_ref, date: eviction_date) if eviction_date.present?
 
         if most_recent_agreement.present?
-          agreement_type = court_case.present? ? :formal : :informal
+          agreement_type = court_case.present? && court_case.result_in_agreement? ? :formal : :informal
           state = most_recent_agreement[:breached] == true ? :breached : :live
           agreement = build_stubbed(:agreement,
                                     agreement_type: agreement_type,


### PR DESCRIPTION
## Context
Noticed while fixing a classification bug, that informal agreement breach actions could have a tighter check

## Changes in this pull request
- Check if the agreement is informal in `informal agreement breach?` helper
- Show `:check_data` action when the court agreement is missing
