### PR TITLE
Refactoring breach detector and renaming court outcome codes

### DIFF
--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -13,21 +13,21 @@ module Hackney
 
         COURT_OUTCOMES_THAT_CAN_HAVE_TERMS =
           [
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+            Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
+            Hackney::Tenancy::CourtOutcomeCodes::STAY_OF_EXECUTION
           ].freeze
 
         OTHER_COURT_OUTCOMES =
           [
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+            Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT,
+            Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+            Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+            Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
           ].freeze
 
         def can_have_terms?
@@ -52,7 +52,7 @@ module Hackney
         def end_of_life?
           return false if court_date.nil?
 
-          court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
+          court_outcome == Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
         end
 
         private

--- a/app/models/hackney/income/models/court_case.rb
+++ b/app/models/hackney/income/models/court_case.rb
@@ -45,6 +45,16 @@ module Hackney
           false
         end
 
+        def struck_out?
+          strike_out_date.present? && strike_out_date.to_date <= Date.today
+        end
+
+        def end_of_life?
+          return false if court_date.nil?
+
+          court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
+        end
+
         private
 
         def court_outcome_is_valid
@@ -56,16 +66,6 @@ module Hackney
 
         def update_associated_worktray_item
           Hackney::Income::Models::CasePriority.find_by(tenancy_ref: tenancy_ref)&.update!(court_outcome: court_outcome, courtdate: court_date)
-        end
-
-        def struck_out?
-          strike_out_date.present? && strike_out_date.to_date <= Date.today
-        end
-
-        def end_of_life?
-          return false if court_date.nil?
-
-          court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
         end
       end
     end

--- a/app/models/hackney/income_collection/letter/court_outcome.rb
+++ b/app/models/hackney/income_collection/letter/court_outcome.rb
@@ -61,8 +61,8 @@ module Hackney
 
           def outright_order?(params)
             [
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
             ].include?(params[:court_outcome])
           end
         end

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -82,19 +82,19 @@ module Hackney
         return nil if outcome.nil? || outcome.strip.empty?
 
         case outcome.strip
-        when Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION
+        when Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
-        when Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+        when Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
         when Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
-        when Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+        when Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
-        when Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+        when Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
         when Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
-        when Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
+        when Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_GENERALLY
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
         when Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
           Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE

--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -83,21 +83,21 @@ module Hackney
 
         case outcome.strip
         when Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
+          Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS
         when Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
-        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+        when Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT
+          Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT
         when Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+          Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
         when Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
-        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+          Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+        when Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+          Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
         when Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_GENERALLY
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
-        when Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+        when Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
         end
       end
 

--- a/lib/hackney/income/tenancy_classification/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/classifier.rb
@@ -61,9 +61,9 @@ module Hackney
 
         def active_agreement_court_outcomes
           [
-            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
-            Hackney::Tenancy::CourtOutcomeCodes::POSTPONED_POSSESSION,
-            Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::POSTPONED_POSSESSION,
+            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENDED_POSSESSION
           ]
         end
       end

--- a/lib/hackney/income/tenancy_classification/classifier.rb
+++ b/lib/hackney/income/tenancy_classification/classifier.rb
@@ -61,9 +61,9 @@ module Hackney
 
         def active_agreement_court_outcomes
           [
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::POSTPONED_POSSESSION,
-            Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENDED_POSSESSION
+            Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+            Hackney::Tenancy::CourtOutcomeCodes::POSTPONED_POSSESSION,
+            Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION
           ]
         end
       end

--- a/lib/hackney/income/tenancy_classification/helpers/court_case_helpers.rb
+++ b/lib/hackney/income/tenancy_classification/helpers/court_case_helpers.rb
@@ -11,12 +11,12 @@ module Hackney
             return false if most_recent_court_case.court_outcome.blank?
 
             if most_recent_court_case.court_outcome.in?([
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+              Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+              Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
+              Hackney::Tenancy::CourtOutcomeCodes::STAY_OF_EXECUTION
             ])
               return most_recent_court_case.court_date > 6.years.ago
             end

--- a/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant.rb
@@ -22,8 +22,8 @@ module Hackney
 
           def prerequisite_court_outcomes_for_action
             [
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
             ]
           end
 

