### PR TITLE
Use correct court outcome codes file for court case add action diary & sync test

### DIFF
--- a/spec/lib/hackney/income/create_court_case_and_sync_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_and_sync_spec.rb
@@ -13,7 +13,7 @@ describe Hackney::Income::CreateCourtCaseAndSync do
 
   let(:tenancy_ref) { Faker::Number.number(digits: 2).to_s }
   let(:court_date) { Faker::Date.between(from: 10.days.ago, to: 2.days.ago) }
-  let(:court_outcome) { Hackney::Tenancy::UpdatedCourtOutcomeCodes::ADJOURNED_ON_TERMS }
+  let(:court_outcome) { Hackney::Tenancy::CourtOutcomeCodes::ADJOURNED_ON_TERMS }
   let(:balance_on_court_outcome_date) { Faker::Commerce.price(range: 10...100) }
   let(:strike_out_date) { Faker::Date.forward(days: 365) }
   let(:terms) { [true, false].sample }


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
To fix tests failing on master, the tests for the `create_court_case_and_sync` usecase needed to reference the correct court outcome codes file
## Changes in this pull request
<!-- List all the changes -->

- Use correct `CourtOutcomeCodes` file for tests

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
