### PR TITLE
Add action diary entry and sync when adding a court outcome

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -33,7 +33,7 @@ class CourtCasesController < ApplicationController
   end
 
   def update
-    parameters = %i[id court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim].freeze
+    parameters = %i[id court_date court_outcome balance_on_court_outcome_date strike_out_date terms disrepair_counter_claim username].freeze
 
     update_court_case_params = params.permit(parameters)
 
@@ -44,7 +44,8 @@ class CourtCasesController < ApplicationController
       balance_on_court_outcome_date: update_court_case_params[:balance_on_court_outcome_date],
       strike_out_date: update_court_case_params[:strike_out_date],
       terms: update_court_case_params[:terms],
-      disrepair_counter_claim: update_court_case_params[:disrepair_counter_claim]
+      disrepair_counter_claim: update_court_case_params[:disrepair_counter_claim],
+      username: update_court_case_params[:username]
     }
 
     updated_court_case = income_use_case_factory.update_court_case.execute(court_case_params: court_case_params)

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -44,11 +44,12 @@ class CourtCasesController < ApplicationController
       balance_on_court_outcome_date: update_court_case_params[:balance_on_court_outcome_date],
       strike_out_date: update_court_case_params[:strike_out_date],
       terms: update_court_case_params[:terms],
-      disrepair_counter_claim: update_court_case_params[:disrepair_counter_claim],
-      username: update_court_case_params[:username]
+      disrepair_counter_claim: update_court_case_params[:disrepair_counter_claim]
     }
 
-    updated_court_case = income_use_case_factory.update_court_case.execute(court_case_params: court_case_params)
+    username = update_court_case_params[:username]
+
+    updated_court_case = income_use_case_factory.update_court_case_and_sync.execute(court_case_params: court_case_params, username: username)
 
     if updated_court_case
       response = map_court_case_to_response(court_case: updated_court_case)

--- a/app/models/hackney/court_outcome_helper.rb
+++ b/app/models/hackney/court_outcome_helper.rb
@@ -1,0 +1,21 @@
+module Hackney
+  module CourtOutcomeHelper
+    def human_readable_outcome(code)
+      code_mapping = {
+        'AGP' => 'Adjourned generally with permission to restore',
+        'AND' => 'Adjourned to next open date',
+        'AAH' => 'Adjourned to another hearing date',
+        'ADH' => 'Adjourned for directions hearing',
+        'ADT' => 'Adjourned on terms',
+        'OPF' => 'Outright possession forthwith',
+        'OPD' => 'Outright possession with date',
+        'SOT' => 'Suspension on terms',
+        'STO' => 'Struck out',
+        'WIT' => 'Withdrawn on the day',
+        'SOE' => 'Stay of execution'
+      }
+
+      code_mapping[code]
+    end
+  end
+end

--- a/app/models/hackney/court_outcome_helper.rb
+++ b/app/models/hackney/court_outcome_helper.rb
@@ -2,17 +2,17 @@ module Hackney
   module CourtOutcomeHelper
     def human_readable_outcome(code)
       code_mapping = {
-        'AGP' => 'Adjourned generally with permission to restore',
-        'AND' => 'Adjourned to next open date',
-        'AAH' => 'Adjourned to another hearing date',
-        'ADH' => 'Adjourned for directions hearing',
-        'ADT' => 'Adjourned on terms',
-        'OPF' => 'Outright possession forthwith',
-        'OPD' => 'Outright possession with date',
-        'SOT' => 'Suspension on terms',
-        'STO' => 'Struck out',
-        'WIT' => 'Withdrawn on the day',
-        'SOE' => 'Stay of execution'
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE => 'Adjourned generally with permission to restore',
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE => 'Adjourned to next open date',
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE => 'Adjourned to another hearing date',
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING => 'Adjourned for directions hearing',
+        Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS => 'Adjourned on terms',
+        Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_FORTHWITH => 'Outright possession forthwith',
+        Hackney::Tenancy::CourtOutcomeCodes::OUTRIGHT_POSSESSION_WITH_DATE => 'Outright possession with date',
+        Hackney::Tenancy::CourtOutcomeCodes::SUSPENSION_ON_TERMS => 'Suspension on terms',
+        Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT => 'Struck out',
+        Hackney::Tenancy::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY => 'Withdrawn on the day',
+        Hackney::Tenancy::CourtOutcomeCodes::STAY_OF_EXECUTION => 'Stay of execution/Re-entry'
       }
 
       code_mapping[code]