--- a/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant.rb
+++ b/lib/hackney/income/tenancy_classification/rulesets/apply_for_outright_possession_warrant.rb
@@ -22,8 +22,8 @@ module Hackney
 
           def prerequisite_court_outcomes_for_action
             [
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-              Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+              Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
             ]
           end
 

--- a/lib/hackney/tenancy/action_codes.rb
+++ b/lib/hackney/tenancy/action_codes.rb
@@ -67,8 +67,8 @@ module Hackney
 
       C19_COURT_ORDER_BREACHED = 'CVB'.freeze
 
-      ADJOURNED_GENERALLY = Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY
-      ADJOURNED_ON_TERMS = Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
+      ADJOURNED_GENERALLY = Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_GENERALLY
+      ADJOURNED_ON_TERMS = Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS
       CHARGE_AGAINST_PROPERTY = 'CAP'.freeze
       COSTS_AWARDED = 'CAW'.freeze
       COURT_BREACH_LETTER = 'CBL'.freeze
@@ -92,10 +92,10 @@ module Hackney
       OFFICE_INTERVIEW = 'OFI'.freeze
       OUT_OF_HOURS_CALL = 'OOC'.freeze
       OUTGOING_TELEPHONE_CALL = 'OTC'.freeze
-      POSTPONED_POSSESSION = Hackney::Tenancy::CourtOutcomeCodes::POSTPONED_POSSESSION
+      POSTPONED_POSSESSION = Hackney::Tenancy::OldCourtOutcomeCodes::POSTPONED_POSSESSION
       PROMISE_OF_PAYMENT = 'POP'.freeze
       REFERRED_FOR_DEBT_ADVICE = 'DEB'.freeze
-      SUSPENDED_POSSESSION = Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION
+      SUSPENDED_POSSESSION = Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION
       UNIVERSAL_CREDIT = 'UCC'.freeze
       UNSUCCESSFUL_VISIT = 'VIU'.freeze
 

--- a/lib/hackney/tenancy/court_outcome_codes.rb
+++ b/lib/hackney/tenancy/court_outcome_codes.rb
@@ -1,6 +1,6 @@
 module Hackney
   module Tenancy
-    module UpdatedCourtOutcomeCodes
+    module CourtOutcomeCodes
       ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE = 'AGP'.freeze
       ADJOURNED_TO_NEXT_OPEN_DATE = 'AND'.freeze
       ADJOURNED_TO_ANOTHER_HEARING_DATE = 'AAH'.freeze

--- a/lib/hackney/tenancy/court_outcome_codes.rb
+++ b/lib/hackney/tenancy/court_outcome_codes.rb
@@ -1,6 +1,8 @@
 module Hackney
   module Tenancy
     module CourtOutcomeCodes
+      # These are the legacy outcome codes from UH, should not be used other than migrating old agreement data from UH
+
       OUTRIGHT_POSSESSION_WITH_DATE = 'OPD'.freeze
       OUTRIGHT_POSSESSION_FORTHWITH = 'OPF'.freeze
 

--- a/lib/hackney/tenancy/old_court_outcome_codes.rb
+++ b/lib/hackney/tenancy/old_court_outcome_codes.rb
@@ -1,6 +1,6 @@
 module Hackney
   module Tenancy
-    module CourtOutcomeCodes
+    module OldCourtOutcomeCodes
       # These are the legacy outcome codes from UH, should not be used other than migrating old agreement data from UH
 
       OUTRIGHT_POSSESSION_WITH_DATE = 'OPD'.freeze

--- a/spec/factories/court_case.rb
+++ b/spec/factories/court_case.rb
@@ -6,17 +6,17 @@ FactoryBot.define do
     strike_out_date { Faker::Date.forward(days: 365) }
     court_outcome do
       [
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-        Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+        Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
+        Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT,
+        Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+        Hackney::Tenancy::CourtOutcomeCodes::STAY_OF_EXECUTION,
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+        Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+        Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
       ].sample
     end
     terms { [true, false].sample if can_have_terms? }

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -5,7 +5,7 @@ describe Hackney::Income::CreateCourtCase do
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS }
+  let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
   let(:terms) { [true, false].sample }

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -62,7 +62,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided a criteria with a court outcome but without a court date' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
           courtdate: UH_NIL_DATE
         }
       }
