### PR TITLE
Support unmapped uh frequency codes

### DIFF
--- a/lib/hackney/income/migrate_uh_agreement.rb
+++ b/lib/hackney/income/migrate_uh_agreement.rb
@@ -132,51 +132,63 @@ module Hackney
       end
 
       def get_frequency(uh_frequency)
-        frequency_mapping = [
+        case uh_frequency
+        when 0
           {
             description: 'Monthly',
-            uh_frequency: 0,
             ma_frequency: 1
-          }, {
+          }
+        when 1
+          {
             description: 'Weekly',
-            uh_frequency: 1,
             ma_frequency: 0
-          }, {
+          }
+        when 2
+          {
             description: '2 Weekly',
-            uh_frequency: 2,
             ma_frequency: 2
-          }, {
+          }
+        when 4
+          {
             description: '4 Weekly',
-            uh_frequency: 4,
             ma_frequency: 3
-          }, {
+          }
+        when 5
+          {
             description: '3 Monthly',
-            uh_frequency: 5,
-            ma_frequency: 4
-          }, {
-            description: '6 Monthly',
-            uh_frequency: 6,
-            ma_frequency: 4
-          }, {
-            description: 'Annually',
-            uh_frequency: 7,
-            ma_frequency: 4
-          }, {
-            description: 'Daily',
-            uh_frequency: 8,
-            ma_frequency: 4
-          }, {
-            description: 'Irregular',
-            uh_frequency: 9,
-            ma_frequency: 4
-          }, {
-            description: 'Quarterly',
-            uh_frequency: 'Q',
             ma_frequency: 4
           }
-        ]
-
-        frequency_mapping.find { |f| f[:uh_frequency] == uh_frequency }
+        when 6
+          {
+            description: '6 Monthly',
+            ma_frequency: 4
+          }
+        when 7
+          {
+            description: 'Annually',
+            ma_frequency: 4
+          }
+        when 8
+          {
+            description: 'Daily',
+            ma_frequency: 4
+          }
+        when 9
+          {
+            description: 'Irregular',
+            ma_frequency: 4
+          }
+        when 'Q'
+          {
+            description: 'Quarterly',
+            ma_frequency: 4
+          }
+        else
+          {
+            description: 'Unknown',
+            ma_frequency: 4
+          }
+        end
       end
 
       def get_state(uh_state)


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
There are some codes in UH that we haven't got mapped - while we should aim to add the unmapped ones, we should also be able to handle those that we do not have.


## Changes in this pull request
<!-- List all the changes -->
Use a case statement instead of a map, and have a default for those unknown ones.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://sentry.io/organizations/london-borough-of-hackney/issues/1883520536/?project=1276456&query=is%3Aunresolved

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
