### PR TITLE
Update UH court case migration to explicitly pass in court_case_params

### DIFF
--- a/lib/hackney/income/migrate_uh_court_case.rb
+++ b/lib/hackney/income/migrate_uh_court_case.rb
@@ -42,17 +42,18 @@ module Hackney
           return
         end
 
-        court_case_params = map_criteria_to_court_case_params(criteria)
+        court_case_data = map_criteria_to_court_case_params(criteria)
 
-        court_case_params[:court_date] = nil if existing_court_case.court_date.present?
-        court_case_params[:court_outcome] = nil if existing_court_case.court_outcome.present?
+        court_case_data[:court_date] = nil if existing_court_case.court_date.present?
+        court_case_data[:court_outcome] = nil if existing_court_case.court_outcome.present?
 
-        if court_case_params.compact.keys.empty?
+        if court_case_data.compact.keys.empty?
           Rails.logger.debug { 'UH Criteria does not contain any new information' }
           return
         end
 
-        @update_court_case.execute(id: existing_court_case.id, **court_case_params)
+        court_case_params = court_case_data.merge(id: existing_court_case.id)
+        @update_court_case.execute(court_case_params: court_case_params)
       end
 
       private

--- a/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
+++ b/spec/lib/hackney/income/migrate_uh_court_case_spec.rb
@@ -265,9 +265,11 @@ describe Hackney::Income::MigrateUhCourtCase do
         it 'does update the court case with the court outcome only' do
           expect(create_court_case).not_to receive(:execute)
           expect(update_court_case).to receive(:execute).with(
-            id: existing_court_cases[0].id,
-            court_date: nil,
-            court_outcome: criteria_attributes[:court_outcome]
+            court_case_params: {
+              id: existing_court_cases[0].id,
+              court_date: nil,
+              court_outcome: criteria_attributes[:court_outcome]
+            }
           )
           subject
         end
@@ -307,9 +309,11 @@ describe Hackney::Income::MigrateUhCourtCase do
         it 'does update the court case with the date' do
           expect(create_court_case).not_to receive(:execute)
           expect(update_court_case).to receive(:execute).with(
-            id: existing_court_cases[0].id,
-            court_date: criteria_attributes[:courtdate],
-            court_outcome: nil
+            court_case_params: {
+              id: existing_court_cases[0].id,
+              court_date: criteria_attributes[:courtdate],
+              court_outcome: nil
+            }
           )
           subject
         end
@@ -325,9 +329,11 @@ describe Hackney::Income::MigrateUhCourtCase do
 
         it 'does update the court case with the court date only' do
           expect(update_court_case).to receive(:execute).with(
-            id: existing_court_cases[0].id,
-            court_date: criteria_attributes[:courtdate],
-            court_outcome: nil
+            court_case_params: {
+              id: existing_court_cases[0].id,
+              court_date: criteria_attributes[:courtdate],
+              court_outcome: nil
+            }
           )
           subject
         end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Errors have been popping up on sentry detecting that syncing UH court cases has been failing as the update_court_case
usecase was missing its keyword arguments thus stopping the migration from running. I am unsure why the original implementation did not work as the current version of ruby the application uses allows a double splat operator to be used within a keyword argument
## Changes in this pull request
<!-- List all the changes -->
- explicitly pass in court_case_params into update_cout_case usecase
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I am unsure if this is the best way of going round that issue due to not understanding the nitty gritty of the language but due to time constraints, it would be best to discuss this in the future.
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-533
## Things to check
- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] Environment variables have been updated