@@ -92,7 +92,7 @@ describe Hackney::Income::MigrateUhCourtCase do
           court_case_params: {
             tenancy_ref: criteria.tenancy_ref,
             court_date: criteria_attributes[:courtdate],
-            court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
             terms: false,
             disrepair_counter_claim: false
           }
@@ -105,7 +105,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       examples = [
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
+          expected: Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS
         },
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::POSTPONED_POSSESSION,
@@ -113,31 +113,31 @@ describe Hackney::Income::MigrateUhCourtCase do
         },
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
+          expected: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS
         },
         {
-          input: Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
+          input: Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT,
+          expected: Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT
         },
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
+          expected: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
         },
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+          expected: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
         },
         {
-          input: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+          input: Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+          expected: Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
         },
         {
           input: Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_GENERALLY,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+          expected: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
         },
         {
-          input: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-          expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
+          input: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+          expected: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE
         },
         {
           input: 'SOME_OTHER_COURT_OUTCOME_CODE',
@@ -171,7 +171,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     let(:existing_court_cases) {
       [create(:court_case,
               court_date: DateTime.now.midnight - 1.month,
-              court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE),
+              court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE),
        create(:court_case,
               court_date: DateTime.now.midnight - 7.days,
               court_outcome: nil)]
@@ -180,7 +180,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided with any criteria' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
           courtdate: DateTime.now.midnight
         }
       }
@@ -197,13 +197,13 @@ describe Hackney::Income::MigrateUhCourtCase do
     let(:existing_court_cases) {
       [create(:court_case,
               court_date: DateTime.now.midnight - 14.days,
-              court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS)]
+              court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS)]
     }
 
     context 'when provided with a criteria' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
           courtdate: DateTime.now.midnight - 7.days
         }
       }
@@ -278,7 +278,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       let(:existing_court_cases) {
         [create(:court_case,
                 court_date: nil,
-                court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE)]
+                court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE)]
       }
 
       context 'when provided a criteria without a court date or outcome' do

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -82,7 +82,7 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when provided a criteria with a court date and a court outcome' do
       let(:criteria_attributes) {
         {
-          court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+          court_outcome: Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION,
           courtdate: DateTime.now.midnight - 7.days
         }
       }
@@ -104,15 +104,15 @@ describe Hackney::Income::MigrateUhCourtCase do
     context 'when setting the court outcome it maps old UH outcomes to the new MA outcomes' do
       examples = [
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION,
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
         },
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::POSTPONED_POSSESSION,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::POSTPONED_POSSESSION,
           expected: nil
         },
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS,
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS
         },
         {
@@ -120,11 +120,11 @@ describe Hackney::Income::MigrateUhCourtCase do
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT
         },
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH
         },
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
         },
         {
@@ -132,7 +132,7 @@ describe Hackney::Income::MigrateUhCourtCase do
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
         },
         {
-          input: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY,
+          input: Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_GENERALLY,
           expected: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
         },
         {
@@ -257,7 +257,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria with a court date and an outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS,
+            court_outcome: Hackney::Tenancy::OldCourtOutcomeCodes::ADJOURNED_ON_TERMS,
             courtdate: DateTime.now.midnight
           }
         }
@@ -318,7 +318,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria with a court date and an outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+            court_outcome: Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION,
             courtdate: DateTime.now.midnight
           }
         }
@@ -336,7 +336,7 @@ describe Hackney::Income::MigrateUhCourtCase do
       context 'when provided a criteria with only an outcome' do
         let(:criteria_attributes) {
           {
-            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENDED_POSSESSION,
+            court_outcome: Hackney::Tenancy::OldCourtOutcomeCodes::SUSPENDED_POSSESSION,
             courtdate: UH_NIL_DATE
           }
         }

