### PR TITLE
add action diary and sync after adding eviction date

### DIFF
--- a/app/controllers/evictions_controller.rb
+++ b/app/controllers/evictions_controller.rb
@@ -21,7 +21,7 @@ class EvictionsController < ApplicationController
       date: create_eviction_params[:date]
     }
 
-    new_eviction = income_use_case_factory.create_eviction.execute(eviction_params: eviction_params)
+    new_eviction = income_use_case_factory.create_eviction_and_sync.execute(eviction_params: eviction_params)
     response = map_eviction_to_response(eviction: new_eviction)
 
     render json: response

--- a/lib/hackney/income/create_eviction.rb
+++ b/lib/hackney/income/create_eviction.rb
@@ -8,6 +8,7 @@ module Hackney
         }
 
         eviction = Hackney::Income::Models::Eviction.create!(params)
+
         eviction
       end
     end

--- a/lib/hackney/income/create_eviction_and_sync.rb
+++ b/lib/hackney/income/create_eviction_and_sync.rb
@@ -1,0 +1,29 @@
+module Hackney
+  module Income
+    class CreateEvictionAndSync
+      def initialize(add_action_diary_and_sync_case:, create_eviction:)
+        @create_eviction = create_eviction
+        @add_action_diary_and_sync_case = add_action_diary_and_sync_case
+      end
+
+      def execute(eviction_params:, username: nil)
+        params = {
+          tenancy_ref: eviction_params[:tenancy_ref],
+          date: eviction_params[:date]
+        }
+        eviction = @create_eviction.execute(eviction_params: params)
+
+        if username
+          @add_action_diary_and_sync_case.execute(
+            tenancy_ref: eviction_params[:tenancy_ref],
+            action_code: Hackney::Tenancy::ActionCodes::EVICTION_DATE_SET,
+            comment: "Eviction date set to #{eviction_params[:date]}",
+            username: username
+          )
+        end
+
+        eviction
+      end
+    end
+  end
+end

--- a/lib/hackney/income/migrate_uh_eviction.rb
+++ b/lib/hackney/income/migrate_uh_eviction.rb
@@ -27,7 +27,7 @@ module Hackney
           return
         end
 
-        return unless uh_eviction.present? && existing_evictions.last.eviction_date < uh_eviction
+        return unless uh_eviction.present? && existing_evictions.last.date < uh_eviction
 
         Rails.logger.info { "UH eviction is older than existing MA date, adding newer eviction for tenancy ref #{criteria.tenancy_ref}" }
         eviction_params = map_criteria_to_eviction_params(criteria).merge(tenancy_ref: criteria.tenancy_ref)

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -291,6 +291,13 @@ module Hackney
         Hackney::Income::UpdateCourtCase.new
       end
 
+      def create_eviction_and_sync
+        Hackney::Income::CreateEvictionAndSync.new(
+          create_eviction: create_eviction,
+          add_action_diary_and_sync_case: add_action_diary_and_sync_case
+        )
+      end
+
       def create_eviction
         Hackney::Income::CreateEviction.new
       end

--- a/spec/hackney/income/migrate_uh_eviction_spec.rb
+++ b/spec/hackney/income/migrate_uh_eviction_spec.rb
@@ -37,8 +37,8 @@ describe Hackney::Income::MigrateUhEviction do
   context 'when there are multiple evictions in MA' do
     let(:existing_evictions) {
       [
-        OpenStruct.new(eviction_date: DateTime.now.midnight - 1.month),
-        OpenStruct.new(eviction_date: DateTime.now.midnight - 7.days)
+        create(:eviction, date: DateTime.now.midnight - 1.month),
+        create(:eviction, date: DateTime.now.midnight - 7.days)
       ]
     }
 

--- a/spec/lib/hackney/income/create_eviction_and_sync_spec.rb
+++ b/spec/lib/hackney/income/create_eviction_and_sync_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Hackney::Income::CreateEvictionAndSync do
+  subject {
+    described_class.new(
+      add_action_diary_and_sync_case: add_action_diary_and_sync_case_usecase,
+      create_eviction: create_eviction_usecase
+    )
+  }
+
+  let(:add_action_diary_and_sync_case_usecase) { double(UseCases::AddActionDiaryAndSyncCase) }
+  let(:create_eviction_usecase) { double(Hackney::Income::CreateEviction) }
+
+  let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
+  let(:date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:username) { Faker::TvShows::StrangerThings.character }
+
+  let(:new_eviction_params) do
+    {
+      tenancy_ref: tenancy_ref,
+      date: date
+    }
+  end
+
+  context 'when a username is provided' do
+    it 'calls create date usecase and adds an action diary and sync' do
+      expect(add_action_diary_and_sync_case_usecase).to receive(:execute).with(
+        tenancy_ref: tenancy_ref,
+        action_code: 'EDS',
+        comment: "Eviction date set to #{date}",
+        username: username
+      )
+
+      expect(create_eviction_usecase).to receive(:execute).with(
+        eviction_params: new_eviction_params
+      )
+
+      subject.execute(eviction_params: new_eviction_params, username: username)
+    end
+  end
+
+  it 'creates and returns a new eviction date' do
+    expect(add_action_diary_and_sync_case_usecase).not_to receive(:execute).with(
+      tenancy_ref: tenancy_ref,
+      action_code: 'EDS',
+      comment: "Eviction date set to #{date}",
+      username: username
+    )
+
+    expect(create_eviction_usecase).to receive(:execute).with(
+      eviction_params: new_eviction_params
+    )
+
+    subject.execute(eviction_params: new_eviction_params)
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
we need to resync the case when an eviction date is added so that the case could be reclassified 

## Changes in this pull request
<!-- List all the changes -->
added a new usecase that will save the date, add the action diary and sync the case

also fixed the eviction date migration bug https://sentry.io/organizations/london-borough-of-hackney/issues/1910471839/?project=1276456&query=is%3Aunresolved

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&modal=detail&selectedIssue=MAAP-523

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