--- a/lib/hackney/income/update_court_case_and_sync.rb
+++ b/lib/hackney/income/update_court_case_and_sync.rb
@@ -1,0 +1,31 @@
+module Hackney
+  module Income
+    class UpdateCourtCaseAndSync
+      include CourtOutcomeHelper
+
+      def initialize(update_court_case:, add_action_diary_and_sync_case:)
+        @update_court_case = update_court_case
+        @add_action_diary_and_sync_case = add_action_diary_and_sync_case
+      end
+
+      def execute(court_case_params:, username: nil)
+        court_case = @update_court_case.execute(court_case_params: court_case_params)
+
+        return if court_case.nil?
+
+        if username.present?
+          tenancy_ref = court_case[:tenancy_ref]
+          court_outcome = court_case[:court_outcome]
+          @add_action_diary_and_sync_case.execute(
+            username: username,
+            tenancy_ref: tenancy_ref,
+            action_code: 'IC6',
+            comment: "Court outcome added: #{human_readable_outcome(court_outcome)}"
+          )
+        end
+
+        court_case
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -297,7 +297,7 @@ module Hackney
           add_action_diary_and_sync_case: add_action_diary_and_sync_case
         )
       end
-      
+
       def create_eviction_and_sync
         Hackney::Income::CreateEvictionAndSync.new(
           create_eviction: create_eviction,

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -291,6 +291,13 @@ module Hackney
         Hackney::Income::UpdateCourtCase.new
       end
 
+      def update_court_case_and_sync
+        Hackney::Income::UpdateCourtCaseAndSync.new(
+          update_court_case: update_court_case,
+          add_action_diary_and_sync_case: add_action_diary_and_sync_case
+        )
+      end
+      
       def create_eviction_and_sync
         Hackney::Income::CreateEvictionAndSync.new(
           create_eviction: create_eviction,

--- a/spec/lib/hackney/income/update_court_case_and_sync_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_and_sync_spec.rb
@@ -14,7 +14,7 @@ describe Hackney::Income::UpdateCourtCaseAndSync do
   let(:id) { Faker::Number.number(digits: 2) }
   let(:tenancy_ref) { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT }
+  let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::STRUCK_OUT }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { nil }
   let(:terms) { nil }
@@ -64,12 +64,6 @@ describe Hackney::Income::UpdateCourtCaseAndSync do
       ).and_return(court_case)
 
       expect(add_action_diary_and_sync_case_usecase).not_to receive(:execute)
-        .with(
-          username: username,
-          tenancy_ref: tenancy_ref,
-          action_code: 'IC6',
-          comment: 'Court outcome added: Struck out'
-        )
 
       updated_court_case = subject.execute(court_case_params: court_case_params)
 