--- a/spec/lib/hackney/income/tenancy_classification/helpers/court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/helpers/court_case_helpers_spec.rb
@@ -114,12 +114,12 @@ describe Hackney::Income::TenancyClassification::Helpers::CourtCaseHelpers do
     context 'when there is a court outcome' do
       let(:court_outcome) {
         [
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
-          Hackney::Tenancy::UpdatedCourtOutcomeCodes::STAY_OF_EXECUTION
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+          Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING,
+          Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
+          Hackney::Tenancy::CourtOutcomeCodes::STAY_OF_EXECUTION
         ].sample
       }
       let(:most_recent_court_case) { { court_outcome: court_outcome, court_date: court_date } }
@@ -190,7 +190,7 @@ describe Hackney::Income::TenancyClassification::Helpers::CourtCaseHelpers do
       end
 
       context 'when the court outcome is not blank' do
-        let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
 
         it 'returns false' do
           expect(subject).to eq(false)
@@ -211,7 +211,7 @@ describe Hackney::Income::TenancyClassification::Helpers::CourtCaseHelpers do
       end
 
       context 'when the court outcome is not blank' do
-        let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
 
         it 'returns false' do
           expect(subject).to eq(false)

--- a/spec/lib/hackney/income/tenancy_classification/helpers/court_case_helpers_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/helpers/court_case_helpers_spec.rb
@@ -190,7 +190,7 @@ describe Hackney::Income::TenancyClassification::Helpers::CourtCaseHelpers do
       end
 
       context 'when the court outcome is not blank' do
-        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+        let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
 
         it 'returns false' do
           expect(subject).to eq(false)
@@ -211,7 +211,7 @@ describe Hackney::Income::TenancyClassification::Helpers::CourtCaseHelpers do
       end
 
       context 'when the court outcome is not blank' do
-        let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
+        let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE }
 
         it 'returns false' do
           expect(subject).to eq(false)

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/check_data_spec.rb
@@ -8,7 +8,7 @@ describe 'Check Data examples' do
       outcome: :check_data,
       active_agreement: false,
       courtdate: 1.week.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ), base_example.merge(
       desription: 'No action when there is no court warrant',
       outcome: :no_action,
@@ -20,13 +20,13 @@ describe 'Check Data examples' do
       is_paused_until: 1.day.from_now.to_date,
       active_agreement: false,
       courtdate: 1.week.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ), base_example.merge(
       desription: 'No action when there is an old court warrant(SUSPENSION_ON_TERMS has 6 years life), without an agreement, and not paused',
       outcome: :no_action,
       active_agreement: false,
       courtdate: 11.years.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS
     ), base_example.merge(
       desription: 'No action when there is an not an active court warrant',
       outcome: :no_action,
@@ -36,7 +36,7 @@ describe 'Check Data examples' do
       description: 'Check Data when case has court outcome but no court date',
       outcome: :check_data,
       courtdate: nil,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     )
   ]
   it_behaves_like 'TenancyClassification', examples

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_no_payment_spec.rb
@@ -9,7 +9,7 @@ describe '"Court Breach - No Payment" examples' do
     balance: 15.0,
     nosp_served_date: 8.months.ago.to_date,
     courtdate: 14.days.ago.to_date,
-    court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+    court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
     last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_VISIT_MADE,
     last_communication_date: 8.days.ago.to_date,
     days_since_last_payment: 8,

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/court_breach_visit_spec.rb
@@ -8,7 +8,7 @@ describe 'Send Court Breach Letter Rule', type: :feature do
     balance: 15.0, # 3 * weekly_rent
     collectable_arrears: 15.0, # 3 * weekly_rent
     active_agreement: false,
-    court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+    court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
     last_communication_action: Hackney::Tenancy::ActionCodes::COURT_BREACH_LETTER_SENT,
     last_communication_date: 2.weeks.ago,
     courtdate: 14.days.ago.to_date,

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_breach_letters_spec.rb
@@ -31,26 +31,26 @@ describe 'Various "Send breach letter" examples (new)' do
       description: 'with a court date before the agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with a court date more than three months before the agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with a last_communication_action which is visit made',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       last_communication_action: Hackney::Tenancy::ActionCodes::VISIT_MADE
     ),
     base_example.deep_merge(
       description: 'with a court date and agreement start date on the same day',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       most_recent_agreement: {
         start_date: 2.weeks.ago,
         breached: true
@@ -60,7 +60,7 @@ describe 'Various "Send breach letter" examples (new)' do
       description: 'with a court date and court agreement start date before court date',
       outcome: :check_data,
       courtdate: 2.weeks.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       most_recent_agreement: {
         start_date: 3.weeks.ago,
         breached: true

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/send_informal_agreement_breach_letter_spec.rb
@@ -34,13 +34,13 @@ describe 'Various "Send informal breach letter" examples (new)' do
       description: 'with a court date before the court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 2.weeks.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with a court date more than three months before the court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 4.months.ago,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
     ),
     base_example.merge(
       description: 'with the last communication being an informal breach letter',

--- a/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
+++ b/spec/lib/hackney/income/tenancy_classification/rulesets/update_court_outcome_spec.rb
@@ -75,7 +75,7 @@ describe '"Update court outcome" examples' do
       description: 'with valid court outcome and breached court agreement',
       outcome: :address_court_agreement_breach,
       courtdate: 14.days.ago.to_date,
-      court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+      court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
       most_recent_agreement: {
         start_date: 1.week.ago,
         breached: true

--- a/spec/lib/hackney/income/universal_housing_criteria_spec.rb
+++ b/spec/lib/hackney/income/universal_housing_criteria_spec.rb
@@ -99,7 +99,7 @@ describe Hackney::Income::UniversalHousingCriteria, universal: true do
     describe '#court_outcome' do
       subject { criteria.court_outcome }
 
-      let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE }
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE }
 
       it 'returns a court_outcome' do
         expect(subject).to eq(court_outcome)

--- a/spec/lib/hackney/income/update_agreement_state_spec.rb
+++ b/spec/lib/hackney/income/update_agreement_state_spec.rb
@@ -465,7 +465,7 @@ describe Hackney::Income::UpdateAgreementState do
     end
 
     context 'when the court outcome is suspended on terms' do
-      let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS }
+      let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS }
       let(:next_check_date) { start_date + days_before_check.days }
       let(:court_case) do
         create(:court_case,

--- a/spec/lib/hackney/income/update_agreement_state_spec.rb
+++ b/spec/lib/hackney/income/update_agreement_state_spec.rb
@@ -537,7 +537,6 @@ describe Hackney::Income::UpdateAgreementState do
           current_balance = 1000
 
           Timecop.freeze(next_check_date) do
-            expect_any_instance_of(described_class).to receive(:end_of_lifecycle?).and_return(false)
             subject.execute(agreement: agreement, current_balance: current_balance)
             expect(agreement.current_state).to eq('breached')
           end

--- a/spec/lib/hackney/income/update_court_case_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_spec.rb
@@ -30,7 +30,7 @@ describe Hackney::Income::UpdateCourtCase do
   end
 
   context 'when adding a court outcome that can not have terms to an existing court case' do
-    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT }
+    let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT }
 
     it 'updates and returns the court case' do
       court_case = subject.execute(court_case_params: court_case_params)
@@ -45,7 +45,7 @@ describe Hackney::Income::UpdateCourtCase do
   end
 
   context 'when adding a court outcome that can have terms to an existing court case' do
-    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE }
+    let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE }
     let(:strike_out_date) { Faker::Date.forward(days: 30) }
     let(:terms) { false }
     let(:disrepair_counter_claim) { false }
@@ -81,7 +81,7 @@ describe Hackney::Income::UpdateCourtCase do
   end
 
   context 'when adding a court outcome without a court date to an existing court case' do
-    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS }
+    let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS }
 
     it 'updates and returns the court case' do
       court_case = subject.execute(court_case_params: { id: id, court_date: nil, court_outcome: court_outcome })

--- a/spec/lib/hackney/income_collection/letter_spec.rb
+++ b/spec/lib/hackney/income_collection/letter_spec.rb
@@ -157,7 +157,7 @@ describe Hackney::IncomeCollection::Letter do
       context 'when generating a outright order court outcome letter' do
         let(:court_letter_params) {
           letter_params.merge(
-            court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+            court_outcome: Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
           )
         }
 