--- a/spec/lib/hackney/income/update_court_case_and_sync_spec.rb
+++ b/spec/lib/hackney/income/update_court_case_and_sync_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Hackney::Income::UpdateCourtCaseAndSync do
+  subject {
+    described_class.new(
+      update_court_case: update_court_case,
+      add_action_diary_and_sync_case: add_action_diary_and_sync_case_usecase
+    )
+  }
+
+  let(:update_court_case) { instance_double(Hackney::Income::UpdateCourtCase) }
+  let(:add_action_diary_and_sync_case_usecase) { instance_double(UseCases::AddActionDiaryAndSyncCase) }
+
+  let(:id) { Faker::Number.number(digits: 2) }
+  let(:tenancy_ref) { "#{Faker::Number.number(digits: 6)}/#{Faker::Number.number(digits: 2)}" }
+  let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
+  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::STRUCK_OUT }
+  let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
+  let(:strike_out_date) { nil }
+  let(:terms) { nil }
+  let(:disrepair_counter_claim) { nil }
+  let(:username) { Faker::Name.name }
+
+  let(:court_case_params) do
+    {
+      id: id,
+      tenancy_ref: tenancy_ref,
+      court_date: court_date,
+      court_outcome: court_outcome,
+      balance_on_court_outcome_date: balance_on_court_outcome_date,
+      strike_out_date: strike_out_date,
+      terms: terms,
+      disrepair_counter_claim: disrepair_counter_claim
+    }
+  end
+
+  let(:court_case) { build_stubbed(:court_case, court_case_params) }
+
+  context 'when provided with a username' do
+    it 'calls the update court case usecase, adds an action diary, syncs the case' do
+      expect(update_court_case).to receive(:execute).with(
+        court_case_params: court_case_params
+      ).and_return(court_case)
+
+      expect(add_action_diary_and_sync_case_usecase).to receive(:execute)
+        .with(
+          username: username,
+          tenancy_ref: tenancy_ref,
+          action_code: 'IC6',
+          comment: 'Court outcome added: Struck out'
+        )
+        .once
+
+      updated_court_case = subject.execute(court_case_params: court_case_params, username: username)
+
+      expect(updated_court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
+    end
+  end
+
+  context 'when not provided with a username' do
+    it 'calls the update court case usecase and returns the updated court case' do
+      expect(update_court_case).to receive(:execute).with(
+        court_case_params: court_case_params
+      ).and_return(court_case)
+
+      expect(add_action_diary_and_sync_case_usecase).not_to receive(:execute)
+        .with(
+          username: username,
+          tenancy_ref: tenancy_ref,
+          action_code: 'IC6',
+          comment: 'Court outcome added: Struck out'
+        )
+
+      updated_court_case = subject.execute(court_case_params: court_case_params)
+
+      expect(updated_court_case).to be_an_instance_of(Hackney::Income::Models::CourtCase)
+    end
+  end
+end

--- a/spec/requests/court_cases_spec.rb
+++ b/spec/requests/court_cases_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'CourtCases', type: :request do
   let(:strike_out_date) { Faker::Date.forward(days: 365).to_s }
   let(:terms) { false }
   let(:disrepair_counter_claim) { false }
+  let(:username) { Faker::Name.name }
 
   describe 'POST /api/v1/court_case/{tenancy_ref}' do
     path '/court_case/{tenancy_ref}' do
@@ -97,7 +98,8 @@ RSpec.describe 'CourtCases', type: :request do
             balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
             strike_out_date: nil,
             terms: nil,
-            disrepair_counter_claim: nil
+            disrepair_counter_claim: nil,
+            username: username
           }
 
         expect(update_court_case_instance).to receive(:execute)
@@ -107,7 +109,7 @@ RSpec.describe 'CourtCases', type: :request do
       end
 
       context 'when adding a court outcome that can not have terms' do
-        let(:update_court_case_params) do
+        let(:court_case_params) do
           {
             id: id,
             court_date: court_date,
@@ -119,7 +121,8 @@ RSpec.describe 'CourtCases', type: :request do
           }
         end
 
-        let(:updated_court_case) { create(:court_case, update_court_case_params) }
+        let(:updated_court_case) { create(:court_case, court_case_params) }
+        let(:update_court_case_params) { court_case_params.merge(username: username) }
 
         before do
           allow(update_court_case_instance).to receive(:execute)
@@ -140,7 +143,7 @@ RSpec.describe 'CourtCases', type: :request do
 
       context 'when adding a court outcome that can have terms' do
         let(:court_outcome) { 'AAH' }
-        let(:update_court_case_params) do
+        let(:court_case_params) do
           {
             id: id,
             court_date: court_date,
@@ -152,7 +155,8 @@ RSpec.describe 'CourtCases', type: :request do
           }
         end
 
-        let(:updated_court_case) { build(:court_case, update_court_case_params) }
+        let(:updated_court_case) { build(:court_case, court_case_params) }
+        let(:update_court_case_params) { court_case_params.merge(username: username) }
 
         before do
           allow(update_court_case_instance).to receive(:execute)
@@ -184,7 +188,8 @@ RSpec.describe 'CourtCases', type: :request do
             balance_on_court_outcome_date: balance_on_court_outcome_date.to_s,
             strike_out_date: nil,
             terms: nil,
-            disrepair_counter_claim: nil
+            disrepair_counter_claim: nil,
+            username: username
           }
         end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When an officer adds a court outcome, we want an entry to be added to the action diary and the case to be synced.
## Changes in this pull request
<!-- List all the changes -->
- Created new UpdateCourtCaseAndSync use case
   - Implements the UpdateCourtCase and AddActionDiaryAndSyncCase
   - This was created because those two use cases have a circular dependency, which this new use case avoids

- Make Court Case Controller use this new use case for the Court Case Update endpoint
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
There is some refactoring to be done court_cases_spec.rb, which I will try and do now.

I'm still not 100% confident when it comes to RSpec and test doubles so please shout if my use of them in the two tests doesn't make sense!

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-522?atlOrigin=eyJpIjoiMmQ0OTczMDEzNjY4NGE3OTg5NTZlYmUxNGRhNDMyYjYiLCJwIjoiaiJ9
## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] Environment variables have been updated