--- a/spec/lib/hackney/pdf/income_preview_spec.rb
+++ b/spec/lib/hackney/pdf/income_preview_spec.rb
@@ -269,7 +269,7 @@ describe Hackney::PDF::IncomePreview do
     end
 
     context 'when sending a court outcome letter with terms' do
-      let(:court_case) { create(:court_case, tenancy_ref: test_tenancy_ref, court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS, terms: true) }
+      let(:court_case) { create(:court_case, tenancy_ref: test_tenancy_ref, court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS, terms: true) }
       let(:court_outcome_letter_template) do
         [
           {

--- a/spec/models/hackney/income/models/court_cases_spec.rb
+++ b/spec/models/hackney/income/models/court_cases_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe Hackney::Income::Models::CourtCase, type: :model do
   let(:valid_outcomes_without_terms) do
     [
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+      Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+      Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE,
+      Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT,
+      Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
     ].sample
   end
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
@@ -138,12 +138,12 @@ describe Hackney::Income::Models::CourtCase, type: :model do
 
     it 'returns true if court_outcome is SUSPENSION_ON_TERMS and passed 6 years life' do
       expect(described_class.new(
-        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+        court_outcome: Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
         court_date: Date.today - 6.years
       ).send(:end_of_life?)).to be_falsey
 
       expect(described_class.new(
-        court_outcome: Hackney::Tenancy::UpdatedCourtOutcomeCodes::SUSPENSION_ON_TERMS,
+        court_outcome: Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS,
         court_date: Date.today - 6.years
       ).send(:end_of_life?)).to be_truthy
     end

--- a/spec/models/hackney/income_collection/letter/court_outcome_spec.rb
+++ b/spec/models/hackney/income_collection/letter/court_outcome_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Hackney::IncomeCollection::Letter::CourtOutcome do
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:created_date) { Faker::Date.between(from: 2.days.ago, to: Date.today) }
-  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY }
+  let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY }
   let(:court_date) {  2.days.ago }
   let(:letter_params) {
     {
@@ -34,7 +34,7 @@ describe Hackney::IncomeCollection::Letter::CourtOutcome do
   end
 
   context 'when generating a court outcome letter with terms' do
-    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS }
+    let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
 
     let(:letter) {
       described_class.new(letter_params.merge(
@@ -52,7 +52,7 @@ describe Hackney::IncomeCollection::Letter::CourtOutcome do
   end
 
   context 'when generating a court outcome letter with terms' do
-    let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH }
+    let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH }
 
     it 'outright_order is true' do
       expect(letter.outright_order).to eq(true)

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe 'CourtCases', type: :request do
   let(:court_date) { Faker::Date.between(from: 2.days.ago, to: Date.today).to_s }
   let(:court_outcome) do
     [
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
-      Hackney::Tenancy::UpdatedCourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
+      Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT,
+      Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY,
+      Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH,
+      Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE
     ].sample
   end
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }

--- a/spec/support/shared_example_for_tenancy_classification.rb
+++ b/spec/support/shared_example_for_tenancy_classification.rb
@@ -79,11 +79,11 @@ shared_examples 'TenancyClassification examples' do |condition_matrix|
 
       before do
         if courtdate.present? || court_outcome.present?
-          if court_outcome.present? && court_outcome == Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+          if court_outcome.present? && court_outcome == Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
             # We should update these on the examples once UH examples are decommissioned so we won't need this mapping
             disrepair_counter_claim = true
             terms = true
-            outcome = Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
+            outcome = Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE
           end
           court_case = build_stubbed(:court_case, tenancy_ref: criteria.tenancy_ref,
                                                   court_date: courtdate,


### PR DESCRIPTION
## Context
Some refactoring was needed in breach detector to reduce duplications between `UpdateAgreementState` and `CourtCase` model

## Changes in this pull request
- Refactor breach detector to use helper methods on court case model
- Rename UpdatedCourtOutcomeCodes to CourtOutcomeCodes## Guidance to review

The review should be the easiest commit by commit!

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
